### PR TITLE
hotfix(ci): switch to Azure's Ubuntu mirror — master CI red on ff1f77f

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,20 @@ jobs:
       image: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
     steps:
       - name: Install build essentials
-        # build-essential / git come from noble/main, pkg-config from
-        # noble/universe — both reliably mirrored. We tolerate
-        # apt-get update failure because Ubuntu's noble-security archive
-        # occasionally serves files that mismatch its InRelease metadata
-        # by one byte (mid-mirror-sync); install only needs the indexes
-        # that did fetch. Acquire::Retries handles purely transient HTTP
-        # errors at the per-package level.
+        # Switch to Azure's Ubuntu mirror (co-located with the GHA runner
+        # network in Azure) before any apt operation. The public
+        # archive.ubuntu.com mirror was returning connection-refused for
+        # several minutes during master CI on commit ff1f77f; Azure's
+        # mirror is what GHA-managed Ubuntu runners themselves use and is
+        # significantly more reliable.
         run: |
           set -ex
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              /etc/apt/sources.list.d/ubuntu.sources
+          fi
           apt-get -o Acquire::Retries=3 update || \
             echo "apt-get update returned nonzero — proceeding with whatever indexes did fetch"
           apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
@@ -74,15 +79,20 @@ jobs:
         go: ["1.25"]
     steps:
       - name: Install build essentials
-        # build-essential / git come from noble/main, pkg-config from
-        # noble/universe — both reliably mirrored. We tolerate
-        # apt-get update failure because Ubuntu's noble-security archive
-        # occasionally serves files that mismatch its InRelease metadata
-        # by one byte (mid-mirror-sync); install only needs the indexes
-        # that did fetch. Acquire::Retries handles purely transient HTTP
-        # errors at the per-package level.
+        # Switch to Azure's Ubuntu mirror (co-located with the GHA runner
+        # network in Azure) before any apt operation. The public
+        # archive.ubuntu.com mirror was returning connection-refused for
+        # several minutes during master CI on commit ff1f77f; Azure's
+        # mirror is what GHA-managed Ubuntu runners themselves use and is
+        # significantly more reliable.
         run: |
           set -ex
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              /etc/apt/sources.list.d/ubuntu.sources
+          fi
           apt-get -o Acquire::Retries=3 update || \
             echo "apt-get update returned nonzero — proceeding with whatever indexes did fetch"
           apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
@@ -115,15 +125,20 @@ jobs:
       image: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
     steps:
       - name: Install build essentials
-        # build-essential / git come from noble/main, pkg-config from
-        # noble/universe — both reliably mirrored. We tolerate
-        # apt-get update failure because Ubuntu's noble-security archive
-        # occasionally serves files that mismatch its InRelease metadata
-        # by one byte (mid-mirror-sync); install only needs the indexes
-        # that did fetch. Acquire::Retries handles purely transient HTTP
-        # errors at the per-package level.
+        # Switch to Azure's Ubuntu mirror (co-located with the GHA runner
+        # network in Azure) before any apt operation. The public
+        # archive.ubuntu.com mirror was returning connection-refused for
+        # several minutes during master CI on commit ff1f77f; Azure's
+        # mirror is what GHA-managed Ubuntu runners themselves use and is
+        # significantly more reliable.
         run: |
           set -ex
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              /etc/apt/sources.list.d/ubuntu.sources
+          fi
           apt-get -o Acquire::Retries=3 update || \
             echo "apt-get update returned nonzero — proceeding with whatever indexes did fetch"
           apt-get -o Acquire::Retries=3 install -y --no-install-recommends \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,12 +28,17 @@ jobs:
       GOFLAGS: -buildvcs=false
     steps:
       - name: Install build essentials
-        # Same mirror-flake tolerance as ci.yml — see ci.yml comment.
-        # `file` is required by CodeQL's Autobuild (it sniffs binary
-        # types). Without it, Autobuild logs "The `file` program is
-        # required, but does not appear to be installed".
+        # Same Azure-mirror swap + tolerance as ci.yml. `file` is
+        # required by CodeQL's Autobuild (binary type sniff); without
+        # it Autobuild logs "The `file` program is required".
         run: |
           set -ex
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              /etc/apt/sources.list.d/ubuntu.sources
+          fi
           apt-get -o Acquire::Retries=3 update || \
             echo "apt-get update returned nonzero — proceeding with whatever indexes did fetch"
           apt-get -o Acquire::Retries=3 install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,15 +41,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 # never shells out to psql; the integration tests connect via Go's
 # database/sql.
 #
-# Acquire::Retries=3 is apt's native retry — preferred over a shell loop
-# wrapper because it retries at the per-package level and survives
-# partial-progress failures cleanly. Same flag in ci.yml + codeql.yml.
-RUN apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+# Switch to Azure's Ubuntu mirror first (co-located with the GHA runner
+# network; significantly more reliable than the public archive.ubuntu.com
+# mirror, which periodically returns connection-refused). Then
+# Acquire::Retries=3 absorbs any per-package transient at the apt layer.
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+        sed -i \
+            -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+            -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
+    fi; \
+    apt-get -o Acquire::Retries=3 update; \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         build-essential \
         git \
-        pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+        pkg-config; \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Go from the official tarball (Ubuntu's apt go is usually older than
 # the active toolchain). Pin GO_VERSION at build time.


### PR DESCRIPTION
## Summary

Master CI went red on commit `ff1f77f` (the merged PR #8). The Lint, Unit (Go 1.25), govulncheck, and Analyze (Go) jobs all failed in the apt-install step with `Could not connect to archive.ubuntu.com:80 - connect (111: Connection refused)`. The public archive.ubuntu.com mirror was unreachable for the duration of the run; `Acquire::Retries=3` retried but the mirror was actually down.

## Fix

Rewrite `/etc/apt/sources.list.d/ubuntu.sources` to point at `azure.archive.ubuntu.com` before any apt operation. Azure's mirror is co-located with the GHA runner network in Azure and is what GitHub-hosted Ubuntu runners use natively. The user-feedback about apt-retry being symptom-treating still applies — this swap addresses the underlying mirror reliability problem.

## Files

- `.github/workflows/ci.yml` — Lint, Unit, govulncheck jobs
- `.github/workflows/codeql.yml` — Analyze (Go) job
- `Dockerfile` (dev image) — applies on cold layer rebuilds in integration CI

The `docker/Dockerfile` (GeoServer image) wasn't touched — it doesn't apt-install at all (PR #8 dropped its apt step in favor of `jar -xf`).

## Verification

- `docker compose build dev` — green with Azure-mirror sources
- `make test-unit` — green inside the rebuilt image

CI on this PR should be green on first run; pinging Azure's mirror is fast.