### PR TITLE
feat(api): functional-options New(...) constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ## [Unreleased]
 
+### Added
+
+- **Functional-options constructor.** New `gismanager.New(opts ...Option) (*ManagerConfig, error)` plus `WithLogger` / `WithGeoserver` / `WithDatastore` / `WithSource` helpers. Programmatic callers can now build a manager without a YAML file and inject a custom `*slog.Logger`. `FromConfig(yamlPath)` keeps working — internally delegates to `New` after the YAML decode. `WithLogger(nil)` falls back to the default `GetLogger()` so a zero-arg `New()` is usable.
+
 ## [1.0.0] — 2026-05-04
 
 ### Context

--- a/options.go
+++ b/options.go
@@ -1,0 +1,65 @@
+package gismanager
+
+import "log/slog"
+
+// Option configures a [ManagerConfig] at construction time. Pass options to
+// [New] in any order.
+//
+// Each option is a small function that mutates the partially-constructed
+// manager. The functional-options pattern matches stdlib precedent
+// ([net/http.Server], [log/slog.HandlerOptions]) and keeps the public
+// surface small while leaving room for additive growth — new
+// configuration knobs can ship as new With* helpers without breaking
+// existing callers.
+type Option func(*ManagerConfig)
+
+// WithLogger sets the structured logger the manager and its sub-operations
+// use for diagnostic output. Passing nil falls back to the default logger
+// returned by [GetLogger] so callers can opt into the default explicitly.
+func WithLogger(l *slog.Logger) Option {
+	return func(m *ManagerConfig) {
+		if l == nil {
+			m.logger = GetLogger()
+			return
+		}
+		m.logger = l
+	}
+}
+
+// WithGeoserver sets the GeoServer endpoint, credentials, and workspace
+// name the manager publishes feature types into.
+func WithGeoserver(cfg GeoserverConfig) Option {
+	return func(m *ManagerConfig) { m.Geoserver = cfg }
+}
+
+// WithDatastore sets the PostGIS connection parameters and GeoServer
+// datastore name the manager loads layers into.
+func WithDatastore(cfg DatastoreConfig) Option {
+	return func(m *ManagerConfig) { m.Datastore = cfg }
+}
+
+// WithSource sets the source-directory configuration the manager scans for
+// supported GIS files.
+func WithSource(cfg SourceConfig) Option {
+	return func(m *ManagerConfig) { m.Source = cfg }
+}
+
+// New constructs a [ManagerConfig] from the given options. With no options,
+// the returned manager has zero-value GeoServer / Datastore / Source
+// configs and the default logger from [GetLogger]. The error return is
+// reserved — today [New] always returns nil — so future validation
+// (e.g. checking required fields) is a non-breaking addition.
+//
+// Programmatic callers should prefer [New] over [FromConfig]; YAML-driven
+// callers can still use [FromConfig], which now delegates here.
+func New(opts ...Option) (*ManagerConfig, error) {
+	m := &ManagerConfig{
+		logger: GetLogger(),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(m)
+		}
+	}
+	return m, nil
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,110 @@
+package gismanager
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_NoOptions_ReturnsUsableManagerWithDefaultLogger(t *testing.T) {
+	mgr, err := New()
+	assert.NoError(t, err)
+	assert.NotNil(t, mgr)
+	assert.NotNil(t, mgr.logger, "default logger must be set when no WithLogger option provided")
+	assert.Equal(t, GeoserverConfig{}, mgr.Geoserver)
+	assert.Equal(t, DatastoreConfig{}, mgr.Datastore)
+	assert.Equal(t, SourceConfig{}, mgr.Source)
+}
+
+func TestNew_WithGeoserver_SetsConfig(t *testing.T) {
+	cfg := GeoserverConfig{
+		WorkspaceName: "ws",
+		ServerURL:     "http://example/geoserver",
+		Username:      "u",
+		Password:      "p",
+	}
+	mgr, err := New(WithGeoserver(cfg))
+	assert.NoError(t, err)
+	assert.Equal(t, cfg, mgr.Geoserver)
+}
+
+func TestNew_WithDatastore_SetsConfig(t *testing.T) {
+	cfg := DatastoreConfig{
+		Host: "h", Port: 5432, DBName: "db", DBUser: "u", DBPass: "p", Name: "ds",
+	}
+	mgr, err := New(WithDatastore(cfg))
+	assert.NoError(t, err)
+	assert.Equal(t, cfg, mgr.Datastore)
+}
+
+func TestNew_WithSource_SetsConfig(t *testing.T) {
+	cfg := SourceConfig{Path: "/some/path"}
+	mgr, err := New(WithSource(cfg))
+	assert.NoError(t, err)
+	assert.Equal(t, cfg, mgr.Source)
+}
+
+func TestNew_WithLogger_AcceptsCustomLogger(t *testing.T) {
+	var buf bytes.Buffer
+	custom := slog.New(slog.NewJSONHandler(&buf, nil))
+	mgr, err := New(WithLogger(custom))
+	assert.NoError(t, err)
+	assert.Same(t, custom, mgr.logger, "custom logger must be installed verbatim")
+}
+
+func TestNew_WithLoggerNil_FallsBackToDefault(t *testing.T) {
+	mgr, err := New(WithLogger(nil))
+	assert.NoError(t, err)
+	assert.NotNil(t, mgr.logger, "WithLogger(nil) must fall back to GetLogger()")
+}
+
+func TestNew_NilOptionIgnored(t *testing.T) {
+	// A nil Option must not panic — useful for callers that conditionally
+	// build slices like `opts = append(opts, maybeOption(...))` where
+	// maybeOption may return nil.
+	var skipped Option
+	mgr, err := New(skipped, WithSource(SourceConfig{Path: "x"}))
+	assert.NoError(t, err)
+	assert.Equal(t, "x", mgr.Source.Path)
+}
+
+func TestFromConfig_ParityWithNew(t *testing.T) {
+	// Loading the same YAML through FromConfig and through New + manual
+	// options should yield deep-equal Geoserver / Datastore / Source
+	// values. Logger pointers will differ — both are GetLogger() instances
+	// which are not deduped — so compare the configurable fields only.
+	viaFromConfig, err := FromConfig("./testdata/test_config.yml")
+	assert.NoError(t, err)
+
+	viaNew, err := New(
+		WithGeoserver(GeoserverConfig{
+			WorkspaceName: "golang",
+			ServerURL:     "http://localhost:8080/geoserver",
+			Username:      "admin",
+			Password:      "geoserver",
+		}),
+		WithDatastore(DatastoreConfig{
+			Host: "postgis", Port: 5432,
+			DBName: "gis", DBUser: "golang", DBPass: "golang", Name: "gismanager_data",
+		}),
+		WithSource(SourceConfig{Path: "./testdata"}),
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, viaFromConfig.Geoserver, viaNew.Geoserver)
+	assert.Equal(t, viaFromConfig.Datastore, viaNew.Datastore)
+	assert.Equal(t, viaFromConfig.Source, viaNew.Source)
+}
+
+func TestNew_OptionsAppliedInOrder(t *testing.T) {
+	// Later WithSource overrides earlier — establishes that options are
+	// applied left-to-right and behaviour is the standard "last write wins".
+	mgr, err := New(
+		WithSource(SourceConfig{Path: "first"}),
+		WithSource(SourceConfig{Path: "second"}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "second", mgr.Source.Path)
+}

--- a/utils.go
+++ b/utils.go
@@ -20,23 +20,29 @@ import (
 //
 // Returns errors wrapping [ErrConfigInvalid]; recover the underlying
 // os/yaml error via [errors.As].
-func FromConfig(configFile string) (config *ManagerConfig, err error) {
-	gpkgConfig := ManagerConfig{}
-	gpkgConfig.logger = GetLogger()
+//
+// Programmatic callers (no YAML file) should prefer [New] with [Option]
+// helpers like [WithGeoserver] / [WithDatastore] / [WithSource] /
+// [WithLogger]. FromConfig now delegates to New after the YAML decode.
+func FromConfig(configFile string) (*ManagerConfig, error) {
+	logger := GetLogger()
 	absPath, _ := filepath.Abs(configFile)
 	yamlFile, readErr := os.ReadFile(absPath) //nolint:gosec // G304: configFile is the operator-supplied --config path; reading it is the documented entry point.
 	if readErr != nil {
-		gpkgConfig.logger.Error("read yaml", "path", absPath, "err", readErr)
-		err = newGISError("FromConfig", absPath, ErrConfigInvalid, readErr)
-		return
+		logger.Error("read yaml", "path", absPath, "err", readErr)
+		return nil, newGISError("FromConfig", absPath, ErrConfigInvalid, readErr)
 	}
-	if unmarshalErr := yaml.Unmarshal(yamlFile, &gpkgConfig); unmarshalErr != nil {
-		gpkgConfig.logger.Error("unmarshal yaml", "path", absPath, "err", unmarshalErr)
-		err = newGISError("FromConfig", absPath, ErrConfigInvalid, unmarshalErr)
-		return
+	var decoded ManagerConfig
+	if unmarshalErr := yaml.Unmarshal(yamlFile, &decoded); unmarshalErr != nil {
+		logger.Error("unmarshal yaml", "path", absPath, "err", unmarshalErr)
+		return nil, newGISError("FromConfig", absPath, ErrConfigInvalid, unmarshalErr)
 	}
-	config = &gpkgConfig
-	return
+	return New(
+		WithLogger(logger),
+		WithGeoserver(decoded.Geoserver),
+		WithDatastore(decoded.Datastore),
+		WithSource(decoded.Source),
+	)
 }
 
 func isSupported(ext string) bool {


### PR DESCRIPTION
First PR in the v1.1 series. Adds the functional-options constructor flagged as a known limitation in the v1.0.0 CHANGELOG.

## What changed

**Public surface (additive only — no removals, no renames, no deprecations):**

\`\`\`go
type Option func(*ManagerConfig)

func WithLogger(l *slog.Logger) Option
func WithGeoserver(GeoserverConfig) Option
func WithDatastore(DatastoreConfig) Option
func WithSource(SourceConfig) Option
func New(opts ...Option) (*ManagerConfig, error)
\`\`\`

\`WithLogger(nil)\` falls back to \`GetLogger()\` so a zero-arg \`New()\` produces a usable manager. Nil options are tolerated. The error return is reserved — always nil today — so future required-field validation is a non-breaking addition.

**\`FromConfig(yamlPath)\` keeps its public signature** but now decodes the YAML and delegates to \`New\` internally. Same external behaviour; single internal code path.

## Why first in the series

PR 2 (logger injection in library helpers) and PR 3 (Walk iterator + PublishAll convenience) both want a constructor they can extend without touching FromConfig.

## Tests

\`options_test.go\` (all-new):

- Each \`WithX\` sets the corresponding field
- \`WithLogger(nil)\` fallback
- Zero-arg \`New()\` returns a usable manager + default logger
- Custom logger installed verbatim (\`assert.Same\`)
- Parity invariant: \`FromConfig\` and \`New\` + manual options yield identical Geoserver / Datastore / Source values
- Last-write-wins option ordering
- Nil \`Option\` tolerated

## Verification

- \`make build\` — green
- \`make test-unit\` — green
- \`make lint\` — \`0 issues.\`
- \`make vuln\` — \`No vulnerabilities found.\`

CHANGELOG \`[Unreleased]\` updated with an Added entry.