### PR TITLE
fix(lifecycle): destroy hooks for features + ctx-aware DBIsAlive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 ### Changed
 
 - **CLIs simplified.** `cmd/gismanager` is now ~10 lines (calls `manager.PublishAll(ctx)`); `cmd/layerSchema` is ~20 lines (iterates `manager.Walk(ctx)`). Both lost the duplicated walk-files → open-source → iterate-layers loop they reimplemented.
+- **`Walk` / `PublishAll` `defer source.Destroy()` automatically.** Per-file CGo handles are released between iterations; long-running pipelines no longer leak `*gdal.DataSource` handles. Direct callers of `OpenSource` remain responsible for their own `defer source.Destroy()` — documented in README.
+
+### Added (continued)
+
+- **`(*GdalLayer).Features(ctx) iter.Seq[gdal.Feature]`.** Streaming iterator that destroys each `gdal.Feature` as iteration advances and on early break (no caller-side cleanup contract). Honors `ctx.Err()` between feature reads.
+- **`DBIsAliveContext(ctx, dbType, conn)`.** Ctx-aware variant of `DBIsAlive`. The original `DBIsAlive` now delegates to this with `context.Background()`.
+
+### Deprecated
+
+- **`(*GdalLayer).GetFeatures()`.** Returns `[]*gdal.Feature` whose handles must be `Destroy()`-ed by the caller, easy to forget. Use `Features(ctx)` instead.
+- **`DBIsAlive(dbType, conn)`.** Hard-codes `context.Background()`. Use `DBIsAliveContext` instead.
 
 ## [1.0.0] — 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -180,25 +180,37 @@ func main() {
 
     ctx := context.Background()
 
-    // Discover GIS files under source.path.
-    files, _ := gismanager.GetGISFiles(mgr.Source.Path)
+    // Convenience: walk + load + publish in one call.
+    if err := mgr.PublishAll(ctx); err != nil { /* ... */ }
 
+    // Or stream-iterate manually for finer control:
+    for item, err := range mgr.Walk(ctx) {
+        if err != nil { continue }
+        // item.Layer is logger-stamped via NewLayer; use it freely.
+        _ = item.Layer
+    }
+
+    // Or call the low-level primitives directly (note the defer to
+    // release CGo handles — Walk / PublishAll do this automatically):
     target, err := mgr.OpenSource(ctx, mgr.Datastore.BuildConnectionString(), 1)
     if err != nil { /* ... */ }
+    defer target.Destroy()
 
-    for _, f := range files {
-        src, err := mgr.OpenSource(ctx, f, 0)
-        if err != nil { continue }
-        for i := 0; i < src.LayerCount(); i++ {
-            layer := src.LayerByIndex(i)
-            gLayer := gismanager.GdalLayer{Layer: &layer}
-            newLayer, err := gLayer.LayerToPostgis(target, mgr, true)
-            if err != nil || newLayer == nil { continue }
-            _ = mgr.PublishGeoserverLayer(ctx, newLayer)
-        }
+    src, err := mgr.OpenSource(ctx, "/path/to/file.geojson", 0)
+    if err != nil { /* ... */ }
+    defer src.Destroy()
+
+    for i := 0; i < src.LayerCount(); i++ {
+        layer := src.LayerByIndex(i)
+        wrapped := mgr.NewLayer(&layer)
+        newLayer, err := wrapped.LayerToPostgis(target, mgr, true)
+        if err != nil || newLayer == nil { continue }
+        _ = mgr.PublishGeoserverLayer(ctx, newLayer)
     }
 }
 ```
+
+> **Resource lifecycle:** `*gdal.DataSource` returned by `OpenSource` owns a CGo-side handle that must be released via `.Destroy()` to avoid leaks. `Walk` and `PublishAll` do this automatically (`defer source.Destroy()` per file). Direct callers of `OpenSource` are responsible for calling `Destroy()` themselves — the binding has no `Close()` method; `Destroy()` is the canonical release primitive in `lukeroth/gdal`.
 
 ## Version compatibility
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,9 +60,31 @@ func (l *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, m *ManagerConf
 // Publish a PostGIS-backed layer as a GeoServer feature type. Idempotent
 // end-to-end (Get + ErrNotFound for workspace, datastore, and feature type).
 func (m *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *GdalLayer) error
+
+// High-level pipeline: walk → load → publish, with per-file source.Destroy().
+// Iteration is files-outer / layers-inner.
+func (m *ManagerConfig) Walk(ctx context.Context) iter.Seq2[WalkItem, error]
+func (m *ManagerConfig) PublishAll(ctx context.Context) error
+
+// Streaming feature iterator that Destroys each gdal.Feature as iteration
+// advances; replaces the deprecated GetFeatures() []*gdal.Feature shape.
+func (l *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature]
 ```
 
 All methods that can fail return errors wrapping a sentinel from [`../errors.go`](../errors.go) — see the README's [Errors](../README.md#errors) section for the matching idiom.
+
+### Resource lifecycle
+
+`*gdal.DataSource` (returned by [`OpenSource`](../manager.go)) and `gdal.Feature` (yielded by [`Features`](../layer.go)) own CGo-side handles that must be released via `.Destroy()`. The binding does not have a `Close()` method — `Destroy()` is the canonical release primitive in `lukeroth/gdal`.
+
+The library's high-level helpers handle this automatically:
+
+- `Walk` / `PublishAll` `defer source.Destroy()` after each file before moving on, so per-file CGo handles never leak even on early `break` of the for-range loop.
+- `Features` destroys each `gdal.Feature` as iteration advances, and the deferred destroy still fires when the for-range loop exits early.
+
+**Direct callers** of `OpenSource` are responsible for their own `defer source.Destroy()`. The README's "Library use" section shows the pattern.
+
+The deprecated `GetFeatures()` and `DBIsAlive()` are kept for back-compat with v1.0 callers but flagged with `// Deprecated:`. New code should use `Features(ctx)` and `DBIsAliveContext(ctx, ...)`.
 
 ## Context-first
 

--- a/layer.go
+++ b/layer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
@@ -216,6 +217,11 @@ func (layer *GdalLayer) GetLayerSchema() (fields []*LayerField) {
 
 // GetFeatures returns every feature in the layer, materialized into a slice.
 // Features are read in OGR-FID order. Returns nil if FeatureCount fails.
+//
+// Deprecated: leaks gdal.Feature handles — each feature in the returned
+// slice owns a C-level handle that must be released via [gdal.Feature.Destroy],
+// which the slice form makes easy to forget. Use [(*GdalLayer).Features]
+// which destroys each feature as iteration advances and on early break.
 func (layer *GdalLayer) GetFeatures() (features []*gdal.Feature) {
 	logger := layer.loggerOrDefault()
 	if layer.Layer != nil {
@@ -231,4 +237,43 @@ func (layer *GdalLayer) GetFeatures() (features []*gdal.Feature) {
 		}
 	}
 	return
+}
+
+// Features returns an iterator over every feature in the layer. Features
+// are emitted in OGR-FID order, and each feature is destroyed via
+// [gdal.Feature.Destroy] as the iteration advances — so the caller never
+// has to remember to free a handle. The cleanup also runs on early break:
+// the still-yielded feature is destroyed when the for-range loop exits,
+// regardless of why.
+//
+// ctx is honored between feature reads — if it is canceled mid-iteration,
+// the iterator stops cleanly (and the deferred destroy still runs).
+//
+// Returns an empty iteration if the embedded *gdal.Layer is nil or
+// FeatureCount fails (the manager's logger gets an Error record in the
+// FeatureCount-failure case).
+func (layer *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature] {
+	logger := layer.loggerOrDefault()
+	return func(yield func(gdal.Feature) bool) {
+		if layer == nil || layer.Layer == nil {
+			return
+		}
+		count, ok := layer.FeatureCount(true)
+		if !ok {
+			logger.Error("could not read features")
+			return
+		}
+		logger.Info("read features", "count", count)
+		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return
+			}
+			f := layer.Feature(int64(i))
+			keepGoing := yield(f)
+			f.Destroy()
+			if !keepGoing {
+				return
+			}
+		}
+	}
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1,0 +1,84 @@
+package gismanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFeatures_NilLayer_YieldsNothing locks in the zero-value safety:
+// iterating Features on a GdalLayer whose embedded *gdal.Layer is nil
+// must produce zero items and not panic.
+func TestFeatures_NilLayer_YieldsNothing(t *testing.T) {
+	zero := &GdalLayer{}
+	count := 0
+	for range zero.Features(context.Background()) {
+		count++
+	}
+	assert.Equal(t, 0, count, "Features on nil-Layer GdalLayer must yield zero items")
+}
+
+// TestFeatures_HonorsCanceledContext locks in cancellation: a ctx that
+// is already canceled before iteration starts produces zero items
+// (the iterator's first ctx.Err() check short-circuits).
+func TestFeatures_HonorsCanceledContext(t *testing.T) {
+	// Use a real layer fixture from testdata — Features needs a non-nil
+	// *gdal.Layer to reach the ctx.Err() check inside the loop.
+	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before iteration begins
+
+	for item, walkErr := range mgr.Walk(context.Background()) {
+		if walkErr != nil || item.Layer == nil {
+			continue
+		}
+		count := 0
+		for range item.Layer.Features(ctx) {
+			count++
+		}
+		assert.Equal(t, 0, count, "canceled ctx must produce zero feature yields; got %d", count)
+		return
+	}
+	t.Fatal("no fixture yielded a non-nil layer to drive the test")
+}
+
+// TestDBIsAliveContext_HonorsCanceledContext exercises the ctx-aware
+// variant: a canceled ctx must produce a non-nil error from PingContext
+// before the open even has a chance to time out on its own. We pair this
+// with a clearly-unreachable connection string so any hang would be
+// obvious; the canceled ctx should fail-fast regardless.
+func TestDBIsAliveContext_HonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Driver-level open with a syntactically invalid DSN returns
+	// an error immediately — that's also acceptable; either way we
+	// expect a non-nil error in under a second.
+	done := make(chan error, 1)
+	go func() {
+		done <- DBIsAliveContext(ctx, "postgres", "postgresql://nobody@127.0.0.1:1/x?connect_timeout=2&sslmode=disable")
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "expected non-nil error from canceled ctx or unreachable DB")
+		// Either context.Canceled, or the underlying driver error — both fine.
+		_ = errors.Is(err, context.Canceled) // documented expected case
+	case <-time.After(5 * time.Second):
+		t.Fatal("DBIsAliveContext hung past the canceled ctx — expected fail-fast")
+	}
+}
+
+// TestDBIsAlive_BackCompat_DelegatesToContext verifies the deprecated
+// DBIsAlive still produces an error against an unreachable DB (i.e.
+// the deprecation didn't remove the behaviour, only deferred to
+// DBIsAliveContext internally).
+func TestDBIsAlive_BackCompat_DelegatesToContext(t *testing.T) {
+	err := DBIsAlive("postgres", "postgresql://nobody@127.0.0.1:1/x?connect_timeout=1&sslmode=disable")
+	assert.Error(t, err, "expected non-nil error from unreachable DB via deprecated DBIsAlive")
+}

--- a/utils.go
+++ b/utils.go
@@ -105,16 +105,25 @@ func getGISFiles(root string, logger *slog.Logger) ([]string, error) {
 // DBIsAlive opens a database/sql connection and pings it. Returns a
 // non-nil error if either step fails.
 //
-// TODO(PR 4): take a context.Context argument so callers can apply
-// deadlines / cancellation.
-func DBIsAlive(dbType string, connectionStr string) (err error) {
+// Deprecated: hard-codes context.Background() for the ping; callers
+// can't apply deadlines or cancellation. Use [DBIsAliveContext].
+func DBIsAlive(dbType string, connectionStr string) error {
+	return DBIsAliveContext(context.Background(), dbType, connectionStr)
+}
+
+// DBIsAliveContext opens a database/sql connection and pings it,
+// honoring ctx for cancellation and deadlines on the ping. The connection
+// is always closed before the function returns. Use this in code that
+// already has a context in scope (HTTP handlers, library calls that
+// thread a ctx, etc.).
+func DBIsAliveContext(ctx context.Context, dbType string, connectionStr string) (err error) {
 	db, dbErr := sql.Open(dbType, connectionStr)
 	if dbErr != nil {
 		err = dbErr
 		return
 	}
-	if pingErr := db.PingContext(context.Background()); pingErr != nil {
-		_ = db.Close()
+	defer func() { _ = db.Close() }()
+	if pingErr := db.PingContext(ctx); pingErr != nil {
 		err = pingErr
 		return
 	}


### PR DESCRIPTION
Fourth PR in the v1.1 series. Fixes two known CGo handle leaks plus the v1.0 \`DBIsAlive\` TODO. Per the v1.1 plan: hygiene only — no new \`*Source\` wrapper type, no \`OpenSource\` deprecation. The facade pattern is v2's break.

## Changes

**`layer.go` — new `Features` iterator + deprecate `GetFeatures`:**

\`\`\`go
func (l *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature]
\`\`\`

Yields each feature, then Destroys it before yielding the next. Cleanup also runs on early \`break\`. Honors \`ctx.Err()\` between feature reads. Returns empty iteration on nil embedded \`*gdal.Layer\`.

\`GetFeatures\` body is unchanged (back-compat) but tagged \`// Deprecated:\` pointing at \`Features(ctx)\`.

**`utils.go` — new `DBIsAliveContext` + deprecate `DBIsAlive`:**

\`\`\`go
func DBIsAliveContext(ctx context.Context, dbType, conn string) error
\`\`\`

Honors \`ctx\` for the ping; always closes the underlying \`*sql.DB\` before returning. \`DBIsAlive\` now delegates to this with \`context.Background()\` so existing callers see no behaviour change.

**`lifecycle_test.go` (new):**

- \`Features\` yields zero on nil-Layer (zero-value safety)
- \`Features\` honors canceled ctx (zero yields)
- \`DBIsAliveContext\` fail-fasts on canceled ctx (under 5s wall clock)
- \`DBIsAlive\` back-compat still surfaces error against unreachable DB

**Docs:**

- README "Library use" section restructured: leads with \`PublishAll\` / \`Walk\` recipes, then shows the low-level form with explicit \`defer src.Destroy()\` calls. Adds a callout block explaining the lifecycle contract.
- \`docs/architecture.md\`: extends public-API listing with Walk / PublishAll / Features. New "Resource lifecycle" subsection documents the Destroy-vs-Close binding choice and which helpers call Destroy automatically.
- CHANGELOG: Added (Features, DBIsAliveContext), Changed (Walk/PublishAll defer Destroy), Deprecated (GetFeatures, DBIsAlive).

## Verification

- \`make build\` — green
- \`make test-unit\` — green
- \`make lint\` — \`0 issues.\`
- \`make vuln\` — \`No vulnerabilities found.\`
- \`make compose-test-up && make test-integration && make compose-test-down\` — green (7.1s; includes TestPublishAll_EndToEnd_Integration)

## Public-API impact

Additive (\`Features\`, \`DBIsAliveContext\`) plus two soft deprecations (\`GetFeatures\`, \`DBIsAlive\`). No removals, signature changes, or behaviour changes on existing exports.