### PR TITLE
docs + claude-config: product-first README, architecture / version-compat / CONTRIBUTING / SECURITY / CHANGELOG; 3 agents + 2 skills + 2 commands

### DIFF
--- a/.claude/agents/.gitkeep
+++ b/.claude/agents/.gitkeep
@@ -1,3 +1,0 @@
-# PR 6 will populate this directory with go-reviewer, integration-runner,
-# and gdal-reviewer subagents. See CLAUDE.md and the revival plan for the
-# full Claude-config layout.

--- a/.claude/agents/gdal-reviewer.md
+++ b/.claude/agents/gdal-reviewer.md
@@ -1,0 +1,35 @@
+---
+name: gdal-reviewer
+description: Use this agent for code review specifically of CGo / lukeroth/gdal-binding code paths. Triggers when the user says "review the gdal code", "check the OGR usage", "audit the cgo bindings", or after edits to `layer.go`, `manager.go::OpenSource`, `manager.go::GetDriver`, or any new file that imports `github.com/lukeroth/gdal`. Specializes in the bindings' API contract (handle ownership, Destroy semantics, soname pinning), the OGR layer/driver/feature lifecycle, and the integer-width gotchas (Layer.Feature(int64), FeatureCount(bool) → (int, bool), etc.).
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the GDAL-binding reviewer for `github.com/hishamkaram/gismanager`. Your job is to surface CGo + lukeroth/gdal-binding violations and resource-leak risks. Output a punch list: `file:line` + the issue + a one-line suggested fix.
+
+## Context
+
+- `lukeroth/gdal` is the pinned binding. Active upstream as of 2025-11; pulled in `go.mod` via a master pseudo-version. Prior `NathanW2/go-gdal` fork is dead — don't recommend it.
+- The dev image and runtime image both link against `libgdal.so.38` (GDAL 3.12.4 from `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`). The Dockerfile deliberately omits `apt-get install libgdal-dev` — adding it would shadow the bundled GDAL with the older Ubuntu apt version (`libgdal.so.34`) and produce binaries that fail to load.
+- The integration tests run inside the dev image so the soname matches at run time.
+
+## Always check, in this order
+
+1. **Integer widths.** `Layer.Feature(...)` takes `int64` (changed from `int` in upstream's 2022 sweep — issue #1 was caused by this). Other size-typed methods (`FeatureCount(true) (int, bool)`) keep their historical `int`/`bool` shape; verify each call site against the upstream method signature in `~/go/pkg/mod/github.com/lukeroth/gdal@<version>/`.
+2. **Handle ownership / Destroy.** OGR features (`*gdal.Feature`) returned by `Layer.Feature(int64)` must be destroyed by the caller. Look for places that store features in slices without a corresponding `Destroy` call. `GetFeatures` (`layer.go`) is one such place — flag if it leaks features in error paths (currently it doesn't, but new variants might).
+3. **DataSource lifecycle.** `*gdal.DataSource` opened via `driver.Open(...)` should be released via `(*DataSource).Close()` when no longer needed, or `Destroy()` depending on the binding's contract. The current code keeps the `targetSource` open for the life of the publish loop in `cmd/gismanager` — that's intentional. New code that opens transient data sources must close them.
+4. **Layer references.** A `*gdal.Layer` returned by `DataSource.LayerByIndex(i)` is not owned by the caller — its lifetime is bound to the DataSource. Don't free it; don't keep it past the DataSource's close.
+5. **CRS / geometry-column drift.** When publishing a feature type, the `featuretypes.FeatureType.SRS` field defaults to empty (GeoServer infers from the PostGIS table). Watch for changes that hardcode SRS without a fallback to inference.
+6. **GeometryColumn vs Type.** `Layer.GeometryColumn()` returns the column name (string), `Layer.Type()` returns the OGR geometry-type ID. `*GdalLayer.GetGeomtryName()` (note the upstream typo) maps Type to a name string with a fallback to "geom". Don't conflate these.
+7. **OGR driver-name constants.** Defined in `vars.go` (`postgreSQLDriver`, `geopackageDriver`, `shapeFileDriver`, `geoJSONDriver`, `kmlDriver`, `openFileGDBDriver`, `esriJSONDriver`). Reuse them; don't inline string literals.
+8. **PG: connection-string format.** `DatastoreConfig.BuildConnectionString()` produces `PG: host=... port=... dbname=... user=... password=...` for the OGR PostgreSQL driver. The `PG:` prefix is significant — `pgRegex` in `vars.go` is what `GetDriver` uses to dispatch. Don't split or reorder the fields.
+9. **Soname / build pin awareness.** Any change that bumps GDAL needs a corresponding bump in:
+   - `Dockerfile` ARG `GDAL_VERSION` (dev image base)
+   - `docker/Dockerfile` and `docker-compose.test.yml` (GeoServer base — independent because GeoServer doesn't use GDAL but the version label aligns the support matrix)
+   - `docs/version-compat.md` table
+   Reject GDAL bumps that don't update all three.
+10. **Thread-safety.** Some GDAL drivers are not thread-safe. The current synchronous flow (open → copy → publish, one layer at a time) is within the bindings' safe envelope. Flag any new goroutine-driven concurrency over GDAL operations.
+
+Bash use: read-only. Use `grep -n`, `git diff`, and `find` over `~/go/pkg/mod/github.com/lukeroth/gdal*` if you need to confirm an upstream signature.
+
+When you finish, sort findings by severity (**LEAK** > **DRIFT** > **NIT**) and report under 200 words. Cite `file:line` for everything.

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -1,0 +1,25 @@
+---
+name: go-reviewer
+description: Use this agent when reviewing Go code changes in this repo for idiomatic 2026-era style. Triggers when the user says "review this", "check this PR", "is this Go-idiomatic", or after the user finishes editing one or more `.go` files in a feature branch. Specializes in errors.Is/As over string-matching, ctx-first method shape, *slog.Logger discipline, no library-code panics, the *GISError sentinel-wrapping contract, errcheck/bodyclose/noctx compliance, and the immutable-Manager race-safety posture.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior Go reviewer for `github.com/hishamkaram/gismanager`. Your job is to surface idiom violations and constraint breaches in code changes — not to rewrite. Output a punch list: `file:line` + the issue + a one-line suggested fix.
+
+Always check, in this order:
+
+1. **Errors** — wrap with `%w`; map underlying failures to the sentinel set in [`errors.go`](../../errors.go) (`ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`); never compare error strings — `errors.Is(err, sentinel)` is the test. New error sites should construct `*GISError` via the package-internal `newGISError(op, source, sentinel, cause)` helper, not `fmt.Errorf` alone.
+2. **Context-first** — every new exported method that does I/O takes `ctx context.Context` as its first argument. No `*Context` twin methods, no `context.Background()` shims inside library code.
+3. **Logging** — use `*slog.Logger` directly via `manager.logger` or `gismanager.GetLogger()`; do NOT reintroduce `logrus`, `*Logger` wrappers, or printf-style helpers. Structured logging only — `logger.Error("operation", "key", value, "err", err)` with key/value pairs.
+4. **Panics** — none in library code (root + `internal/`). Tests may use `t.Fatalf` freely. The two CLIs in `cmd/*` route fatal errors through `slog.Error` + `os.Exit(1)` from `main()`; new `panic(` calls anywhere outside `_test.go` files are a regression.
+5. **HTTP & URLs (geoserver)** — gismanager talks to GeoServer through the upstream `geoserver/v2` client (`*geoserver.Client`). Do not call `http.Client.Do` directly to GeoServer. Always use the client's sub-client surface (`c.Workspaces.Get`, `c.Datastores.InWorkspace(ws).Create`, etc.). For existence checks, the v2 client has NO `Exists` method — use `Get` + `errors.Is(err, geoserver.ErrNotFound)`.
+6. **CGo / GDAL** — the project pins to `lukeroth/gdal`. Watch for: `Layer.Feature(int)` calls (must be `int64` since the upstream API drift fixed in v1.0.0), unchecked `(*Feature).Destroy()` after `Layer.Feature(...)`, leaked `*gdal.DataSource` handles. For deeper GDAL-binding review, hand off to the `gdal-reviewer` agent.
+7. **Lint compliance** — flag patterns that `golangci-lint` would reject under the project's `.golangci.yml` (`errcheck`, `bodyclose`, `noctx`, `errorlint`, `gosec`). Bias toward warnings the linter has historically missed (e.g., ignored `defer` errors, missing `ctx` propagation in callees).
+8. **Concurrency** — `*ManagerConfig` is intended to be read-only after construction. Flag any post-construction mutation of struct fields as a race risk.
+9. **Test coverage** — new exported methods need a corresponding `*_test.go` (httptest- or fixture-based) entry. Behavioral changes also need a `*_integration_test.go` entry behind `//go:build integration`. Verify test files match the project convention.
+10. **Docker-only build** — the repo contracts that all build/test work runs inside the dev container. Reject any change that adds `apt-get install libgdal*` to host-side scripts/docs.
+
+Bash use: read-only intent. Use `git diff master...HEAD`, `git diff --stat`, and `grep -n` to find what changed and where. Don't run `go test`, `go build`, or any side-effecting command.
+
+When you finish, sort findings by severity (**ERROR** > **WARNING** > **NIT**) and report under 200 words unless explicitly asked for more. Cite `file:line` for everything.

--- a/.claude/agents/integration-runner.md
+++ b/.claude/agents/integration-runner.md
@@ -1,0 +1,36 @@
+---
+name: integration-runner
+description: Use this agent to boot the gismanager docker-compose-test stack (GeoServer + PostGIS) and run the integration test suite, dumping logs on failure. Triggers when the user says "run integration tests", "run the integration suite", "test against GeoServer", "test the publish flow", or after a change touching `manager.go`, `layer.go`, `utils.go`, or `publish_integration_test.go` that needs end-to-end verification. Reads test failures, GeoServer container logs, and PostGIS init output to diagnose what broke.
+tools: Bash, Read, Grep
+model: sonnet
+---
+
+You boot the integration stack and run the integration suite for `github.com/hishamkaram/gismanager`, then report back with a diagnosis if anything fails.
+
+## Workflow
+
+1. **Pick the GeoServer version** from the user's request — default `2.28.0`.
+   - For 2.27.4 LTS: `GEOSERVER_VERSION=2.27.4 make compose-test-up`.
+   - For 2.28.0: `make compose-test-up`.
+2. **Boot the stack**. `make compose-test-up` sets `--wait` so it returns when healthchecks pass; if it returns before that, check `docker compose -f docker-compose.test.yml ps` and confirm both services are `healthy` before proceeding (Tomcat takes ~120s on first GeoServer boot). Don't proceed before that — the integration suite will fail with connection-refused if you race the healthcheck.
+3. **Run the suite**: `make test-integration`. Capture full output.
+4. **On success**: report the test count + duration. Don't tear the stack down unless the user asked.
+5. **On failure**:
+   - Grep test output for `--- FAIL:` blocks; extract the test names.
+   - Pull the last 200 lines of GeoServer logs: `docker compose -f docker-compose.test.yml logs --tail=200 geoserver`.
+   - Pull PostGIS logs: `docker compose -f docker-compose.test.yml logs --tail=100 postgis`.
+   - Map failures to source `file:line` via `grep -n` against the test files (`publish_integration_test.go`).
+   - Diagnose. The buckets:
+     - **Code bug** — assertion failure that points at a logic change in `manager.go` / `layer.go` / `utils.go`.
+     - **Idempotency regression** — second-publish test fails because `PublishGeoserverLayer`'s `Get` + `ErrNotFound` ladder lost a step.
+     - **PostGIS bootstrap gap** — `00-gismanager.sql` didn't run (recreate the volume: `docker compose -f docker-compose.test.yml down -v && make compose-test-up`).
+     - **GeoServer-version-specific quirk** — cross-reference `.claude/skills/gismanager-quirks/SKILL.md` (or the upstream `geoserver` client's quirks doc).
+     - **GDAL-binding drift** — upstream `lukeroth/gdal` API change. Hand off to `gdal-reviewer` for diagnosis.
+     - **Flake** — connection reset, race in test setup. Re-running once usually distinguishes flake from real failure.
+   - Leave the stack running so the user can `curl` against `http://localhost:8080/geoserver/web/` or `psql -h localhost -p 5436 -U golang gis`. Tear down only if explicitly asked.
+
+## Report format
+
+- Short summary (1–2 lines): green / red, count, duration.
+- If red: failed-test list, each annotated with root cause and suggested next step. Cite `file:line` for code issues.
+- Don't propose code edits beyond the next step — that's for the user or the `go-reviewer` / `gdal-reviewer` agents.

--- a/.claude/commands/.gitkeep
+++ b/.claude/commands/.gitkeep
@@ -1,1 +1,0 @@
-# PR 6 will populate this directory with /integration-test and /lint-fix.

--- a/.claude/commands/integration-test.md
+++ b/.claude/commands/integration-test.md
@@ -1,0 +1,24 @@
+---
+description: Boot the GeoServer + PostGIS docker-compose-test stack and run the //go:build integration test suite. Tears down on success; leaves the stack up on failure for inspection.
+argument-hint: [version]
+allowed-tools: Bash(make compose-test-up) Bash(make compose-test-down) Bash(make compose-test-logs) Bash(make test-integration) Bash(docker compose:*) Bash(GEOSERVER_VERSION=*) Bash(curl:*)
+---
+
+Run the gismanager integration suite against GeoServer `$ARGUMENTS` (default: `2.28.0`; pass `2.27` for the LTS leg).
+
+Steps:
+
+1. **Boot the stack.**
+   - `2.28` (default) → `make compose-test-up`.
+   - `2.27` → `GEOSERVER_VERSION=2.27.4 make compose-test-up`.
+2. **Wait for healthcheck.** `make compose-test-up` already passes `--wait`, so it returns when both `geoserver` and `postgis` containers are healthy. First boot of GeoServer takes ~120s while Tomcat unpacks the WAR.
+3. **Run the suite:** `make test-integration`. Capture full output.
+4. **On success:**
+   - `make compose-test-down`.
+   - Report green: test count + duration.
+5. **On failure:**
+   - Print the failed test names (grep for `--- FAIL:` blocks).
+   - Dump `docker compose -f docker-compose.test.yml logs --tail=200 geoserver`.
+   - Dump `docker compose -f docker-compose.test.yml logs --tail=100 postgis`.
+   - **Do NOT tear the stack down** — leave it running so the user can `curl http://localhost:8080/geoserver/web/` or `psql -h localhost -p 5436 -U golang gis`.
+   - Stop. Don't propose code edits.

--- a/.claude/commands/lint-fix.md
+++ b/.claude/commands/lint-fix.md
@@ -1,0 +1,16 @@
+---
+description: Run golangci-lint with autofix where supported, then gofmt and goimports across the module — all inside the dev container. Reports the diff produced and any remaining unfixable findings.
+allowed-tools: Bash(make lint) Bash(make lint-fix) Bash(make fmt) Bash(make tidy) Bash(docker compose:*) Bash(git diff --stat) Bash(git diff)
+---
+
+Apply automatic lint and format fixes to the working tree. Everything runs inside the dev container — no host-side Go invocations.
+
+Steps:
+
+1. **Run autofix:** `make lint-fix`. This shells `golangci-lint run --fix ./...` inside the container with the project's `.golangci.yml` v2 config.
+2. **Format:** `make fmt`. Runs `gofmt -s -w` then `goimports -w -local github.com/hishamkaram/gismanager`.
+3. **Show what changed:** `git diff --stat` — concise summary of touched files.
+4. **List remaining manual fixes.** Re-run `make lint`. For each remaining finding, format as `file:line — linter: message`. Group by linter.
+5. Report verdict: **CLEAN** if no remaining findings, or **NEEDS WORK** with the manual-fix list.
+
+Do NOT commit, push, or open a PR. The user reviews the diff and commits manually.

--- a/.claude/skills/.gitkeep
+++ b/.claude/skills/.gitkeep
@@ -1,2 +1,0 @@
-# PR 6 will populate this directory with /gismanager-quirks and
-# /docker-only-dev skills.

--- a/.claude/skills/docker-only-dev/SKILL.md
+++ b/.claude/skills/docker-only-dev/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: Reference for the Docker-only dev pattern gismanager uses. Loads automatically when the user asks how to build/test/lint, or when guidance involves running Go commands locally.
+when_to_use: User says "how do I build", "run go test", "run lint", "where does this run", "install GDAL", "add libgdal-dev", or any path that would otherwise lead to a host-side install.
+---
+
+# Docker-only dev
+
+gismanager pins to **`ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`** and shells every Go command into a dev container. The host machine never installs GDAL, libpq-dev, or any of the heavy native deps. This is a **rule**, not a convention — see `feedback_dockerize_native_deps.md` in this user's auto-memory.
+
+## What's in the dev image
+
+The multi-stage `Dockerfile` at the repo root has three targets:
+
+| Target | Contents |
+|---|---|
+| `dev` | OSGeo GDAL base + Go 1.25.9 + golangci-lint v2.12.1 + govulncheck + goimports + libpq-dev + pkg-config + build-essential |
+| `build` | Compiles binaries from source |
+| `runtime` | OSGeo GDAL base + libpq5 + the gismanager + layerSchema binaries |
+
+All Go invocations the user makes locally happen inside `dev`.
+
+## How to run anything
+
+The `Makefile` is the canonical entry point. Every target shells through `docker compose run --rm -T dev <command>`:
+
+| You want to … | Run |
+|---|---|
+| Open an interactive bash shell inside the container | `make dev` |
+| `go build ./...` | `make build` |
+| Unit tests (`go test -race ./...`) | `make test-unit` |
+| Integration tests (boots GeoServer + PostGIS first) | `make compose-test-up && make test-integration` |
+| `golangci-lint run` (or with autofix) | `make lint` / `make lint-fix` |
+| `govulncheck ./...` | `make vuln` |
+| `gofmt -s -w .` + `goimports -w .` | `make fmt` |
+| `go mod tidy` | `make tidy` |
+| Build the runtime image | `make image` |
+| Tear everything down (clears volumes too) | `make clean` |
+
+If a contributor wants to add a new target, add it to the Makefile in the same shape: `$(RUN) <go invocation> $(ARGS)`. Don't add `go` invocations that run on the host directly.
+
+## What NOT to do
+
+- ❌ `apt-get install libgdal-dev` on the host (or in any host-side script / README / contributing doc).
+- ❌ `apt-get install libgdal-dev` inside the dev image — the OSGeo base already provides headers at `/usr/include/gdal_*.h` + `gdal.pc`. Adding apt's libgdal-dev shadows the bundled GDAL with an older soname (`libgdal.so.34` vs the bundled `libgdal.so.38`) and produces binaries that fail to load at runtime. See `gismanager-quirks` quirk #5.
+- ❌ Pinning `:latest` for the OSGeo image. Always pin to a specific GDAL minor (`ubuntu-small-3.12.4`).
+- ❌ Running `go test` directly on the host — even if the host has Go installed, the test will fail to find `<gdal.h>`. The error is misleading; users won't know the test was intended to run in Docker.
+- ❌ Adding a "fast path" that skips Docker. There isn't one. The CGo dep makes the host-vs-container distinction load-bearing.
+
+## VS Code
+
+Open the source tree inside the dev container via `.devcontainer/devcontainer.json`. That's how `gopls` resolves the `<gdal.h>` CGo headers — without devcontainer, the editor flags every `lukeroth/gdal` import as unresolved.
+
+## CI
+
+The same dev image is used in CI:
+
+```yaml
+container: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
+```
+
+Each job apt-installs a minimal helper set (build-essential, pkg-config, ca-certificates, git) on top of the base — but never `libgdal-dev`. The `actions/setup-go` step pulls Go 1.25 into the container.
+
+## Image hygiene
+
+The runtime image (`make image`) is `~500 MB`. Most of that is the OSGeo base plus the libpq runtime; the gismanager binary itself is `~10 MB`. Don't try to `FROM scratch` or `FROM gcr.io/distroless/...` — CGo + libgdal needs glibc + the OSGeo libgdal at runtime. The same base image used at build time is the cleanest runtime base.
+
+If image size becomes a concern, evaluate `osgeo/gdal:alpine-small-X.Y.Z` (musl-based, smaller). Alpine + CGo + GDAL has historically been touchier than Ubuntu — verify the integration suite end-to-end before switching the pinned base.

--- a/.claude/skills/gismanager-quirks/SKILL.md
+++ b/.claude/skills/gismanager-quirks/SKILL.md
@@ -1,0 +1,71 @@
+---
+description: Catalog of GDAL-binding + GeoServer wire-format quirks that gismanager works around. Reference content; loaded automatically when working on the publish flow, the OGR ingest, or debugging container-side errors.
+when_to_use: User mentions "OGR returned 500", "GeoServer returned 500", "no attributes" error, "Layer.Feature drift", "PG connection string", "zip-slip", "libgdal.so missing", "decompression bomb", "soname mismatch", or is implementing a new file format / driver / wire path.
+---
+
+# gismanager quirks
+
+Reference material. Each quirk lists the symptom, the root cause, and the file:line where the workaround lives. Whenever you change any code that talks to GDAL or to GeoServer, scan this list for relevance.
+
+## 1. `Layer.Feature(...)` takes `int64`, not `int`
+
+- **Symptom:** `cannot use index (type int) as type int64 in argument to Layer.Feature` from `lukeroth/gdal`. Build fails on Go 1.13+.
+- **Root cause:** Upstream's 2022 API sweep moved feature IDs from `int` to `int64`. The pre-revival code was written against the older signature and never bumped — issue #1.
+- **Workaround:** Cast `index` to `int64` at the call site.
+- **Where:** `layer.go:172` in `GetFeatures`.
+
+## 2. `mholt/archiver` is deprecated; use stdlib `archive/zip`
+
+- **Symptom:** `(*archiver.Zip).Open` requires a pointer receiver in v3+; older code calling `archiver.Zip.Open` (value receiver) fails to build. Upstream is also flagged DEPRECATED in the README.
+- **Root cause:** `mholt/archiver` was deprecated in 2024 in favor of `mholt/archives` (which is itself pre-1.0 as of mid-2026).
+- **Workaround:** Drop the dep entirely. gismanager only used the Zip extraction; stdlib `archive/zip` does it cleanly. Custom extractor lives in `internal/zipx/extract.go` with zip-slip rejection (filepath.Rel based, recognized by CodeQL's `go/zipslip` query) and a 2 GiB per-entry size cap (gosec G110).
+- **Where:** `internal/zipx/extract.go`; called from `utils.go:104` (`zippedShapeFile`).
+
+## 3. PostGIS feature-type creation requires the table to have non-geometry attributes
+
+- **Symptom:** `POST /workspaces/{ws}/datastores/{ds}/featuretypes` returns `400 "Trying to create new feature type inside the store, but no attributes were specified"` if the target PostGIS table is empty or has only the geometry column.
+- **Root cause:** GeoServer's wire-format expects the schema to have at least one attribute besides the geometry column to publish a feature type.
+- **Workaround:** gismanager uses OGR's `CopyLayer` to materialize the PostGIS table from the source GIS file, which preserves the source schema (geometry + attributes). The integration suite verifies this by publishing a real GeoJSON with attribute fields. Don't introduce a "publish empty stub" code path without addressing the upstream constraint.
+- **Where:** `layer.go::LayerToPostgis` (uses `datasource.CopyLayer`); integration test `publish_integration_test.go::TestPublishGeoJSON_EndToEnd_Integration`.
+
+## 4. v2 GeoServer client has no `Exists` method — use `Get` + `errors.Is(err, geoserver.ErrNotFound)`
+
+- **Symptom:** Pre-revival code called `catalog.WorkspaceExists(name)` / `DatastoreExists(...)`. The v2 client doesn't expose those.
+- **Root cause:** Deliberate v2 design — `Get` + sentinel matching is more flexible than a boolean (it preserves the underlying `*geoserver.APIError` for 5xx vs 404 disambiguation).
+- **Workaround:** The publish flow in `layer.go` does `c.Workspaces.Get(ctx, name)` first; if it returns `ErrNotFound`, calls `Create`; any other error short-circuits. Same pattern for datastore + feature type.
+- **Where:** `layer.go::ensureWorkspace`, `ensureDatastore`, plus the inline featuretype check in `PublishGeoserverLayer`.
+
+## 5. Don't `apt-get install libgdal-dev` on the OSGeo image
+
+- **Symptom:** Runtime crash with `error while loading shared libraries: libgdal.so.34: cannot open shared object file: No such file or directory`.
+- **Root cause:** The OSGeo image (`ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`) ships its own GDAL (3.12.4 → `libgdal.so.38`). Ubuntu 24's apt has GDAL 3.6 → `libgdal.so.34`. Installing the apt version on top shadows the bundled headers, so the binary links against the older soname which then doesn't exist at runtime.
+- **Workaround:** Don't apt-install anything GDAL-named. The OSGeo image already provides headers at `/usr/include/gdal_*.h` and a pkg-config file at `/usr/lib/x86_64-linux-gnu/pkgconfig/gdal.pc`.
+- **Where:** `Dockerfile` apt-install line (commented to flag the trap).
+
+## 6. Go 1.25.x stdlib CVEs (GO-2026-4869 / 4865 / 4603 …)
+
+- **Symptom:** `govulncheck` flags 10+ stdlib vulnerabilities on Go 1.25.3.
+- **Root cause:** Upstream Go security cadence — patches land in 1.25.x point releases.
+- **Workaround:** Pin `GO_VERSION=1.25.9` in `Dockerfile`. When Go 1.25.10+ ships, bump.
+- **Where:** `Dockerfile` ARG `GO_VERSION`.
+
+## 7. golangci-lint v2 needs golangci-lint-action v7
+
+- **Symptom:** CI Lint job fails with `invalid version string 'v2.12.1', golangci-lint v2 is not supported by golangci-lint-action v6`.
+- **Root cause:** Action v6 only supports v1.x; v7 is the v2-aware release.
+- **Workaround:** Pin the action to `golangci/golangci-lint-action@v7` in `.github/workflows/ci.yml`.
+- **Where:** `.github/workflows/ci.yml::Lint`.
+
+## 8. `GOFLAGS=-buildvcs=false` required when go-build runs in a container
+
+- **Symptom:** `error obtaining VCS status: exit status 128` from `go build` in CI.
+- **Root cause:** The mounted `.git` directory is owned by a different uid than the runner-user; git refuses to operate on it for security reasons.
+- **Workaround:** Set `GOFLAGS=-buildvcs=false` at the workflow `env:` level (the dev image has it baked in via `Dockerfile` ENV; on Actions the setup-go step inherits its own env so we set it again).
+- **Where:** `.github/workflows/ci.yml::env`, `.github/workflows/integration.yml::env` (if present).
+
+## When this catalog is most useful
+
+- Implementing a new GIS-format ingest path — scan items 1, 2, 5 before writing the OGR open.
+- Debugging an integration-test failure with `unmarshal` / `5xx` / `no attributes` — items 3, 4 are the usual suspects.
+- Bumping GDAL or Go in `Dockerfile` — items 5, 6 are the gotchas.
+- A CI gate flipping red after a workflow / dependency bump — items 7, 8 cover the recurring traps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to `github.com/hishamkaram/gismanager` are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] — 2026-05-04
+
+### Context
+
+First-ever stable release. Revives a 7-year-stale repo whose build had been broken on Go 1.13+ since 2022 (issue #1). The codebase has been rewritten end-to-end on top of the stabilized [`hishamkaram/geoserver/v2`](https://github.com/hishamkaram/geoserver) client. Everything below was delivered across 5 sequenced PRs (#2 → #6) on `master`.
+
+### Added
+
+- **Docker-only dev environment.** Multi-stage `Dockerfile` based on `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4` with three targets: `dev` (Go 1.25.9 + golangci-lint v2.12.1 + govulncheck + goimports + libgdal headers), `build` (compile binaries from source), `runtime` (binaries + libgdal at ~500 MB). `docker-compose.yml` for the dev shell. `.devcontainer/devcontainer.json` for VS Code. No GDAL on the host.
+- **Go modules.** `go.mod` (Go 1.25 floor) + `go.sum`. Replaces `dep`'s `Gopkg.toml` / `Gopkg.lock` (abandoned 2020).
+- **`internal/zipx` package.** Stdlib-only zip extractor with zip-slip rejection (CVE-2018-1002200 class) and a 2 GiB per-entry size cap. Replaces the deprecated `mholt/archiver` dependency.
+- **`*GISError` typed error + 7 sentinels.** `ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`. Match by sentinel via `errors.Is`; recover wrapped `*geoserver.APIError` via `errors.As`. The `*GISError.Error()` format is `gismanager: <Op> <Source>: <sentinel>: <cause>`.
+- **`*slog.Logger` throughout.** Default `gismanager.GetLogger()` returns a stderr text-handler logger. Internal call sites use structured key/value logging.
+- **Idempotent publish flow.** `PublishGeoserverLayer` checks workspace, datastore, and feature-type existence via `Get` + `errors.Is(err, geoserver.ErrNotFound)` before creating; running the same publish twice is a no-op rather than a 409 Conflict.
+- **GitHub Actions CI.** `Lint` (golangci-lint v2.12.1), `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), all running in container `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`.
+- **Integration test stack.** `docker-compose.test.yml` boots GeoServer (parameterized 2.27.4 LTS or 2.28.0 stable) + PostGIS 16 + a `test-runner` service on the same network. `publish_integration_test.go` (`//go:build integration`) covers end-to-end publish, idempotency, unsupported-format sentinel surfacing, and the nil-datasource / nil-layer error paths from the pre-revival suite.
+- **Integration matrix workflow.** `.github/workflows/integration.yml` runs the integration suite against both supported GeoServer versions on every PR; both legs must pass before merge.
+- **Project docs.** README rewritten product-first; new `docs/architecture.md`, `docs/version-compat.md`. Issue templates, PR template, CODEOWNERS, Dependabot config.
+- **Project Claude Code config** under `.claude/`: `go-reviewer`, `gdal-reviewer`, `integration-runner` agents; `gismanager-quirks` and `docker-only-dev` skills; `/integration-test` and `/lint-fix` slash commands. `CLAUDE.md` at the repo root documents the conventions.
+
+### Changed
+
+- **`OpenSource` signature** — was `(path, access) (*gdal.DataSource, bool)` (the redundant `ok bool` v1.0 idiom); now `(ctx, path, access) (*gdal.DataSource, error)`. Errors surface `ErrUnsupportedFormat` / `ErrInvalidDatasource`.
+- **`PublishGeoserverLayer` signature** — was `(*GdalLayer) (bool, error)`; now `(ctx, *GdalLayer) error`. Idempotent end-to-end.
+- **`GetGeoserverCatalog` signature** — was `() *GeoServer` (v1 monolithic client); now `() (*geoserver.Client, error)` returning a `geoserver/v2` sub-client client.
+- **Datastore connection shape** — replaced the v1 `gsconfig.DatastoreConnection` with v2's typed `datastores.PostGIS`.
+- **Logging migration** — `logrus` → `*slog.Logger` direct. `GetLogger` now returns `*slog.Logger`.
+- **CLIs no longer panic.** `cmd/gismanager` and `cmd/layerSchema` now have a `func main() { if err := run(ctx); err != nil { slog.Error(...); os.Exit(1) } }` shape. Missing config / load failures produce one-line structured errors instead of goroutine stack dumps.
+- **`make fmt`** — actually works (`goimports` is now installed in the dev image; was missing from the v1.0.0 RC).
+
+### Removed
+
+- **`mholt/archiver` dependency.** The upstream package was deprecated in 2024. gismanager only used `archiver.Zip.Open` for shapefile-zip preprocessing; `internal/zipx` replaces it.
+- **`logrus` dependency.** Replaced with stdlib `*slog.Logger`.
+- **`Gopkg.toml`, `Gopkg.lock`.** The `dep` dependency manager was abandoned in 2020.
+- **`.travis.yml`.** Travis CI hasn't been viable for OSS since 2021.
+- **`gopkg.in/yaml.v2`.** Bumped to `gopkg.in/yaml.v3`.
+- **`v1` `hishamkaram/geoserver` client import.** Migrated to `hishamkaram/geoserver/v2` v2.0.0+.
+
+### Fixed
+
+- **Issue #1** (Compile Issues, Jan 2022): the `lukeroth/gdal` API drift (`Layer.Feature(int)` → `Layer.Feature(int64)`) and the `mholt/archiver.Zip.Open` value→pointer receiver change. `go get -v github.com/hishamkaram/gismanager` works on Go 1.25 again.
+- **Library-code panics removed.** Library code (root + `internal/`) contains zero `panic(` calls; cmd/ binaries also panic-free as of v1.0.0.
+
+### Security
+
+- **govulncheck clean** as of v1.0.0. The Go 1.25.3 stdlib CVEs flagged during PR 3 (GO-2026-4869 / 4865 / 4603 etc.) are all fixed by the pinned 1.25.9 toolchain.
+- **Zip-slip protection** added to `internal/zipx` via the canonical `filepath.Rel` defense pattern (also recognized by CodeQL's `go/zipslip` query).
+
+### Known limitations
+
+- **GDAL CGo dep** — the runtime image is ~500 MB and dynamically linked against `libgdal.so.38`. Pure-Go alternatives (`twpayne/go-shapefile`, `paulmach/orb`) cover fewer formats than GDAL; the trade-off is documented in [`docs/architecture.md`](docs/architecture.md).
+- **No streaming publish.** Each layer is materialized into PostGIS before publishing; very large datasets need to fit memory at OGR-copy time.
+- **No functional-options constructor yet.** `gismanager.FromConfig(yamlPath)` is the only public constructor; a `gismanager.New(opts ...Option)` form will land in v1.1.x.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,18 +89,18 @@ gismanager is **context-first**: every exported method on `*Manager` takes `ctx 
 
 ## Index of project Claude config
 
-Subagents (delegated workers, own context window) — *populated in PR 6:*
+Subagents (delegated workers, own context window):
 
-- `go-reviewer` — Go-idiom review of changed files (adapted from the geoserver repo).
-- `integration-runner` — boots the gismanager compose stack, runs integration suite, dumps logs on failure.
-- `gdal-reviewer` — CGo + GDAL-binding review (catches Feature/int64 drift, leaked OGR handles, etc.).
+- `go-reviewer` — Go-idiom review of changed files: errors.Is/As over string-matching, ctx-first method shape, slog discipline, no library-code panics, the `*GISError` sentinel-wrapping contract.
+- `integration-runner` — boots the gismanager compose-test stack, runs the integration suite, dumps logs on failure.
+- `gdal-reviewer` — CGo + `lukeroth/gdal`-binding review: integer-width drift (`Layer.Feature(int64)`), OGR handle ownership / Destroy semantics, soname pinning, OGR driver-name constants.
 
-Skills (loadable knowledge / procedures) — *populated in PR 6:*
+Skills (loadable knowledge / procedures):
 
-- `/gismanager-quirks` — catalog of GDAL-binding quirks the codebase works around.
-- `/docker-only-dev` — reference for the "shell every Go command into Docker" pattern.
+- `/gismanager-quirks` — catalog of GDAL-binding + GeoServer wire-format quirks the codebase works around (auto-loads on relevant edits).
+- `/docker-only-dev` — reference for the "shell every Go command into Docker" pattern (auto-loads on build/test/run questions).
 
-Slash commands (callable recipes) — *populated in PR 6:*
+Slash commands (callable recipes):
 
-- `/integration-test` — boot compose stack and run integration suite.
+- `/integration-test [version]` — boot compose-test stack and run integration suite (default 2.28.0; pass `2.27` for the LTS leg).
 - `/lint-fix` — golangci-lint with autofix + gofmt + goimports, all in-container.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility, apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via the contact method in [SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [contributor-covenant.org/version/2/1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to gismanager
+
+Thanks for your interest in contributing! This document describes how to get a development environment running and what we expect from pull requests.
+
+## Development environment — Docker only
+
+**This project does NOT install GDAL on the host machine.** All build, test, integration, and CI work runs inside containers. Requirements:
+
+- Docker + Docker Compose v2
+- `make`
+- `git`
+
+Clone and bootstrap:
+
+```bash
+git clone https://github.com/hishamkaram/gismanager
+cd gismanager
+make dev          # opens an interactive bash inside the dev container
+```
+
+The first `make dev` builds the dev image (Go 1.25.9 + golangci-lint v2.12.1 + govulncheck + goimports + libgdal-dev headers, all on top of `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`). Subsequent runs are cached.
+
+Run targets non-interactively:
+
+```bash
+make build              # go build ./...
+make test-unit          # unit tests, no Docker stack required
+make test-integration   # integration tests against compose-managed GeoServer + PostGIS
+make lint               # golangci-lint v2
+make vuln               # govulncheck
+make fmt                # gofmt -s -w + goimports -w
+make tidy               # go mod tidy
+```
+
+For the integration suite:
+
+```bash
+make compose-test-up                    # default — GeoServer 2.28.0
+GEOSERVER_VERSION=2.27.4 make compose-test-up   # LTS leg
+make test-integration                   # runs go test -tags=integration ./...
+make compose-test-down
+```
+
+See [`docker/README.md`](docker/README.md) for what's in the GeoServer image. (Or the Dockerfile itself, which is short.)
+
+## Make targets
+
+| Target | What it does |
+|---|---|
+| `make help` | Print this list. |
+| `make dev` | Open an interactive bash inside the dev container. |
+| `make build` | `go build ./...` |
+| `make test-unit` | Unit tests with `-race` |
+| `make test-integration` | Integration tests (`-tags=integration`) against the compose-test stack |
+| `make lint` / `make lint-fix` | `golangci-lint run` (with `--fix` variant) |
+| `make vuln` | `govulncheck ./...` |
+| `make tidy` | `go mod tidy` |
+| `make fmt` | `gofmt -s -w` + `goimports -w` |
+| `make image` | Build the runtime image (`gismanager:local`) |
+| `make compose-test-up` / `compose-test-down` / `compose-test-logs` | Manage the integration stack |
+| `make clean` | Tear down dev + test compose volumes |
+
+## Pull requests
+
+1. **Branch from `master`.** Use a short descriptive name (`fix/url-escape`, `feat/new-format`). Never commit directly to `master`.
+2. **One concern per PR.** Smaller PRs review faster.
+3. **Conventional Commits.** Commit messages follow [Conventional Commits 1.0](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, `build:`, `ci:`).
+4. **Tests are mandatory.** New code needs unit tests (`*_test.go`, no build tag). Behavior changes also need an integration test entry (`*_integration_test.go` with `//go:build integration`). **Both layers run on every PR**: matrix CI exercises GeoServer 2.27.4 LTS + 2.28.0 stable; both legs must pass.
+5. **Lint clean.** `make lint` must pass with zero warnings.
+6. **No new runtime dependencies** without prior discussion. Test-only deps are fine.
+7. **No GDAL on the host.** Anything that requires GDAL must run inside the dev container. PRs that add `apt-get install libgdal-dev` to host docs / scripts will be rejected.
+8. **No `panic(` in library code.** Panics may live only in `cmd/*` `main.go` entry points (and PR 4 already removed the panics there). Library code returns errors wrapped with sentinels from `errors.go`.
+9. **All CI checks must pass before merge.** The required gates on every PR: `Lint`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0`. Don't merge with any check red, pending, or skipped.
+10. **Squash merge.** PRs are squash-merged into `master` so each merge produces exactly one commit on the trunk.
+
+## Project layout
+
+```
+.
+├── *.go                          # Library: ManagerConfig, GdalLayer, GISError, sentinels (datastore.go, errors.go, layer.go, log.go, manager.go, utils.go, vars.go)
+├── *_test.go                     # Unit tests
+├── *_integration_test.go         # Integration tests (//go:build integration)
+├── cmd/
+│   ├── gismanager/               # Full pipeline CLI
+│   └── layerSchema/              # Read-only schema printer
+├── internal/
+│   └── zipx/                     # stdlib archive/zip extractor (zip-slip rejection + size cap)
+├── docs/                         # Architecture, version compat
+├── docker/
+│   ├── Dockerfile                # GeoServer image used by the integration stack
+│   ├── env/geoserver.env         # GeoServer JVM + admin password config
+│   └── postgis/init/             # PostGIS init SQL (CREATE EXTENSION postgis)
+├── docker-compose.yml            # Dev stack (just the dev shell)
+├── docker-compose.test.yml       # Integration stack (GeoServer + PostGIS + test-runner)
+├── Dockerfile                    # Multi-stage: dev (Go + tools) / build / runtime (binaries + libgdal)
+├── .devcontainer/                # VS Code devcontainer config
+├── .github/                      # Workflows, issue + PR templates, CODEOWNERS, Dependabot
+├── .claude/                      # Claude Code config: agents, skills, commands
+└── testdata/                     # GIS file fixtures for unit + integration tests
+```
+
+## Reporting bugs / asking questions
+
+- **Bugs:** open a GitHub issue with the bug-report template.
+- **Security issues:** see [SECURITY.md](SECURITY.md). Do not open a public issue.
+- **Questions:** GitHub Discussions if available, otherwise an issue.
+
+## Releasing
+
+Releases are cut by maintainers via tags (`v1.x.y`). After a tag is pushed, `release.yml` (added in a future PR) will assemble release notes from Conventional Commit messages.
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The `[Unreleased]` block at the top of the file accumulates entries between tags; cutting a release promotes the block contents into a dated stanza and leaves a fresh `[Unreleased]` placeholder.
+
+## Working with Claude Code in this repo
+
+The repo ships project-scoped Claude Code config so any contributor using Claude Code (CLI, IDE extensions, web app) gets the same conventions and shortcuts. Auto-loaded from `CLAUDE.md` (root) and `.claude/`.
+
+| Type | Name | Purpose |
+|---|---|---|
+| Slash command | `/integration-test [version]` | Boot the docker-compose-test stack and run the integration suite (default 2.28; `2.27` for the LTS leg). |
+| Slash command | `/lint-fix` | Run `golangci-lint --fix` + `gofmt` + `goimports` inside the dev container; report the diff and any remaining manual fixes. |
+| Skill | `/gismanager-quirks` | Catalog of GDAL-binding + wire-format quirks gismanager works around (auto-loads when relevant). |
+| Skill | `/docker-only-dev` | Reference for the "shell every Go command into Docker" pattern (auto-loads when relevant). |
+| Subagent | `go-reviewer` | Idiom + sentinel-error + slog review of changed Go files. |
+| Subagent | `gdal-reviewer` | CGo + lukeroth/gdal-binding review (catches OGR API drift, leaked feature handles, etc.). |
+| Subagent | `integration-runner` | Boots the gismanager test stack, runs integration tests, diagnoses failures from container logs. |
+
+Personal per-machine settings live in `.claude/settings.local.json` (gitignored). The team baseline is intentionally minimal; extend if the project grows enough contributors to warrant it.

--- a/README.md
+++ b/README.md
@@ -3,183 +3,225 @@
 [![GitHub license](https://img.shields.io/github/license/hishamkaram/gismanager.svg)](https://github.com/hishamkaram/gismanager/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/hishamkaram/gismanager.svg)](https://github.com/hishamkaram/gismanager/issues)
 
+# GIS Manager
 
-<p align="center">
-  <img src="http://geoserver.org/img/OSGeo_project.png" width="200"/>
-</p>
-<p align="center">
-  <img src="https://i.imgur.com/31CL1xg.png" width="200"/>
-</p>
+**A Go tool that publishes GIS vector data to GeoServer via PostGIS.** Drop a directory of shapefiles, GeoJSON, GeoPackage, or KML files into a config, run one command, and gismanager loads each file into a PostGIS database and registers the resulting tables as GeoServer feature types — workspace creation, datastore registration, and layer publishing all idempotent.
 
-# GISManager
-Publish Your GIS Data(Vector Data) to PostGIS and Geoserver
+It exists because the path from "I have a shapefile" to "I have a published GeoServer layer" otherwise involves three different tools (ogr2ogr, psql, and the GeoServer admin UI or REST API). gismanager is one CLI plus one config.
 
-- How to install:
-    - `go get -v github.com/hishamkaram/gismanager`
-- Usage:
-  - `testdata` folder content:
-    ```
-    ./testdata/
-    ├── neighborhood_names_gis.geojson
-    ├── nested
-    │   └── nyc_wi-fi_hotspot_locations.geojson
-    ├── sample.gpkg
-    ```
-  - create `ManagerConfig` instance:
-    ```
-    manager:= gismanager.ManagerConfig{
-      Geoserver: gismanager.GeoserverConfig{WorkspaceName: "golang", Username: "admin", Password: "geoserver", ServerURL: "http://localhost:8080/geoserver"},
-      Datastore: gismanager.DatastoreConfig{Host: "localhost", Port: 5432, DBName: "gis", DBUser: "golang", DBPass: "golang", Name: "gismanager_data"},
-      Source:    gismanager.SourceConfig{Path: "./testdata"},
-      logger:    gismanager.GetLogger(),
+## Contents
+
+- [What this tool does](#what-this-tool-does)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [Worked example: publish a directory of GIS files](#worked-example-publish-a-directory-of-gis-files)
+- [Errors](#errors)
+- [Configuration](#configuration)
+- [Library use](#library-use)
+- [Version compatibility](#version-compatibility)
+- [Contributing](#contributing)
+- [License](#license)
+
+## What this tool does
+
+Two CLI binaries plus a small Go library:
+
+- **`gismanager`** — full pipeline. Walks `source.path`, picks every supported GIS file, copies its layers into PostGIS via OGR's PostgreSQL driver, then publishes each PostGIS table as a GeoServer feature type. Idempotent: workspace, datastore, and feature-type creation all check existence first via the `geoserver/v2` client's `Get` + `errors.Is(err, geoserver.ErrNotFound)` idiom.
+- **`layerSchema`** — read-only schema inspector. Walks `source.path`, opens each GIS file via GDAL, and prints the geometry column + attribute fields for every layer it finds. No PostGIS, no GeoServer.
+- **`package gismanager`** — the same flow as a Go library. Construct a `*ManagerConfig` (today via `gismanager.FromConfig(yamlPath)`; functional-options constructor planned), then call `OpenSource` / `LayerToPostgis` / `PublishGeoserverLayer` directly.
+
+### Supported source formats
+
+Driven by GDAL's OGR drivers; whatever GDAL can read, gismanager can ingest. The currently dispatched extensions:
+
+| Extension | Driver |
+|---|---|
+| `.shp`, `.zip` (zipped shapefile bundle) | ESRI Shapefile |
+| `.geojson`, `.json` | GeoJSON |
+| `.gpkg` | GeoPackage |
+| `.kml` | KML |
+
+Zipped shapefile bundles are auto-extracted into a temp directory before the OGR open — see [`internal/zipx`](internal/zipx) for the stdlib `archive/zip`-based extractor (zip-slip rejection, 2 GiB per-entry cap).
+
+## Install
+
+**This project does NOT install GDAL on the host machine.** All build, test, and run work happens inside the Docker dev image (`ghcr.io/osgeo/gdal:ubuntu-small-3.12.4` base + Go 1.25.9 + tooling). If you don't have Docker, [install Docker first](https://docs.docker.com/get-docker/).
+
+```bash
+git clone https://github.com/hishamkaram/gismanager
+cd gismanager
+make dev          # opens an interactive bash inside the container
+# OR run targets non-interactively:
+make build        # go build ./...
+make test-unit    # unit tests (no live GeoServer)
+make image        # produce a runtime image: gismanager:local
+```
+
+The runtime image (`make image`) is a multi-stage build that ships only the binaries + libgdal at `~500 MB`. It's what you'd publish to a registry for production-ish use.
+
+## Quick start
+
+The shortest path to a published layer assumes you have a GeoServer + PostGIS already running somewhere reachable. If you don't, the project's own integration test stack is a working example — `make compose-test-up` boots GeoServer 2.28.0 + PostGIS 16 in two containers.
+
+1. Write a config file. Example `my-config.yaml`:
+
+   ```yaml
+   geoserver:
+     url: http://localhost:8080/geoserver
+     username: admin
+     password: geoserver
+     workspace: my_workspace
+   datastore:
+     host: localhost
+     port: 5432
+     database: gis
+     username: golang
+     password: golang
+     name: my_postgis_store
+   source:
+     path: ./testdata
+   ```
+
+2. Run the CLI from the runtime image:
+
+   ```bash
+   docker run --rm --network host \
+     -v "$PWD/my-config.yaml:/cfg.yaml:ro" \
+     -v "$PWD/testdata:/testdata:ro" \
+     gismanager:local --config /cfg.yaml
+   ```
+
+   gismanager scans `/testdata`, loads each supported file into PostGIS, and publishes the resulting tables as feature types in the `my_workspace` workspace.
+
+## Worked example: publish a directory of GIS files
+
+The repo's own `testdata/` directory has a GeoJSON file and a GeoPackage. Booting the integration stack and publishing them end-to-end:
+
+```bash
+# Boot GeoServer 2.28.0 + PostGIS 16 in containers.
+make compose-test-up
+
+# Run the CLI inside the test-runner container so it can see the
+# in-network GeoServer + PostGIS by service name.
+docker compose -f docker-compose.test.yml run --rm test-runner \
+  bash -c 'go run ./cmd/gismanager --config testdata/test_config.yml'
+
+# Verify via the GeoServer REST API.
+curl -fsS -u admin:geoserver \
+  http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gismanager_data/featuretypes.json | jq
+
+# Tear down.
+make compose-test-down
+```
+
+Same idea programmatically (the integration suite is a worked example — see [`publish_integration_test.go`](publish_integration_test.go) `TestPublishGeoJSON_EndToEnd_Integration`).
+
+## Errors
+
+Every error gismanager returns is a `*GISError` wrapping a sentinel from [`errors.go`](errors.go). Match by sentinel:
+
+```go
+import "github.com/hishamkaram/gismanager"
+
+err := mgr.PublishGeoserverLayer(ctx, layer)
+switch {
+case errors.Is(err, gismanager.ErrPostGISConnect):
+    // PostGIS unreachable; bring it up and retry.
+case errors.Is(err, gismanager.ErrGeoServerPublish):
+    // Workspace/datastore/feature-type creation failed; the wrapped
+    // *geoserver.APIError carries the HTTP status (404, 409, 500…).
+    var apiErr *geoserver.APIError
+    if errors.As(err, &apiErr) {
+        log.Printf("status=%d body=%s", apiErr.StatusCode, apiErr.Body)
     }
-    ```
-  - get Supported GIS Files:
-    ```
-    files, _ := gismanager.GetGISFiles(manager.Source.Path)
-    for _, file := range files {
-      fmt.Println(file)
+case errors.Is(err, gismanager.ErrUnsupportedFormat):
+    // The path's extension isn't one of the dispatched OGR drivers.
+}
+```
+
+Sentinels: `ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`. Never compare error strings — `errors.Is(err, sentinel)` is the only correct test.
+
+## Configuration
+
+YAML schema (the same struct gets used by `gismanager.FromConfig`):
+
+```yaml
+geoserver:
+  url: <string>          # GeoServer base URL, e.g. http://geoserver:8080/geoserver
+  username: <string>     # admin user
+  password: <string>
+  workspace: <string>    # workspace gismanager publishes into; created on first use
+
+datastore:               # connection params for the PostGIS database
+  host: <string>
+  port: <uint>
+  database: <string>     # database name (created externally; gismanager does not provision databases)
+  username: <string>
+  password: <string>
+  name: <string>         # GeoServer datastore name (must be unique within the workspace)
+
+source:
+  path: <string>         # directory or single file containing GIS data
+```
+
+A working config used by the integration suite lives at [`testdata/test_config.yml`](testdata/test_config.yml).
+
+## Library use
+
+```go
+import (
+    "context"
+    "github.com/hishamkaram/gismanager"
+)
+
+func main() {
+    mgr, err := gismanager.FromConfig("my-config.yaml")
+    if err != nil { /* ... */ }
+
+    ctx := context.Background()
+
+    // Discover GIS files under source.path.
+    files, _ := gismanager.GetGISFiles(mgr.Source.Path)
+
+    target, err := mgr.OpenSource(ctx, mgr.Datastore.BuildConnectionString(), 1)
+    if err != nil { /* ... */ }
+
+    for _, f := range files {
+        src, err := mgr.OpenSource(ctx, f, 0)
+        if err != nil { continue }
+        for i := 0; i < src.LayerCount(); i++ {
+            layer := src.LayerByIndex(i)
+            gLayer := gismanager.GdalLayer{Layer: &layer}
+            newLayer, err := gLayer.LayerToPostgis(target, mgr, true)
+            if err != nil || newLayer == nil { continue }
+            _ = mgr.PublishGeoserverLayer(ctx, newLayer)
+        }
     }
-    ```
-    - output:
-      ```
-      <full_path>/testdata/neighborhood_names_gis.geojson
-      <full_path>/testdata/nested/nyc_wi-fi_hotspot_locations.geojson
-      <full_path>/testdata/sample.gpkg
-      ```
-  - read files and get layers Schema:
-    ```
-      for _, file := range files {
-        source, ok := manager.OpenSource(file, 0)
-        if ok {
-          for index := 0; index < source.LayerCount(); index++ {
-            layer := source.LayerByIndex(index)
-            gLayer := gismanager.GdalLayer{
-              Layer: &layer,
-            }
-            fmt.Println(layer.Name())
-            for _, f := range gLayer.GetLayerSchema() {
-              fmt.Printf("\n%+v\n", *f)
-            }
-          }
-        }
-      }
-    ```
-    - output sample:
-      ```
-      neighborhood_names_gis
+}
+```
 
-      {Name:geom Type:POINT}
+## Version compatibility
 
-      {Name:stacked Type:String}
+gismanager v1.0.x targets:
 
-      {Name:name Type:String}
+- **Go 1.25+** — required by the transitive `geoserver/v2` dependency.
+- **GeoServer 2.27 LTS + 2.28 stable** — both validated by the matrix integration leg in CI on every PR.
+- **PostGIS 16-3.4** — the integration stack pins this; older PostGIS (≥ 2.5) should work but isn't gated in CI.
+- **GDAL 3.12.x** — pinned via the `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4` base image. Bumping requires re-running the integration suite.
 
-      {Name:annoline1 Type:String}
+GeoServer 3.0 (Tomcat 11 / Jakarta EE / ImageN) is parked for a future v1.x point release after the upstream migration settles.
 
-      {Name:annoline3 Type:String}
+Full matrix: [`docs/version-compat.md`](docs/version-compat.md).
 
-      {Name:objectid Type:String}
+## Contributing
 
-      {Name:annoangle Type:String}
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Highlights:
 
-      {Name:annoline2 Type:String}
+- All work happens inside the Docker dev image — no host GDAL install.
+- Branch from `master`; squash-merge with `--delete-branch`. Never push directly to `master`.
+- Both unit and integration tests are mandatory on every PR. The matrix CI runs against GeoServer 2.27.4 + 2.28.0; both legs must pass.
+- Conventional Commits.
 
-      {Name:borough Type:String}
-      ...
-      ```
-  - add your gis data to your database:
-    ```
-      for _, file := range files {
-          source, ok := manager.OpenSource(file, 0)
-          targetSource, targetOK := manager.OpenSource(manager.Datastore.BuildConnectionString(), 1)
-          if ok && targetOK {
-            for index := 0; index < source.LayerCount(); index++ {
-              layer := source.LayerByIndex(index)
-              gLayer := gismanager.GdalLayer{
-                Layer: &layer,
-              }
-              newLayer, postgisErr := gLayer.LayerToPostgis(targetSource, manager, true)
-              if postgisErr != nil {
-                panic(postgisErr)
-              }
-              logger.Infof("Layer: %s added to you database", newLayer.Name())
-            }
-          }
-      }
-    ```
-    - output:
-      ```
-      INFO[14-10-2018 17:28:37] Layer: neighborhood_names_gis added to you database 
-      INFO[14-10-2018 17:28:38] Layer: nyc_wi_fi_hotspot_locations added to you database 
-      INFO[14-10-2018 17:28:38] Layer: hwy_patrol added to you database
-      ```
-   - update the previous code to publish your postgis layers to geoserver
-     ```
-      for _, file := range files {
-        source, ok := manager.OpenSource(file, 0)
-        targetSource, targetOK := manager.OpenSource(manager.Datastore.BuildConnectionString(), 1)
-        if ok && targetOK {
-          for index := 0; index < source.LayerCount(); index++ {
-            layer := source.LayerByIndex(index)
-            gLayer := gismanager.GdalLayer{
-              Layer: &layer,
-            }
-            if newLayer, postgisErr := gLayer.LayerToPostgis(targetSource, manager, true); newLayer.Layer != nil || postgisErr != nil {
-              ok, pubErr := manager.PublishGeoserverLayer(newLayer)
-              if pubErr != nil {
-                logger.Error(pubErr)
-              }
-              if !ok {
-                logger.Error("Failed to Publish")
-              } else {
-                logger.Info("published")
-              }
-            }
+## License
 
-          }
-        }
-      }
-     ```
-     - output:
-     ```
-      INFO[14-10-2018 17:37:07] url:http://localhost:8080/geoserver/rest/workspaces/golang  Status=404  
-      ERRO[14-10-2018 17:37:07] No such workspace: 'golang' found            
-      INFO[14-10-2018 17:37:07] url:http://localhost:8080/geoserver/rest/workspaces  Status=201  
-      INFO[14-10-2018 17:37:07] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis?quietOnNotFound=true  Status=404  
-      INFO[14-10-2018 17:37:07] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores  Status=201  
-      ERRO[14-10-2018 17:37:07] {"featureType":{"name":"neighborhood_names_gis","nativeName":"neighborhood_names_gis"}} 
-      INFO[14-10-2018 17:37:07] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis/featuretypes  Status=201  
-      INFO[14-10-2018 17:37:07] published                                    
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang  Status=200  
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis?quietOnNotFound=true  Status=200  
-      ERRO[14-10-2018 17:37:08] {"featureType":{"name":"nyc_wi_fi_hotspot_locations","nativeName":"nyc_wi_fi_hotspot_locations"}} 
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis/featuretypes  Status=201  
-      INFO[14-10-2018 17:37:08] published                                    
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang  Status=200  
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis?quietOnNotFound=true  Status=200  
-      ERRO[14-10-2018 17:37:08] {"featureType":{"name":"hwy_patrol","nativeName":"hwy_patrol"}} 
-      INFO[14-10-2018 17:37:08] url:http://localhost:8080/geoserver/rest/workspaces/golang/datastores/gis/featuretypes  Status=201  
-      INFO[14-10-2018 17:37:08] published 
-     ```
-     - done check you geoserver or via geoserver rest api url http://localhost:8080/geoserver/rest/layers.json : 
-       ```
-        {
-          "layers": {
-            "layer": [..., {
-              "name": "golang:hwy_patrol",
-              "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/golang%3Ahwy_patrol.json"
-            }, {
-              "name": "golang:neighborhood_names_gis",
-              "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/golang%3Aneighborhood_names_gis.json"
-            }, {
-              "name": "golang:nyc_wi_fi_hotspot_locations",
-              "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/golang%3Anyc_wi_fi_hotspot_locations.json"
-            }]
-          }
-        }
-       ```
- ---
- 
-# Todo:
-  - [ ] backup postgis as geopackage
+[MIT](LICENSE) © Hesham Karm.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| 1.x   | ✅ Active development and security fixes (latest `v1.0.0`, on `master`) |
+| < 1.0 | ❌ No support — pre-revival source (last commit October 2018, build broken since Go 1.13). |
+
+## Reporting a vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+Use one of these private channels:
+
+1. **GitHub Security Advisories** (preferred) — go to the repository's [Security tab](https://github.com/hishamkaram/gismanager/security) → "Report a vulnerability".
+2. **Email** — open a private advisory request via GitHub if you cannot use the Security tab.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- A minimal reproduction (config + sample data, or a Go program if using the library directly).
+- The version of `github.com/hishamkaram/gismanager`, Go, GeoServer, and GDAL where the issue was observed.
+
+## What to expect
+
+- Acknowledgement within 5 business days.
+- A triage response with severity assessment within 10 business days.
+- A fix, mitigation, or workaround as quickly as severity allows. Critical issues are prioritized.
+- A coordinated disclosure: we will agree on a public disclosure timeline with the reporter before publishing.
+
+## Scope
+
+This policy covers the Go code in this repository (the `gismanager` library + the two CLIs in `cmd/`) and the dev/test container images shipped from `Dockerfile` and `docker/Dockerfile`.
+
+Out of scope:
+
+- **Upstream GeoServer** (the server) — report to the [GeoServer project](https://geoserver.org/) directly.
+- **Upstream GDAL / OGR** — report to [OSGeo/gdal](https://github.com/OSGeo/gdal/issues).
+- **`lukeroth/gdal` Go bindings** — report to [lukeroth/gdal](https://github.com/lukeroth/gdal/issues).
+- **`hishamkaram/geoserver` (the lower-level Go client)** — report to [hishamkaram/geoserver](https://github.com/hishamkaram/geoserver/security).
+- **Other dependencies** — please also report upstream so the broader ecosystem benefits.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,47 @@
+# Docker dev/test stack
+
+This directory builds the GeoServer container the project's integration tests run against. It is a **dev/test stack only** — do not use this image in production. The admin password is the literal string `geoserver`, the container ships without TLS, and JVM/resource limits are tuned for a fast `compose up` rather than a hardened deploy.
+
+## What's in the image
+
+| Layer | Choice | Why |
+|---|---|---|
+| Base | `tomcat:9-jdk17-temurin` | GeoServer 2.x uses the `javax.*` servlet namespace (Servlet 4.x) and does not run on Tomcat 10/11 (which moved to `jakarta.*`). GeoServer 3.0 will be the Tomcat 11 / Jakarta EE target — see [`../docs/version-compat.md`](../docs/version-compat.md). |
+| GeoServer | 2.28.0 by default; 2.27.4 LTS for the LTS leg | The supported matrix. CI runs both legs on every PR. Override with `--build-arg GEOSERVER_VERSION=...` or `GEOSERVER_VERSION=2.27.4 make compose-test-up`. |
+| Layout | WAR pre-extracted into `webapps/geoserver/` | Lets Tomcat boot faster on subsequent runs. |
+| Healthcheck | `curl -fsS http://localhost:8080/geoserver/web/` every 30s after a 120s start period | Compose `depends_on: condition: service_healthy` waits on this before starting the test runner. |
+
+No Importer or Monitor extensions — gismanager only exercises the publish flow (workspace + datastore + feature type), not the import or monitoring REST surfaces. The lower-level [`hishamkaram/geoserver`](https://github.com/hishamkaram/geoserver) Go client's integration suite has those.
+
+## Boot the stack
+
+From the repo root:
+
+```bash
+make compose-test-up                          # default — GeoServer 2.28.0
+GEOSERVER_VERSION=2.27.4 make compose-test-up # LTS leg
+make test-integration                         # runs go test -tags=integration ./...
+make compose-test-down
+```
+
+PostGIS exposes port `5436` on the host (mapped from the container's `5432`) so it doesn't collide with a local Postgres install or the lower-level `geoserver` client's compose stack. Default credentials: `golang` / `golang`, database `gis`.
+
+Inside the test-runner container, the postgis hostname is just `postgis:5432` — they share the compose network.
+
+## Files in this directory
+
+| File | Role |
+|---|---|
+| `Dockerfile` | Assembles the GeoServer image. Pulls the GeoServer WAR from `downloads.sourceforge.net` over TLS, unpacks the WAR. |
+| `env/geoserver.env` | Environment variables consumed by the container at start: `GEOSERVER_ADMIN_PASSWORD`, JVM `INITIAL_MEMORY` / `MAXIMUM_MEMORY`, plus a few feature toggles (`ENABLE_JSONP`, `MAX_FILTER_RULES`, `OPTIMIZE_LINE_WIDTH`, `XFRAME_OPTIONS`). |
+| `postgis/init/01-gismanager.sql` | Idempotently `CREATE EXTENSION IF NOT EXISTS postgis` on the `gis` database. The postgres image runs `*.sql` files from `/docker-entrypoint-initdb.d/` alphabetically on first boot of an empty data volume. To re-run after a schema change, recreate the volume: `docker compose -f docker-compose.test.yml down -v && make compose-test-up`. |
+
+## Production caveat
+
+Do not deploy this image as-is. To use GeoServer in production, build your own image (or use the official one from the GeoServer project) with at minimum: a real admin password, TLS in front, JVM limits tuned for your traffic, persistent volumes for the data dir, and CORS / CSRF configured for your tenancy model.
+
+## See also
+
+- [`../docker-compose.test.yml`](../docker-compose.test.yml) — the integration stack that wires this image together with PostGIS + a test-runner.
+- [`../docs/version-compat.md`](../docs/version-compat.md) — supported Go × GeoServer × GDAL × PostGIS matrix and the Tomcat 9 / JDK 17 rationale.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — how to run lint, unit, and integration tests locally.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,142 @@
+# Architecture
+
+This document describes how `github.com/hishamkaram/gismanager` is laid out, the design tenets, and the trade-offs behind v1.0's shape. Reference material; release notes live in [`../CHANGELOG.md`](../CHANGELOG.md).
+
+## Big picture
+
+gismanager is a small composition of three things:
+
+```
+                 ┌─────────────────────────┐
+   GIS files ───▶│   GDAL OGR readers      │  (lukeroth/gdal CGo bindings)
+   (shp, gpkg,   │  (file ingest + schema  │
+    geojson, kml,│   introspection)        │
+    zip)         └────────────┬────────────┘
+                              │
+                              ▼
+                 ┌─────────────────────────┐
+                 │   OGR PostgreSQL driver │  (CopyLayer over the OGR API)
+                 │   → PostGIS table       │
+                 └────────────┬────────────┘
+                              │
+                              ▼
+                 ┌─────────────────────────┐
+                 │  geoserver/v2 client    │  (REST: workspace, datastore,
+                 │  → published feature    │   feature type)
+                 │     type                │
+                 └─────────────────────────┘
+```
+
+The package wires the three together with a `*ManagerConfig` that holds the GeoServer endpoint, the PostGIS connection params, and the source-directory path. Everything else is a thin orchestration layer over GDAL + the upstream Go client.
+
+## Package shape
+
+| Path | Purpose |
+|---|---|
+| `github.com/hishamkaram/gismanager` | Public API — `*ManagerConfig`, `*GdalLayer`, `*GISError`, sentinels, public method receivers |
+| `github.com/hishamkaram/gismanager/internal/zipx` | stdlib `archive/zip` extractor with zip-slip rejection + per-entry size cap. Used to auto-extract zipped shapefile bundles before the OGR open. Internal — not importable |
+| `github.com/hishamkaram/gismanager/cmd/gismanager` | Full-pipeline CLI |
+| `github.com/hishamkaram/gismanager/cmd/layerSchema` | Read-only schema-printing CLI |
+
+A single Go module at the repo root. No `/v2` semantic-import-versioning suffix because gismanager has no released versions to preserve — v1.0.0 is the first stable tag.
+
+## Public API
+
+The lead type is `*ManagerConfig` (currently constructed from YAML via `gismanager.FromConfig(path)`; functional-options constructor planned). Methods:
+
+```go
+// Build a v2 GeoServer client from the configured endpoint + credentials.
+func (m *ManagerConfig) GetGeoserverCatalog() (*geoserver.Client, error)
+
+// Open a GIS data source via GDAL. ctx is reserved for cancellation.
+func (m *ManagerConfig) OpenSource(ctx context.Context, path string, access int) (*gdal.DataSource, error)
+
+// Map a path or connection string to its OGR driver.
+func (m *ManagerConfig) GetDriver(path string) (gdal.OGRDriver, error)
+
+// Copy this GDAL layer into a PostGIS-backed OGR data source.
+func (l *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, m *ManagerConfig, overwrite bool) (*GdalLayer, error)
+
+// Publish a PostGIS-backed layer as a GeoServer feature type. Idempotent
+// end-to-end (Get + ErrNotFound for workspace, datastore, and feature type).
+func (m *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *GdalLayer) error
+```
+
+All methods that can fail return errors wrapping a sentinel from [`../errors.go`](../errors.go) — see the README's [Errors](../README.md#errors) section for the matching idiom.
+
+## Context-first
+
+Every exported method that does I/O takes `ctx context.Context` as its first argument. There are no `*Context` twin methods — that pattern was an upstream `geoserver` v1 source-compat idiom that v2 dropped, and gismanager mirrors v2's discipline. Callers without a context pass `context.Background()` at the call site.
+
+Today the OGR / GDAL bindings don't accept context (no upstream cancellation surface), so gismanager threads ctx through its own boundary and uses it for the geoserver/v2 calls. When upstream grows ctx propagation, swapping it in is a non-breaking change.
+
+## Errors
+
+`errors.go` defines 7 sentinels (`ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`) and a typed `*GISError` with `Op`, `Source`, `Sentinel`, `Cause` fields. `Unwrap` returns Cause; `Is` matches Sentinel.
+
+Why both layers: callers can branch by category (`errors.Is(err, ErrPostGISConnect)`) for control flow, *and* extract the underlying `*geoserver.APIError` (or driver-level error) via `errors.As` for diagnostic logging. The same error satisfies both at once.
+
+The wrapped `*geoserver.APIError` from the upstream v2 client carries HTTP status + body preview, so a 409 Conflict from a duplicate datastore looks like:
+
+```
+gismanager: PublishGeoserverLayer "myws/mystore": gismanager: geoserver publish: geoserver: Datastores.Create POST http://...: 409 Conflict: Store 'mystore' already exists in workspace 'myws'
+```
+
+## Logging
+
+`*slog.Logger` directly. No wrapper. The default `gismanager.GetLogger()` returns `slog.New(slog.NewTextHandler(os.Stderr, nil))`; production callers should construct their own `*slog.Logger` (any handler — JSON, lumberjack rotation, otel) and pass it on `ManagerConfig.logger`.
+
+Internal call sites use structured logging — `logger.Error("publish feature type", "workspace", ws, "datastore", ds, "layer", name, "err", err)`. The library emits Debug/Warn/Error only; `cmd/*` may emit Info on successful publish events.
+
+## Concurrency
+
+`*ManagerConfig` is intended to be read-only after construction. The `logger` field is `*slog.Logger` (concurrency-safe by stdlib contract). The other fields are configuration values that never change.
+
+The geoserver/v2 client constructed by `GetGeoserverCatalog` is itself concurrency-safe (the upstream contract — verified in that project's CI under `-race`). gismanager itself doesn't introduce shared mutable state.
+
+The CGo GDAL bindings have their own thread-safety constraints — review `lukeroth/gdal` upstream docs before parallelizing GDAL operations across goroutines. The current synchronous flow (open → copy → publish, one layer at a time) is well within the bindings' safe envelope.
+
+## Docker-only build
+
+CGo + GDAL means the build needs system GDAL headers and a C toolchain. Rather than ask every contributor to install GDAL on their host, gismanager pins to `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4` and shells every Go invocation into a dev container.
+
+The dev image (built via `docker compose build dev`) installs Go 1.25.9 + golangci-lint v2.12.1 + govulncheck + goimports on top of the OSGeo image. The `Makefile` shells every target through `docker compose run --rm -T dev <command>`.
+
+A `.devcontainer/devcontainer.json` lets VS Code (and other devcontainer-aware editors) open the source tree inside the container; that's how `gopls` resolves the GDAL CGo headers (`#include <gdal.h>`) without any host install.
+
+**Critical Dockerfile note:** do NOT `apt-get install libgdal-dev` on top of the OSGeo image. Ubuntu 24's apt ships GDAL 3.6 (`libgdal.so.34`); installing it alongside the OSGeo-bundled GDAL 3.12 (`libgdal.so.38`) produces binaries linked against the older soname, which fail to load at runtime. The Dockerfile's apt step deliberately omits `libgdal-dev`; the OSGeo image already provides headers at `/usr/include/gdal_*.h` + `gdal.pc`.
+
+## Test split
+
+Two layers, distinguished by file name + build tag:
+
+| Layer | Files | Build tag | What it does |
+|---|---|---|---|
+| Unit | `*_test.go` (no `_integration_` infix) | none | Self-contained: GDAL + testdata fixtures, no network. `make test-unit` runs them in <2s. |
+| Integration | `*_integration_test.go` | `//go:build integration` | Real GeoServer + PostGIS via `docker-compose.test.yml`. Exercises end-to-end publish flow plus the nil-check error paths that need a live PostGIS to reach (DBIsAlive runs first). `make test-integration` boots the stack first. |
+
+Both layers are mandatory on every PR. CI runs unit on Go 1.25 and integration on **GeoServer 2.27.4 LTS + 2.28.0 stable** — all three legs (Lint + Unit + Integration matrix) must go green.
+
+## v2 geoserver client integration
+
+gismanager publishes via [`github.com/hishamkaram/geoserver/v2`](https://github.com/hishamkaram/geoserver). Mapping of gismanager calls to v2 surface:
+
+| gismanager step | v2 client call |
+|---|---|
+| Build client | `geoserver.New(url, geoserver.WithBasicAuth(user, pass))` |
+| Workspace exists? | `c.Workspaces.Get(ctx, name)` + `errors.Is(err, geoserver.ErrNotFound)` |
+| Create workspace | `c.Workspaces.Create(ctx, &workspaces.Workspace{Name: name})` |
+| Datastore exists? | `c.Datastores.InWorkspace(ws).Get(ctx, name)` + ErrNotFound |
+| Create PostGIS datastore | `c.Datastores.InWorkspace(ws).Create(ctx, datastores.PostGIS{...})` |
+| Feature type exists? | `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Get(ctx, name)` + ErrNotFound |
+| Publish feature type | `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Create(ctx, &featuretypes.FeatureType{...})` |
+
+The Get + ErrNotFound idiom is what makes the publish flow idempotent end-to-end — see [`../publish_integration_test.go`](../publish_integration_test.go) `TestPublishGeoJSON_Idempotent_Integration`.
+
+## Cross-references
+
+- [`../README.md`](../README.md) — install, quick start, worked example, errors, config schema
+- [`../CHANGELOG.md`](../CHANGELOG.md) — release notes
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — Docker-only dev workflow, PR conventions
+- [`version-compat.md`](version-compat.md) — Go × GeoServer × GDAL × PostGIS matrix
+- [`../publish_integration_test.go`](../publish_integration_test.go) — worked end-to-end example as a test

--- a/docs/version-compat.md
+++ b/docs/version-compat.md
@@ -1,0 +1,66 @@
+# Version compatibility
+
+This document is the source of truth for what gismanager v1.0.x supports, what's tested in CI, and what's parked.
+
+## Go
+
+| Version | Status | Notes |
+|---|---|---|
+| **1.25** | **Required (minimum)** | Set by `go.mod`; required transitively by `github.com/hishamkaram/geoserver/v2 v2.0.0+`. |
+| 1.26+    | Forward-compatible | No CI gate yet; bump matrix when GA ships. |
+| ≤ 1.24   | Unsupported | Won't compile (transitive `geoserver/v2` requires 1.25). |
+
+## GeoServer (the server)
+
+| Version | Status | Tested in CI | Notes |
+|---|---|---|---|
+| **2.27.4 LTS** | Supported (CI) | `GeoServer 2.27.4` integration job | Long-term support release. |
+| **2.28.0 stable** | Supported (CI) | `GeoServer 2.28.0` integration job | Current stable. |
+| 2.18 – 2.26 | Best-effort | not in CI | Many endpoints work; security and feature-type-discovery responses may differ in shape. |
+| ≤ 2.17 | Unsupported | not in CI | Pre-modern security API; major drift in JSON response shapes. |
+| 3.0.x | Tracked for v1.x | not in CI | Jakarta EE / Tomcat 11 / ImageN raster engine. Validates only after the upstream migration settles in production deploys. |
+
+**Integration coverage:** every PR runs the full integration suite against both 2.27.4 LTS and 2.28.0 stable. Both legs must pass before merge. The matrix lives in [`../.github/workflows/integration.yml`](../.github/workflows/integration.yml).
+
+## GDAL
+
+| Version | Status | Notes |
+|---|---|---|
+| **3.12.4** | Pinned (CI + dev) | `ghcr.io/osgeo/gdal:ubuntu-small-3.12.4` is the base image for both the dev container and the GeoServer container. Bumping requires re-running the integration suite end-to-end. |
+| 3.10–3.11 | Best-effort | Likely works (the `lukeroth/gdal` Go bindings target `>=3.x`). Not gated. |
+| < 3.10 | Unsupported | Older OGR APIs — `Layer.Feature(int)` vs `Layer.Feature(int64)`, etc. |
+
+**Why pin to one GDAL?** The `lukeroth/gdal` CGo bindings link against system GDAL at compile time; the binary's `libgdal.so.NN` soname is locked to whatever the build container's GDAL ships. Pinning the dev/build image to a specific GDAL minor avoids surprise soname mismatches between a developer's container and the runtime image.
+
+## PostGIS
+
+| Version | Status | Notes |
+|---|---|---|
+| **PostGIS 16-3.4** (`postgis/postgis:16-3.4`) | Pinned (CI + dev) | What `docker-compose.test.yml` boots. |
+| ≥ 2.5 | Best-effort | OGR's PostgreSQL driver supports any modern PostGIS. Older PostGIS lacks GIST index defaults that LayerToPostgis assumes. |
+| < 2.5 | Unsupported | |
+
+## Tomcat / Java (for GeoServer)
+
+The integration GeoServer container uses **Tomcat 9 + JDK 17 (Temurin)**. GeoServer 2.x (2.27 / 2.28) is built against the `javax.*` servlet namespace (Servlet 4.x); Tomcat 10+ moved to `jakarta.*` and breaks GeoServer 2.x at WAR-deploy time. GeoServer 3.0 will unblock Tomcat 11 — see the GeoServer roadmap.
+
+## Module path
+
+| Path | Status |
+|---|---|
+| `github.com/hishamkaram/gismanager` | v1.x — stable (latest `v1.0.0`) |
+
+No `/v2` semantic-import-versioning suffix — gismanager has no released versions to preserve, so v1.0.0 is the first stable tag.
+
+## When this matrix changes
+
+- **Go 1.26 release** → add to the matrix as untested, then move to supported once CI validates.
+- **GeoServer 2.29 release** → swap 2.28 for 2.29 in the integration matrix; keep 2.27 LTS as the LTS leg.
+- **GeoServer 2.27 LTS retires** → drop from the matrix when GeoServer's own LTS support ends.
+- **GeoServer 3.0 stabilizes** → add as a third matrix entry once Jakarta EE / Tomcat 11 / ImageN settle.
+- **GDAL 3.13 release** → bump the pin in `Dockerfile` and `docker/Dockerfile`, re-run the integration suite end-to-end on both GeoServer legs before promoting.
+
+## Cross-references
+
+- [`../README.md`](../README.md) — install, quick start
+- [`architecture.md`](architecture.md) — package shape, design tenets


### PR DESCRIPTION
## Summary

Final PR (PR 6 in the plan) of the gismanager revival series. Adds the documentation surface and the project Claude Code config the previous PRs deferred.

## Commits (2)

1. **`docs: product-first README, full architecture/version-compat, contributing/security/coc, v1.0.0 CHANGELOG`** — 8 files, +739/-177:
   - **`README.md`** rewritten product-first (lede + TOC + What it does + Install + Quick start + Worked example + Errors + Configuration + Library use + Version compat + Contributing + License). Mirrors the geoserver-client project's post-#105 shape.
   - **`docs/architecture.md`** — package shape, public-API surface, ctx-first rule, error-wrapping contract, slog discipline, concurrency, Docker-only build with the libgdal-dev shadow gotcha, test split, v2-client integration mapping.
   - **`docs/version-compat.md`** — Go × GeoServer × GDAL × PostGIS × Tomcat/JDK matrix with rationale for each pin.
   - **`CONTRIBUTING.md`** — Docker-only dev workflow, Make targets table, PR conventions (branch + conventional commits + both unit + integration mandatory + no library panics + squash-merge), project layout tree, Claude Code config table.
   - **`SECURITY.md`** — v1.0.0 stable framing; GH Security Advisories preferred channel; out-of-scope routes to upstream trackers.
   - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
   - **`CHANGELOG.md`** — `[Unreleased]` + `[1.0.0] — 2026-05-04` capturing the entire revival across PRs #2–#6 (Added / Changed / Removed / Fixed / Security / Known limitations).
   - **`docker/README.md`** — what's in the GeoServer container image, how to boot the stack, production caveat.

2. **`feat(claude-config): populate .claude/ — 3 agents, 2 skills, 2 commands`** — replaces the `.gitkeep` placeholders from PR 1:
   - **Subagents:** `go-reviewer` (idiom + sentinel + slog + ctx review), `gdal-reviewer` (NEW; CGo + lukeroth/gdal-binding specifics — integer-width drift, OGR handle ownership, soname pinning awareness), `integration-runner` (boots compose-test stack, runs integration suite, diagnoses by bucket).
   - **Skills:** `/gismanager-quirks` (catalog of 8 quirks: Layer.Feature int→int64, mholt/archiver deprecation, GeoServer no-attributes 400, v2 client's no-Exists pattern, libgdal-dev shadow trap, Go stdlib CVE pin requirement, golangci-lint-action v6→v7, GOFLAGS=-buildvcs=false in containers — each with Symptom / Root cause / Workaround / Where), `/docker-only-dev` (reference for the "shell every Go command into Docker" pattern).
   - **Slash commands:** `/integration-test [version]` (boot stack → run suite → teardown-or-leave-running), `/lint-fix` (autofix + report).
   - `CLAUDE.md` index drops the "(populated in PR 6)" markers; each entry now describes actual content.

## End of revival

After this lands, master ships v1.0.0-ready. The plan called for tagging `v1.0.0-rc.1` first, running the full integration matrix, then promoting to `v1.0.0` and closing issue #1 — those are explicit user actions, not auto-tagged.

## Test plan

Inside the dev container (`docker compose run --rm -T dev ...`):

- [x] `make build` — green
- [x] `make test-unit` — green (`gismanager`, `internal/zipx` both `ok`; integration-flavored tests skipped behind `//go:build integration`)
- [x] `make lint` — `0 issues.`
- [x] `make vuln` — `No vulnerabilities found.`
- [x] All cross-references in the new docs resolve to existing files
- [ ] CI green on the new GitHub Actions workflows (integration matrix is the slowest gate; expect ~6-10 min per leg).

## Notes

- No co-author trailer.
- Branch will be **squash-merged**.