### PR TITLE
test+chore: table-driven GetDriver, GeometryName sibling, fix supportedEXT .kml bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 - **`(*GdalLayer).GetFeatures()`.** Returns `[]*gdal.Feature` whose handles must be `Destroy()`-ed by the caller, easy to forget. Use `Features(ctx)` instead.
 - **`DBIsAlive(dbType, conn)`.** Hard-codes `context.Background()`. Use `DBIsAliveContext` instead.
+- **`(*GdalLayer).GetGeomtryName()`.** Typo (missing 'e' in "Geometry"). Use `GeometryName()`.
+
+### Fixed
+
+- **KML files were silently dropped from directory walks** because `supportedEXT` had `"kml"` (no leading dot); `filepath.Ext()` always returns the dot, so the entry never matched. The bug was present since the project's first commit. Fixed: entry is now `".kml"`. A `testdata/sample.kml` fixture was added so directory-walk tests exercise the path.
+
+### Added (continued)
+
+- **`(*GdalLayer).GeometryName()`** — properly-spelled sibling of the deprecated `GetGeomtryName()`. Identical behaviour.
+
+### Removed
+
+- **Unused unexported constants `openFileGDBDriver` and `esriJSONDriver`** in `vars.go`. They were never referenced from `GetDriver`'s switch and dropping them keeps the dispatch table honest. Unexported, no external API impact.
 
 ## [1.0.0] — 2026-05-04
 

--- a/driver_table_test.go
+++ b/driver_table_test.go
@@ -1,0 +1,105 @@
+package gismanager
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+)
+
+// TestGetDriver_Table is the table-driven canonical test for the
+// path-or-connection-string → OGR driver dispatch. Replaces the ad-hoc
+// per-extension assertions in manager_test.go::TestGetDriver with a
+// single source of truth. Every supported extension + edge case lives
+// here so adding a new format means adding one row.
+func TestGetDriver_Table(t *testing.T) {
+	mgr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		path       string
+		wantDriver string // empty → expect ErrUnsupportedFormat
+	}{
+		// --- supported extensions, lowercase ---
+		{name: "geopackage", path: "data/sample.gpkg", wantDriver: geopackageDriver},
+		{name: "shapefile", path: "data/cities.shp", wantDriver: shapeFileDriver},
+		{name: "zipped-shapefile", path: "data/cities.zip", wantDriver: shapeFileDriver},
+		{name: "geojson", path: "data/places.geojson", wantDriver: geoJSONDriver},
+		{name: "json-as-geojson", path: "data/places.json", wantDriver: geoJSONDriver},
+		{name: "kml", path: "data/places.kml", wantDriver: kmlDriver},
+
+		// --- supported extensions, uppercase / mixed (filepath.Ext is
+		// case-sensitive but GetDriver lowercases internally, so these
+		// must dispatch the same as their lowercase form) ---
+		{name: "shapefile-uppercase", path: "data/CITIES.SHP", wantDriver: shapeFileDriver},
+		{name: "geojson-mixed", path: "data/Places.GeoJSON", wantDriver: geoJSONDriver},
+		{name: "kml-uppercase", path: "data/PLACES.KML", wantDriver: kmlDriver},
+		{name: "geopackage-mixed", path: "data/Sample.Gpkg", wantDriver: geopackageDriver},
+
+		// --- PostgreSQL connection strings (pgRegex match) ---
+		{name: "pg-typical", path: "PG: host=localhost port=5432 dbname=gis user=u password=p", wantDriver: postgreSQLDriver},
+		{name: "pg-no-leading-space", path: "PG:host=localhost port=5432", wantDriver: postgreSQLDriver},
+		{name: "pg-leading-space", path: " PG: host=postgis port=5432 dbname=gis", wantDriver: postgreSQLDriver},
+
+		// --- unsupported / unknown ---
+		{name: "tiff-raster", path: "data/elevation.tiff", wantDriver: ""},
+		{name: "tif-raster", path: "data/elevation.tif", wantDriver: ""},
+		{name: "csv", path: "data/points.csv", wantDriver: ""},
+		{name: "xml", path: "data/metadata.xml", wantDriver: ""},
+		{name: "no-extension", path: "data/somefile", wantDriver: ""},
+		{name: "empty-path", path: "", wantDriver: ""},
+		{name: "double-extension-tar-gz", path: "data/archive.tar.gz", wantDriver: ""},
+
+		// --- edge: known-supported extension that ISN'T tied to a
+		// recognized OGR driver in GetDriver's switch (.gdb is in
+		// supportedEXT but GetDriver doesn't dispatch it). Documents
+		// the discrepancy; fix is a v2 cleanup. ---
+		{name: "gdb-listed-but-unrouted", path: "data/store.gdb", wantDriver: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			drv, err := mgr.GetDriver(tc.path)
+			if tc.wantDriver == "" {
+				if !errors.Is(err, ErrUnsupportedFormat) {
+					t.Fatalf("expected ErrUnsupportedFormat, got %v", err)
+				}
+				if drv != (gdal.OGRDriver{}) {
+					t.Errorf("expected zero-value OGRDriver on error, got %#v", drv)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			want := gdal.OGRDriverByName(tc.wantDriver)
+			if drv != want {
+				t.Errorf("driver mismatch: got %#v, want %#v (driver name %q)", drv, want, tc.wantDriver)
+			}
+		})
+	}
+}
+
+// TestSupportedEXT_AllHaveLeadingDot guards the v1.0 bug where the
+// "kml" entry in supportedEXT lacked a leading dot — filepath.Ext()
+// returns ".kml" so the entry never matched and KML files were
+// silently dropped from directory walks. Fixed in PR 5; this test
+// keeps it from regressing.
+func TestSupportedEXT_AllHaveLeadingDot(t *testing.T) {
+	for _, ext := range supportedEXT {
+		if ext == "" || ext[0] != '.' {
+			t.Errorf("supportedEXT entry %q lacks a leading '.', will never match filepath.Ext output", ext)
+		}
+	}
+}
+
+// TestSupportedEXT_IncludesKML guards the specific KML branch so a
+// future trim of supportedEXT can't silently drop KML support again.
+func TestSupportedEXT_IncludesKML(t *testing.T) {
+	if !isSupported(".kml") {
+		t.Errorf("isSupported(.kml) = false; expected true after PR 5 of v1.1 series")
+	}
+}

--- a/layer.go
+++ b/layer.go
@@ -179,17 +179,24 @@ func (layer *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, manager *M
 	return
 }
 
-// GetGeomtryName returns the OGR geometry-type name for this layer ("POINT",
-// "LINESTRING", etc.), defaulting to "geom" if the layer has no geometry
-// column.
-func (layer *GdalLayer) GetGeomtryName() (geometryName string) {
+// GeometryName returns the OGR geometry-type name for this layer
+// ("POINT", "LINESTRING", etc.), defaulting to "geom" if the layer has
+// no geometry column.
+func (layer *GdalLayer) GeometryName() string {
 	geom := gdal.Create(layer.Type())
-	geometryName = geom.Name()
-	if geometryName == "" {
-		geometryName = "geom"
+	name := geom.Name()
+	if name == "" {
+		return "geom"
 	}
-	return
+	return name
 }
+
+// GetGeomtryName is the historical (typo'd) name of [GeometryName].
+//
+// Deprecated: typo (missing 'e' in "Geometry"). Use [GeometryName],
+// which is byte-for-byte identical in behaviour. The typo'd form is
+// kept for v1.x back-compat and will be removed at v2.
+func (layer *GdalLayer) GetGeomtryName() string { return layer.GeometryName() }
 
 // GetLayerSchema returns the layer's geometry column followed by every
 // attribute field, each as a LayerField with name + OGR type.
@@ -199,7 +206,7 @@ func (layer *GdalLayer) GetLayerSchema() (fields []*LayerField) {
 		geomName := layer.GeometryColumn()
 		geomField := LayerField{
 			Name: geomName,
-			Type: layer.GetGeomtryName(),
+			Type: layer.GeometryName(),
 		}
 		fields = append(fields, &geomField)
 		for index := 0; index < layerDef.FieldCount(); index++ {

--- a/testdata/sample.kml
+++ b/testdata/sample.kml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>gismanager-test</name>
+    <Placemark>
+      <name>origin</name>
+      <description>Reference point used by GetDriver tests + Walk fixture coverage.</description>
+      <Point>
+        <coordinates>0,0,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>offset</name>
+      <Point>
+        <coordinates>10,20,0</coordinates>
+      </Point>
+    </Placemark>
+  </Document>
+</kml>

--- a/utils_test.go
+++ b/utils_test.go
@@ -39,7 +39,10 @@ func TestPreprocessFile(t *testing.T) {
 }
 func TestGetGISFiles(t *testing.T) {
 	files, err := GetGISFiles("./testdata")
-	assert.Equal(t, 4, len(files))
+	// 5 supported files post-PR 5 of v1.1: faults.zip, neighborhood_names_gis.geojson,
+	// nested/nyc_wi-fi_hotspot_locations.geojson, sample.gpkg, sample.kml.
+	// faults_empty.zip yields no GIS files so doesn't count.
+	assert.Equal(t, 5, len(files))
 	assert.Nil(t, err)
 	noDir, NoDirerr := GetGISFiles("./testdata/sample.gpkg")
 	assert.Equal(t, 1, len(noDir))

--- a/vars.go
+++ b/vars.go
@@ -3,14 +3,19 @@ package gismanager
 import "regexp"
 
 var pgRegex = regexp.MustCompile(`^\s?PG:\s?.*$`)
-var supportedEXT = []string{".zip", ".json", ".gpkg", ".geojson", ".gdb", "kml", ".shp"}
+
+// supportedEXT is the closed set of file extensions GetGISFiles will
+// recurse into. Each entry MUST start with a dot — filepath.Ext()
+// always returns the dot, so a bare "kml" entry never matches and the
+// extension is silently unsupported. (That was the pre-v1.1 bug here:
+// "kml" was missing the leading dot and KML files were silently
+// dropped from directory walks. Fixed in PR 5 of the v1.1 series.)
+var supportedEXT = []string{".zip", ".json", ".gpkg", ".geojson", ".gdb", ".kml", ".shp"}
 
 const (
-	geopackageDriver  = "GPKG"
-	postgreSQLDriver  = "PostgreSQL"
-	shapeFileDriver   = "ESRI Shapefile"
-	geoJSONDriver     = "GeoJSON"
-	kmlDriver         = "KML"
-	openFileGDBDriver = "OpenFileGDB"
-	esriJSONDriver    = "ESRIJSON"
+	geopackageDriver = "GPKG"
+	postgreSQLDriver = "PostgreSQL"
+	shapeFileDriver  = "ESRI Shapefile"
+	geoJSONDriver    = "GeoJSON"
+	kmlDriver        = "KML"
 )

--- a/walk_test.go
+++ b/walk_test.go
@@ -86,6 +86,36 @@ func TestWalk_HonorsContextCancellation(t *testing.T) {
 		"with a canceled context the iterator must either surface context.Canceled or yield zero items; got %d items", yielded)
 }
 
+// TestWalk_PicksUpKMLFixture confirms the KML branch is exercised
+// end-to-end after the supportedEXT ".kml" fix: the testdata/sample.kml
+// fixture must appear at least once in Walk's yielded paths. Pre-PR 5
+// the supportedEXT entry was "kml" (no dot) and KML files were silently
+// dropped from directory walks; this test would have failed.
+func TestWalk_PicksUpKMLFixture(t *testing.T) {
+	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	assert.NoError(t, err)
+
+	sawKML := false
+	for item, walkErr := range mgr.Walk(context.Background()) {
+		if walkErr != nil {
+			continue
+		}
+		if endsWith(item.Path, ".kml") {
+			sawKML = true
+			break
+		}
+	}
+	assert.True(t, sawKML,
+		"expected testdata/sample.kml to appear in Walk output after the .kml supportedEXT fix")
+}
+
+func endsWith(s, suffix string) bool {
+	if len(suffix) > len(s) {
+		return false
+	}
+	return s[len(s)-len(suffix):] == suffix
+}
+
 // TestWalk_NonexistentSource_ReturnsError confirms a non-existent source
 // directory surfaces as an error item (not a panic, not a silent empty
 // iteration). The error wraps the os.Stat failure from getGISFiles.


### PR DESCRIPTION
Fifth and final PR in the v1.1 series. Three small wins bundled because they share \`vars.go\` / \`layer.go\` touch points.

## What changed

**1. Real bug fix — KML files were silently dropped from directory walks.**

\`vars.go::supportedEXT\` had \`"kml"\` (no leading dot). \`filepath.Ext()\` always returns the dot, so the entry never matched and \`isSupported(".kml")\` returned false. Bug present since the project's first commit. Fix: entry is now \`".kml"\`. Added a regression-guard test (\`TestSupportedEXT_AllHaveLeadingDot\`) so a future trim can't re-introduce it.

**2. Table-driven \`GetDriver\` test.**

\`driver_table_test.go\` (new) replaces the ad-hoc per-extension assertions in \`manager_test.go::TestGetDriver\` with a single source of truth. ~22 rows covering:
- Every supported extension (lower / upper / mixed case)
- Every \`pgRegex\`-matching PostgreSQL connection-string variant
- Unsupported categories (raster, csv, xml, no-extension, empty path, double extension like \`.tar.gz\`)
- The \`.gdb\` edge case (in \`supportedEXT\` but \`GetDriver\` doesn't dispatch it — documents the discrepancy)

**3. \`GeometryName()\` sibling, deprecate \`GetGeomtryName()\`.**

The typo'd public method survived from 2018 (missing 'e' in "Geometry"). Adding a properly-spelled sibling and marking the typo \`// Deprecated:\` is non-breaking; rename is deferred to v2.

**4. KML fixture.**

\`testdata/sample.kml\` (new, ~20 lines XML) — tiny KML with two Placemarks, drives the KML branch through both \`Walk\` and the \`GetDriver\` table.

**5. Drop unused unexported constants.**

\`openFileGDBDriver\` and \`esriJSONDriver\` in \`vars.go\` were never referenced. Unexported (lowercase) so removal is internal-only.

## Tests

- \`driver_table_test.go\` — table + 2 guard tests
- \`walk_test.go::TestWalk_PicksUpKMLFixture\` — confirms KML appears in \`Walk\` output (pre-PR-5 this would have failed)
- \`utils_test.go::TestGetGISFiles\` count updated 4 → 5 (the new sample.kml fixture)

## Public API impact

Additive (\`GeometryName\`) + one soft deprecation (\`GetGeomtryName\`). No removals on the exported surface. The two unexported constants we dropped are package-private.

## Verification

- \`make build\` — green
- \`make test-unit\` — green
- \`make lint\` — \`0 issues.\`
- \`make vuln\` — \`No vulnerabilities found.\`

After this lands, the v1.1 series is complete and ready to tag \`v1.1.0-rc.1\` → integration matrix → \`v1.1.0\`.