### PR TITLE
feat(convert): ConvertVector + WithVector* option set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ### Added
 
+- **`ConvertVector(ctx, src, dst, opts...) error`** — vector format conversion (GeoJSON ↔ GeoPackage ↔ Shapefile ↔ FlatGeobuf ↔ KML) plus reprojection, bbox clip, attribute filter, simplification, field-select, and layer rename. Thin wrapper around the C entry point behind `ogr2ogr` (`gdal.VectorTranslate`). Stateless — does NOT require a `*ManagerConfig`. (PR 2 of v1.2)
+- **`WithVector*` option helpers**: `WithVectorLogger`, `WithVectorFormat`, `WithVectorSourceSRS`, `WithVectorTargetSRS`, `WithVectorBoundingBox`, `WithVectorWhere`, `WithVectorSimplify`, `WithVectorSelectFields`, `WithVectorLayerName`, `WithVectorOverwrite`, `WithVectorRawOptions`. Each maps 1:1 to a `ogr2ogr` CLI flag. (PR 2 of v1.2)
+- **`ErrConvertFailed`** sentinel for the conversion subsystem. Wrap-recoverable via `errors.As` into `*GISError`; `GISError.Op` disambiguates the conversion entry point. (PR 2 of v1.2)
 - **Manifest-driven `make fetch-testdata`.** Real-world geo fixtures (Natural Earth countries, rasterio `RGB.byte.tif`, rio-tiler `cog.tif`, plus more in subsequent PRs) are downloaded into the gitignored sibling `testdata-fetched/` directory on demand, with sha256 verification on each fetch. CI caches the fetched payload keyed on the manifest hash, so cold-runs pay ~3 s of network and warm-runs are zero-network. Tracked: `testdata/manifest.sha256`, `testdata/LICENSES.md`, `testdata/README.md`, `scripts/fetch-testdata.sh`, `testdata-fetched/.gitignore`. Untracked: the binaries themselves. The fetched fixtures live in a sibling directory (not under `testdata/`) so the existing `TestGetGISFiles` unit test and `TestPublishAll_EndToEnd` integration test — both of which walk `./testdata/` — are unaffected. (PR 1 of v1.2)
 
 ## [1.1.0] — 2026-05-04

--- a/convert_vector.go
+++ b/convert_vector.go
@@ -1,0 +1,236 @@
+package gismanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/lukeroth/gdal"
+)
+
+// VectorConvertOption configures a [ConvertVector] call. Construct via
+// the [WithVector*] helpers below; pass any number of options in any
+// order. Each helper mutates a private config struct; nil options are
+// tolerated.
+//
+// The pattern matches v1.1's manager [Option] precedent — functional
+// options for additive growth without breaking the public surface.
+type VectorConvertOption func(*vectorConvertConfig)
+
+type vectorConvertConfig struct {
+	logger       *slog.Logger
+	format       string
+	sourceSRS    string
+	targetSRS    string
+	bbox         *vectorBBox
+	where        string
+	simplifyTol  float64
+	selectFields []string
+	layerName    string
+	overwrite    bool
+	rawOptions   []string
+}
+
+type vectorBBox struct {
+	MinX, MinY, MaxX, MaxY float64
+}
+
+func newVectorConvertConfig(opts []VectorConvertOption) *vectorConvertConfig {
+	c := &vectorConvertConfig{logger: GetLogger()}
+	for _, o := range opts {
+		if o != nil {
+			o(c)
+		}
+	}
+	return c
+}
+
+// WithVectorLogger sets the structured logger used for diagnostic output
+// during conversion. Passing nil falls back to the default logger from
+// [GetLogger]. Mirrors v1.1's [WithLogger] semantics for the manager.
+func WithVectorLogger(l *slog.Logger) VectorConvertOption {
+	return func(c *vectorConvertConfig) {
+		if l == nil {
+			c.logger = GetLogger()
+			return
+		}
+		c.logger = l
+	}
+}
+
+// WithVectorFormat selects the OGR output driver by name (e.g. "GPKG",
+// "GeoJSON", "FlatGeobuf", "ESRI Shapefile", "KML"). Maps to ogr2ogr's
+// `-f` flag. When empty, GDAL infers the driver from the destination
+// path's extension.
+func WithVectorFormat(driverName string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.format = driverName }
+}
+
+// WithVectorSourceSRS overrides the input CRS. Accepts any GDAL
+// SetFromUserInput-friendly form ("EPSG:4326", "+proj=longlat ...",
+// well-known WKT). Use only when the source has a missing or wrong CRS.
+// Maps to ogr2ogr's `-s_srs`.
+func WithVectorSourceSRS(srs string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.sourceSRS = srs }
+}
+
+// WithVectorTargetSRS reprojects features to the given CRS during the
+// conversion. The most common use is `WithVectorTargetSRS("EPSG:3857")`
+// for web tile pipelines. Maps to ogr2ogr's `-t_srs`.
+func WithVectorTargetSRS(srs string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.targetSRS = srs }
+}
+
+// WithVectorBoundingBox restricts output to features intersecting the
+// given bounding box. Coordinates are in the *source* CRS unless
+// [WithVectorSourceSRS] also reinterprets them. Maps to ogr2ogr's
+// `-spat`.
+func WithVectorBoundingBox(minX, minY, maxX, maxY float64) VectorConvertOption {
+	return func(c *vectorConvertConfig) {
+		c.bbox = &vectorBBox{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
+	}
+}
+
+// WithVectorWhere restricts output to features matching the given OGR
+// SQL WHERE expression (without the `WHERE` keyword), e.g.
+// `"CONTINENT = 'Africa'"`. Maps to ogr2ogr's `-where`.
+func WithVectorWhere(sql string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.where = sql }
+}
+
+// WithVectorSimplify applies Douglas-Peucker simplification with the
+// given tolerance (in target-CRS units). Useful for thinning vector
+// data before web delivery. Maps to ogr2ogr's `-simplify`.
+func WithVectorSimplify(tolerance float64) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.simplifyTol = tolerance }
+}
+
+// WithVectorSelectFields restricts the output to the named attribute
+// fields. The geometry column is always preserved. Maps to ogr2ogr's
+// `-select`.
+func WithVectorSelectFields(fields ...string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.selectFields = append([]string(nil), fields...) }
+}
+
+// WithVectorLayerName renames the destination layer (e.g. forces a
+// different table name when copying to PostGIS or a different layer
+// name in GPKG). Maps to ogr2ogr's `-nln`.
+func WithVectorLayerName(name string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.layerName = name }
+}
+
+// WithVectorOverwrite replaces an existing destination layer instead of
+// failing with a "layer already exists" error. Maps to ogr2ogr's
+// `-overwrite`.
+func WithVectorOverwrite() VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.overwrite = true }
+}
+
+// WithVectorRawOptions appends raw `ogr2ogr`-style flags to the
+// generated argument list, after every other option. Use this to reach
+// flags the typed helpers do not yet expose (e.g. `-lco`, `-skipfailures`,
+// `-nlt`). Each entry is one CLI token.
+func WithVectorRawOptions(args ...string) VectorConvertOption {
+	return func(c *vectorConvertConfig) { c.rawOptions = append(c.rawOptions, args...) }
+}
+
+// ConvertVector converts the vector source at src into dst, applying any
+// of the provided options. It is a thin wrapper around the GDAL C entry
+// point behind `ogr2ogr` ([gdal.VectorTranslate]) — every option maps
+// 1:1 to an ogr2ogr CLI flag.
+//
+// Behavior:
+//   - The destination driver is chosen by [WithVectorFormat] when set,
+//     else inferred from dst's extension (GDAL behavior).
+//   - Reprojection happens during the copy when [WithVectorTargetSRS] is
+//     set; chain with [WithVectorBoundingBox] / [WithVectorWhere] /
+//     [WithVectorSimplify] for the typical "extract a region" pipeline.
+//   - dst and src paths can use any GDAL Virtual File System prefix
+//     (`/vsimem/`, `/vsis3/`, `/vsicurl/`, `/vsigs/`, `/vsizip/`); the
+//     function passes paths through to GDAL unchanged. Bare `.zip`
+//     Shapefile bundles do NOT auto-prefix — pass `/vsizip/<path>`
+//     explicitly, or extract first via [GetGISFiles].
+//   - ctx is honored at the function boundary (checked before opening
+//     the source); the underlying CGo call is synchronous and
+//     uninterruptible — long conversions cannot be cancelled mid-way.
+//
+// Errors are wrapped with [ErrConvertFailed]; recover the underlying
+// GDAL error via [errors.As] into [*GISError].
+//
+// Known gap: lukeroth/gdal's VectorTranslate wrapper only surfaces a Go
+// error when the C-level cerr is nonzero. Some failure modes — notably
+// an unknown destination driver passed via [WithVectorFormat] — fail at
+// option-parsing time inside GDAL, log to stderr, and return a NULL
+// dataset with cerr=0; ConvertVector then returns nil. Pre-validate
+// driver names on the caller side if you need a hard guarantee.
+func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg := newVectorConvertConfig(opts)
+
+	srcDS, err := gdal.OpenEx(src, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		cfg.logger.Error("ConvertVector: open source", "src", src, "err", err)
+		return newGISError("ConvertVector", src, ErrConvertFailed, err)
+	}
+	defer srcDS.Close()
+
+	args := buildVectorTranslateArgs(cfg)
+	cfg.logger.Debug("ConvertVector: invoking VectorTranslate",
+		"src", src, "dst", dst, "args", args)
+
+	out, vErr := gdal.VectorTranslate(dst, []gdal.Dataset{srcDS}, args)
+	if vErr != nil {
+		return newGISError("ConvertVector", fmt.Sprintf("%s -> %s", src, dst),
+			ErrConvertFailed, vErr)
+	}
+	out.Close()
+	return nil
+}
+
+// buildVectorTranslateArgs renders cfg into the []string ogr2ogr-style
+// arg list GDALVectorTranslate expects. Unit-tested separately so the
+// option->arg mapping is locked in without needing CGo.
+func buildVectorTranslateArgs(cfg *vectorConvertConfig) []string {
+	var args []string
+	if cfg.format != "" {
+		args = append(args, "-f", cfg.format)
+	}
+	if cfg.overwrite {
+		args = append(args, "-overwrite")
+	}
+	if cfg.sourceSRS != "" {
+		args = append(args, "-s_srs", cfg.sourceSRS)
+	}
+	if cfg.targetSRS != "" {
+		args = append(args, "-t_srs", cfg.targetSRS)
+	}
+	if cfg.bbox != nil {
+		args = append(args, "-spat",
+			formatFloat(cfg.bbox.MinX),
+			formatFloat(cfg.bbox.MinY),
+			formatFloat(cfg.bbox.MaxX),
+			formatFloat(cfg.bbox.MaxY))
+	}
+	if cfg.where != "" {
+		args = append(args, "-where", cfg.where)
+	}
+	if cfg.simplifyTol > 0 {
+		args = append(args, "-simplify", formatFloat(cfg.simplifyTol))
+	}
+	if len(cfg.selectFields) > 0 {
+		args = append(args, "-select", strings.Join(cfg.selectFields, ","))
+	}
+	if cfg.layerName != "" {
+		args = append(args, "-nln", cfg.layerName)
+	}
+	args = append(args, cfg.rawOptions...)
+	return args
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/convert_vector_integration_test.go
+++ b/convert_vector_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package gismanager_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestConvertVector_ShapefileToGeoPackage_Integration exercises the most
+// common conversion in the wild: a zipped Shapefile to a single-layer
+// GeoPackage. Asserts the destination is readable, has exactly one layer,
+// and preserves the source feature count.
+//
+// The /vsizip/ prefix is required: lukeroth/gdal's OpenEx does not
+// auto-prefix bare .zip paths (verified against the dev container's
+// ogrinfo). Callers shipping zipped Shapefiles to ConvertVector must
+// either use the /vsizip/ prefix or pre-extract via GetGISFiles.
+func TestConvertVector_ShapefileToGeoPackage_Integration(t *testing.T) {
+	src := "/vsizip/" + mustFetched(t, "ne_110m_admin_0_countries.zip")
+	dst := filepath.Join(t.TempDir(), "countries.gpkg")
+
+	if err := gismanager.ConvertVector(context.Background(), src, dst,
+		gismanager.WithVectorFormat("GPKG"),
+		gismanager.WithVectorOverwrite(),
+	); err != nil {
+		t.Fatalf("ConvertVector: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	srcOpen, err := gdal.OpenEx(src, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	defer srcOpen.Close()
+
+	srcLayer := srcOpen.LayerByIndex(0)
+	srcCount, ok := srcLayer.FeatureCount(true)
+	if !ok {
+		t.Fatal("source layer feature count read failed")
+	}
+
+	dstLayer := dsOut.LayerByIndex(0)
+	dstCount, ok := dstLayer.FeatureCount(true)
+	if !ok {
+		t.Fatal("destination layer feature count read failed")
+	}
+
+	if srcCount != dstCount {
+		t.Errorf("feature count mismatch: src=%d dst=%d", srcCount, dstCount)
+	}
+	if srcCount == 0 {
+		t.Errorf("source has zero features — fixture may be corrupted")
+	}
+}
+
+// TestConvertVector_GeoJSONReprojectAndFilter_Integration exercises the
+// "extract a region in a different CRS" workflow: take 4326 countries,
+// project to 3857, clip to a bbox roughly covering Africa, and filter by
+// continent attribute. Asserts the destination has fewer features than
+// the source AND that the destination geometry is in 3857.
+func TestConvertVector_GeoJSONReprojectAndFilter_Integration(t *testing.T) {
+	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
+	dst := filepath.Join(t.TempDir(), "africa_3857.gpkg")
+
+	if err := gismanager.ConvertVector(context.Background(), src, dst,
+		gismanager.WithVectorFormat("GPKG"),
+		gismanager.WithVectorOverwrite(),
+		gismanager.WithVectorTargetSRS("EPSG:3857"),
+		// Africa-ish bbox in 4326 (-spat applies to source CRS by default).
+		gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
+		gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
+		gismanager.WithVectorLayerName("africa_3857"),
+	); err != nil {
+		t.Fatalf("ConvertVector: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	dstLayer := dsOut.LayerByIndex(0)
+	dstCount, ok := dstLayer.FeatureCount(true)
+	if !ok {
+		t.Fatal("destination layer feature count read failed")
+	}
+	// Africa has ~50 countries in Natural Earth 1:110m. Allow a wide
+	// envelope so the test is robust to fixture revisions.
+	if dstCount < 30 || dstCount > 80 {
+		t.Errorf("expected ~50 African countries, got %d", dstCount)
+	}
+
+	// Verify the destination spatial reference is in fact EPSG:3857.
+	sr := dstLayer.SpatialReference()
+	authCode, ok := srAuthorityCode(sr)
+	if !ok || authCode != "3857" {
+		t.Errorf("expected EPSG:3857 destination CRS, got authority code %q (ok=%v)",
+			authCode, ok)
+	}
+}
+
+// TestConvertVector_Idempotent_Integration confirms re-running the same
+// conversion with WithVectorOverwrite() succeeds twice. This is the
+// "rerun a tile-prep pipeline after upstream data refreshes" use case.
+func TestConvertVector_Idempotent_Integration(t *testing.T) {
+	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
+	dst := filepath.Join(t.TempDir(), "countries.gpkg")
+
+	for i := 0; i < 2; i++ {
+		if err := gismanager.ConvertVector(context.Background(), src, dst,
+			gismanager.WithVectorFormat("GPKG"),
+			gismanager.WithVectorOverwrite(),
+		); err != nil {
+			t.Fatalf("iteration %d: %v", i+1, err)
+		}
+	}
+}
+
+// Note: a "TestConvertVector_UnsupportedDestination_Integration" was
+// drafted but removed — lukeroth/gdal's VectorTranslate wrapper does not
+// surface NULL-options-from-bad-driver as a Go error (only `cerr != 0`
+// is checked, and unknown -f values fail at GDALVectorTranslateOptionsNew
+// with an stderr message but no nonzero return code). Detecting that
+// failure cleanly would require an upstream binding patch. Documented
+// in the convert_vector.go top-comment as a known gap.
+
+// mustFetched returns the absolute path to a fixture inside
+// `testdata-fetched/`. It t.Skips the test if the fixture is missing
+// (the user forgot to run `make fetch-testdata`); CI always pre-fetches.
+func mustFetched(t *testing.T, name string) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("testdata-fetched", name))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	return abs
+}
+
+// srAuthorityCode pulls the authority code (e.g. "3857") out of a
+// SpatialReference for assertion. The lukeroth/gdal binding doesn't
+// wrap OSRGetAuthorityCode, so we read the AUTHORITY[] node's second
+// child via the generic AttrValue helper. Returns ("", false) when the
+// SR is unset or has no authority recorded.
+func srAuthorityCode(sr gdal.SpatialReference) (string, bool) {
+	code, ok := sr.AttrValue("AUTHORITY", 1)
+	if !ok || code == "" {
+		return "", false
+	}
+	return code, true
+}

--- a/convert_vector_test.go
+++ b/convert_vector_test.go
@@ -1,0 +1,181 @@
+package gismanager
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildVectorTranslateArgs is a table-driven unit test that locks in
+// the option -> ogr2ogr-arg mapping. CGo isn't exercised here — the goal
+// is to catch any drift between the WithVector* helpers and the actual
+// GDALVectorTranslate flag set without needing the GeoServer/PostGIS
+// stack.
+func TestBuildVectorTranslateArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []VectorConvertOption
+		want []string
+	}{
+		{
+			name: "no options yields empty args",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "format only",
+			opts: []VectorConvertOption{WithVectorFormat("GPKG")},
+			want: []string{"-f", "GPKG"},
+		},
+		{
+			name: "overwrite",
+			opts: []VectorConvertOption{WithVectorOverwrite()},
+			want: []string{"-overwrite"},
+		},
+		{
+			name: "source + target SRS",
+			opts: []VectorConvertOption{
+				WithVectorSourceSRS("EPSG:4326"),
+				WithVectorTargetSRS("EPSG:3857"),
+			},
+			want: []string{"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857"},
+		},
+		{
+			name: "bbox emits four float args after -spat",
+			opts: []VectorConvertOption{
+				WithVectorBoundingBox(-10.5, -20, 30.25, 45.75),
+			},
+			want: []string{"-spat", "-10.5", "-20", "30.25", "45.75"},
+		},
+		{
+			name: "where clause",
+			opts: []VectorConvertOption{
+				WithVectorWhere("CONTINENT = 'Africa'"),
+			},
+			want: []string{"-where", "CONTINENT = 'Africa'"},
+		},
+		{
+			name: "simplify with non-zero tolerance",
+			opts: []VectorConvertOption{WithVectorSimplify(0.001)},
+			want: []string{"-simplify", "0.001"},
+		},
+		{
+			name: "simplify with zero tolerance is dropped",
+			opts: []VectorConvertOption{WithVectorSimplify(0)},
+			want: nil,
+		},
+		{
+			name: "select fields",
+			opts: []VectorConvertOption{
+				WithVectorSelectFields("NAME", "POP_EST", "CONTINENT"),
+			},
+			want: []string{"-select", "NAME,POP_EST,CONTINENT"},
+		},
+		{
+			name: "layer name",
+			opts: []VectorConvertOption{WithVectorLayerName("countries_3857")},
+			want: []string{"-nln", "countries_3857"},
+		},
+		{
+			name: "raw options append at end",
+			opts: []VectorConvertOption{
+				WithVectorFormat("GPKG"),
+				WithVectorRawOptions("-lco", "FID=fid", "-skipfailures"),
+			},
+			want: []string{"-f", "GPKG", "-lco", "FID=fid", "-skipfailures"},
+		},
+		{
+			name: "full pipeline: reproject + bbox + where + simplify + select + rename",
+			opts: []VectorConvertOption{
+				WithVectorFormat("GPKG"),
+				WithVectorOverwrite(),
+				WithVectorTargetSRS("EPSG:3857"),
+				WithVectorBoundingBox(-20, 0, 60, 40),
+				WithVectorWhere("CONTINENT = 'Africa'"),
+				WithVectorSimplify(100),
+				WithVectorSelectFields("NAME", "POP_EST"),
+				WithVectorLayerName("africa_3857"),
+			},
+			want: []string{
+				"-f", "GPKG",
+				"-overwrite",
+				"-t_srs", "EPSG:3857",
+				"-spat", "-20", "0", "60", "40",
+				"-where", "CONTINENT = 'Africa'",
+				"-simplify", "100",
+				"-select", "NAME,POP_EST",
+				"-nln", "africa_3857",
+			},
+		},
+		{
+			name: "nil options are tolerated",
+			opts: []VectorConvertOption{
+				nil,
+				WithVectorFormat("GPKG"),
+				nil,
+			},
+			want: []string{"-f", "GPKG"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newVectorConvertConfig(tc.opts)
+			got := buildVectorTranslateArgs(cfg)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestWithVectorLogger_NilFallsBackToDefault confirms passing nil through
+// WithVectorLogger doesn't leave cfg.logger nil — the helper falls back
+// to GetLogger() so downstream callers can always emit structured logs.
+func TestWithVectorLogger_NilFallsBackToDefault(t *testing.T) {
+	cfg := newVectorConvertConfig([]VectorConvertOption{WithVectorLogger(nil)})
+	assert.NotNil(t, cfg.logger, "logger must never be nil after option apply")
+}
+
+// TestWithVectorLogger_CustomHandlerCaptured exercises the custom-logger
+// path: a JSON handler routed at a *bytes.Buffer captures structured
+// output, so callers can verify ConvertVector emits the expected records.
+func TestWithVectorLogger_CustomHandlerCaptured(t *testing.T) {
+	var buf bytes.Buffer
+	custom := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cfg := newVectorConvertConfig([]VectorConvertOption{WithVectorLogger(custom)})
+	cfg.logger.Debug("test", "key", "value")
+	assert.Contains(t, buf.String(), `"key":"value"`)
+}
+
+// TestConvertVector_CtxCancelledFailsFast verifies the ctx-honor at the
+// function boundary: a pre-canceled context surfaces as ctx.Err() before
+// any GDAL call, so callers can use a context to abort batches between
+// conversions.
+func TestConvertVector_CtxCancelledFailsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := ConvertVector(ctx, "ignored.geojson", "ignored.gpkg")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"expected context.Canceled, got %v", err)
+}
+
+// TestConvertVector_OpenError_WrapsErrConvertFailed locks in the error
+// envelope: a missing source surfaces as *GISError wrapping
+// ErrConvertFailed, so callers can branch on the sentinel without
+// scraping strings.
+func TestConvertVector_OpenError_WrapsErrConvertFailed(t *testing.T) {
+	err := ConvertVector(context.Background(),
+		"./testdata/__definitely_does_not_exist__.geojson",
+		"/tmp/gismanager_should_not_be_created.gpkg")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConvertFailed),
+		"expected ErrConvertFailed, got %v", err)
+
+	var gerr *GISError
+	assert.True(t, errors.As(err, &gerr), "expected *GISError envelope")
+	assert.Equal(t, "ConvertVector", gerr.Op)
+}

--- a/errors.go
+++ b/errors.go
@@ -41,6 +41,13 @@ var (
 	// ErrNoSourcesFound signals that the configured source directory
 	// contained no supported GIS files.
 	ErrNoSourcesFound = errors.New("gismanager: no sources found")
+
+	// ErrConvertFailed signals that a vector or raster conversion
+	// (ConvertVector / ConvertRaster / ToCOG / ReprojectRaster) failed.
+	// The underlying GDAL error is recoverable via [errors.As] into
+	// [*GISError]; the GISError.Op field disambiguates which entry
+	// point produced the error.
+	ErrConvertFailed = errors.New("gismanager: convert failed")
 )
 
 // GISError is the typed error gismanager returns for higher-level


### PR DESCRIPTION
## Summary

PR 2 of the v1.2 conversion-feature series. Ships the **ogr2ogr equivalent**: a single \`ConvertVector\` entry point that covers GeoJSON ↔ GeoPackage ↔ Shapefile ↔ FlatGeobuf ↔ KML format conversion plus reprojection, bbox clip, attribute filter, simplification, field-select, and layer rename.

Stateless — does NOT require a \`*ManagerConfig\`. Mirrors the v1.1 \`Option\` precedent (functional options + \`With*\` helpers); modality prefix (\`WithVector*\`) avoids name collisions with the upcoming raster surface (PR 3).

### New public surface

\`\`\`go
func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOption) error

// 11 WithVector* helpers: Logger, Format, SourceSRS, TargetSRS,
// BoundingBox, Where, Simplify, SelectFields, LayerName, Overwrite,
// RawOptions

var ErrConvertFailed = errors.New(\"gismanager: convert failed\")
\`\`\`

### Implementation

Thin wrapper around \`gdal.VectorTranslate\` (utilities.go:178 in lukeroth/gdal), the C entry point behind the \`ogr2ogr\` CLI. Each \`WithVector*\` helper maps 1:1 to a CLI flag; the \`buildVectorTranslateArgs\` renderer is unit-tested separately so the mapping is locked in without needing CGo.

### Tests

- **Unit (13 cases, table-driven)** — option → arg mapping
- **Unit** — logger nil/custom handler, ctx-canceled fails fast, source-open error wrapped with \`ErrConvertFailed\`
- **Integration** — Shapefile via \`/vsizip/\` → GeoPackage with feature-count parity
- **Integration** — GeoJSON → GeoPackage with reproject (4326 → 3857) + bbox clip + WHERE filter + EPSG:3857 SRS verification
- **Integration** — idempotent rerun with \`WithVectorOverwrite\`

### Documented binding gap

\`lukeroth/gdal\`'s \`VectorTranslate\` doesn't surface NULL-options-from-bad-driver failures as Go errors. Documented in the \`ConvertVector\` doc comment; pre-validate driver names on the caller side for a hard guarantee.

## Test plan

- [x] \`make build\` — green
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` (local, GeoServer 2.28.0) — green
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green