### PR TITLE
feat(convert): ReprojectRaster (gdalwarp wrapper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ### Added
 
+- **`ReprojectRaster(ctx, src, dst, srcSRS, dstSRS, opts...) error`** — raster reprojection (the `gdalwarp` equivalent). Pairs with the EPSG:4326↔EPSG:3857 web-tile workflow but accepts any GDAL-friendly CRS. Reuses the `RasterConvertOption` type — chain with `WithRasterResamplingAlg`, `WithRasterTargetResolution`, `WithRasterCutline` for the typical "warp + clip" pipeline. Cutline support emits `-cutline` + `-cl` + `-crop_to_cutline`. (PR 4 of v1.2)
 - **`ConvertRaster(ctx, src, dst, opts...) error`** — generic raster format conversion (GeoTIFF → COG, GeoTIFF → PNG, band-subset, output-window). Thin wrapper around the C entry point behind `gdal_translate` (`gdal.Translate`). (PR 3 of v1.2)
 - **`ToCOG(ctx, src, dst, opts...) error`** — convenience wrapper that pre-fills `WithRasterFormat("COG")` plus sane defaults (`COMPRESS=DEFLATE`, `BLOCKSIZE=512`, `OVERVIEW_RESAMPLING=NEAREST`). Caller-supplied options override defaults — pass `WithRasterCreationOption("COMPRESS", "ZSTD")` to swap codecs. (PR 3 of v1.2)
 - **`WithRaster*` option helpers**: `WithRasterLogger`, `WithRasterFormat`, `WithRasterCreationOption`, `WithRasterOutputBounds`, `WithRasterBands`, `WithRasterResamplingAlg`, `WithRasterTargetResolution`, `WithRasterCutline`, `WithRasterRawOptions`. Each maps 1:1 to a `gdal_translate` / `gdalwarp` CLI flag. The cutline option is wired only on the warp-side (PR 4); `gdal_translate` does not support cutlines. (PR 3 of v1.2)

--- a/convert_raster_reproject.go
+++ b/convert_raster_reproject.go
@@ -1,0 +1,114 @@
+package gismanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lukeroth/gdal"
+)
+
+// ReprojectRaster reprojects the raster source at src into dst, going
+// from srcSRS to dstSRS. It is a thin wrapper around the C entry point
+// behind `gdalwarp` ([gdal.Warp]).
+//
+// srcSRS and dstSRS accept any GDAL SetFromUserInput-friendly form
+// ("EPSG:4326", "EPSG:3857", "+proj=longlat +datum=WGS84 +no_defs",
+// well-known WKT). The most common pair in 2025–26 web pipelines is
+// EPSG:32618 / EPSG:4326 → EPSG:3857.
+//
+// Supports the same [WithRaster*] options as [ConvertRaster] /
+// [ToCOG] — chain with [WithRasterResamplingAlg],
+// [WithRasterTargetResolution], [WithRasterCutline] for the typical
+// "warp + clip" pipeline.
+//
+// Output bounds, when supplied via [WithRasterOutputBounds], are
+// interpreted in the *target* CRS (gdalwarp's `-te` semantics), not
+// the source CRS (gdal_translate's `-projwin`).
+//
+// Errors are wrapped with [ErrConvertFailed]; recover via
+// [errors.As] into [*GISError]. The Op field is "ReprojectRaster".
+//
+// Known gap: same as [ConvertVector] — silent failures when GDAL's C
+// option-parsing rejects an input (e.g. an unknown CRS string) without
+// setting cerr. Pre-validate inputs on the caller side if needed.
+func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterConvertOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if srcSRS == "" || dstSRS == "" {
+		return newGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
+			ErrConvertFailed,
+			fmt.Errorf("srcSRS and dstSRS must both be non-empty"))
+	}
+
+	cfg := newRasterConvertConfig(opts)
+
+	srcDS, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		cfg.logger.Error("ReprojectRaster: open source", "src", src, "err", err)
+		return newGISError("ReprojectRaster", src, ErrConvertFailed, err)
+	}
+	defer srcDS.Close()
+
+	args := buildWarpArgs(cfg, srcSRS, dstSRS)
+	cfg.logger.Debug("ReprojectRaster: invoking Warp",
+		"src", src, "dst", dst, "args", args)
+
+	out, wErr := gdal.Warp(dst, nil, []gdal.Dataset{srcDS}, args)
+	if wErr != nil {
+		return newGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
+			ErrConvertFailed, wErr)
+	}
+	out.Close()
+	return nil
+}
+
+// buildWarpArgs renders cfg + (srcSRS, dstSRS) into gdalwarp-style args.
+// Differs from [buildTranslateArgs] in two ways:
+//   - Uses `-s_srs` / `-t_srs` for CRS pair (mandatory for warp).
+//   - Uses `-te` for output bounds (target CRS) rather than `-projwin`
+//     (source CRS) — this is the gdalwarp convention.
+//   - Adds `-cutline` / `-cl` when the cutline option is set (cutline is
+//     a warp-only flag; gdal_translate does not support it).
+//
+// Unit-tested separately so the mapping is locked in without CGo.
+func buildWarpArgs(cfg *rasterConvertConfig, srcSRS, dstSRS string) []string {
+	var args []string
+	if cfg.format != "" {
+		args = append(args, "-of", cfg.format)
+	}
+	args = append(args, "-s_srs", srcSRS, "-t_srs", dstSRS)
+	for _, co := range cfg.creationOptions {
+		args = append(args, "-co", co)
+	}
+	if cfg.resamplingAlg != "" {
+		args = append(args, "-r", cfg.resamplingAlg)
+	}
+	if cfg.outputBounds != nil {
+		// gdalwarp -te uses (xmin ymin xmax ymax) in target CRS.
+		args = append(args, "-te",
+			formatFloat(cfg.outputBounds.MinX),
+			formatFloat(cfg.outputBounds.MinY),
+			formatFloat(cfg.outputBounds.MaxX),
+			formatFloat(cfg.outputBounds.MaxY))
+	}
+	if cfg.hasTargetRes {
+		args = append(args, "-tr",
+			formatFloat(cfg.targetResX),
+			formatFloat(cfg.targetResY))
+	}
+	if cfg.cutlineDS != "" {
+		args = append(args, "-cutline", cfg.cutlineDS)
+		if cfg.cutlineLayer != "" {
+			args = append(args, "-cl", cfg.cutlineLayer)
+		}
+		// -crop_to_cutline is the typical companion (the alternative is
+		// to keep the original raster extent and only mask pixels). We
+		// default to crop because the cutline use case is almost always
+		// cookie-cutter clipping for tile pipelines. Users who want
+		// preserve-extent semantics can pass -overwrite via raw options.
+		args = append(args, "-crop_to_cutline")
+	}
+	args = append(args, cfg.rawOptions...)
+	return args
+}

--- a/convert_raster_reproject_integration_test.go
+++ b/convert_raster_reproject_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package gismanager_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestReprojectRaster_GeoTIFFToWebMercator_Integration exercises the
+// dominant raster reprojection in 2025-26 web tile pipelines: a UTM-zone
+// GeoTIFF (EPSG:32618) reprojected to Web Mercator (EPSG:3857). Asserts
+// the destination opens, has the expected CRS, and contains pixel data.
+func TestReprojectRaster_GeoTIFFToWebMercator_Integration(t *testing.T) {
+	src := mustFetched(t, "RGB.byte.tif")
+	dst := filepath.Join(t.TempDir(), "RGB.3857.tif")
+
+	if err := gismanager.ReprojectRaster(context.Background(),
+		src, dst, "EPSG:32618", "EPSG:3857",
+		gismanager.WithRasterFormat("GTiff"),
+		gismanager.WithRasterResamplingAlg("bilinear"),
+	); err != nil {
+		t.Fatalf("ReprojectRaster: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	if dsOut.RasterCount() == 0 {
+		t.Fatal("destination has no raster bands")
+	}
+
+	// Verify the projection includes the EPSG:3857 marker. We don't use
+	// a parsed SR comparison because Dataset.Projection() returns WKT
+	// directly and GDAL has multiple equivalent ways to express 3857.
+	wkt := dsOut.Projection()
+	if wkt == "" {
+		t.Errorf("expected non-empty projection WKT on warped output")
+	}
+	// The Web Mercator WKT contains "Mercator" and either AUTHORITY
+	// "3857" or one of the EPSG:3857 aliases.
+	if !containsAny(wkt, []string{"3857", "Mercator_1SP", "WGS_1984_Web_Mercator", "Pseudo-Mercator"}) {
+		t.Errorf("expected Web Mercator marker in projection WKT, got:\n%s", wkt)
+	}
+}
+
+func containsAny(haystack string, needles []string) bool {
+	for _, n := range needles {
+		for i := 0; i+len(n) <= len(haystack); i++ {
+			if haystack[i:i+len(n)] == n {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/convert_raster_reproject_test.go
+++ b/convert_raster_reproject_test.go
@@ -1,0 +1,150 @@
+package gismanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildWarpArgs(t *testing.T) {
+	cases := []struct {
+		name   string
+		opts   []RasterConvertOption
+		srcSRS string
+		dstSRS string
+		want   []string
+	}{
+		{
+			name:   "minimal: just src and dst SRS",
+			srcSRS: "EPSG:32618",
+			dstSRS: "EPSG:3857",
+			want:   []string{"-s_srs", "EPSG:32618", "-t_srs", "EPSG:3857"},
+		},
+		{
+			name: "with format and creation option",
+			opts: []RasterConvertOption{
+				WithRasterFormat("GTiff"),
+				WithRasterCreationOption("COMPRESS", "DEFLATE"),
+			},
+			srcSRS: "EPSG:4326",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-of", "GTiff",
+				"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857",
+				"-co", "COMPRESS=DEFLATE",
+			},
+		},
+		{
+			name: "output bounds use -te (target CRS) not -projwin",
+			opts: []RasterConvertOption{
+				WithRasterOutputBounds(-180, -90, 180, 90),
+			},
+			srcSRS: "EPSG:4326",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857",
+				"-te", "-180", "-90", "180", "90",
+			},
+		},
+		{
+			name: "resampling + target resolution",
+			opts: []RasterConvertOption{
+				WithRasterResamplingAlg("bilinear"),
+				WithRasterTargetResolution(30, 30),
+			},
+			srcSRS: "EPSG:32618",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-s_srs", "EPSG:32618", "-t_srs", "EPSG:3857",
+				"-r", "bilinear",
+				"-tr", "30", "30",
+			},
+		},
+		{
+			name: "cutline emits -cutline + -cl + -crop_to_cutline",
+			opts: []RasterConvertOption{
+				WithRasterCutline("clip.geojson", "outline"),
+			},
+			srcSRS: "EPSG:4326",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857",
+				"-cutline", "clip.geojson",
+				"-cl", "outline",
+				"-crop_to_cutline",
+			},
+		},
+		{
+			name: "cutline without explicit layer omits -cl",
+			opts: []RasterConvertOption{
+				WithRasterCutline("clip.geojson", ""),
+			},
+			srcSRS: "EPSG:4326",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857",
+				"-cutline", "clip.geojson",
+				"-crop_to_cutline",
+			},
+		},
+		{
+			name: "raw options append at end",
+			opts: []RasterConvertOption{
+				WithRasterRawOptions("-overwrite", "-multi"),
+			},
+			srcSRS: "EPSG:4326",
+			dstSRS: "EPSG:3857",
+			want: []string{
+				"-s_srs", "EPSG:4326", "-t_srs", "EPSG:3857",
+				"-overwrite", "-multi",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newRasterConvertConfig(tc.opts)
+			got := buildWarpArgs(cfg, tc.srcSRS, tc.dstSRS)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReprojectRaster_CtxCancelledFailsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := ReprojectRaster(ctx, "ignored.tif", "ignored.warped.tif",
+		"EPSG:32618", "EPSG:3857")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestReprojectRaster_RejectsEmptySRS(t *testing.T) {
+	t.Run("empty srcSRS", func(t *testing.T) {
+		err := ReprojectRaster(context.Background(),
+			"/dev/null", "/tmp/out.tif", "", "EPSG:3857")
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrConvertFailed))
+	})
+	t.Run("empty dstSRS", func(t *testing.T) {
+		err := ReprojectRaster(context.Background(),
+			"/dev/null", "/tmp/out.tif", "EPSG:4326", "")
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrConvertFailed))
+	})
+}
+
+func TestReprojectRaster_OpenError_WrapsErrConvertFailed(t *testing.T) {
+	err := ReprojectRaster(context.Background(),
+		"./testdata/__definitely_does_not_exist__.tif",
+		"/tmp/should_not_be_created.warped.tif",
+		"EPSG:32618", "EPSG:3857")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConvertFailed))
+
+	var gerr *GISError
+	assert.True(t, errors.As(err, &gerr))
+	assert.Equal(t, "ReprojectRaster", gerr.Op)
+}


### PR DESCRIPTION
## Summary

PR 4 of the v1.2 conversion-feature series. Ships the **gdalwarp equivalent**: \`ReprojectRaster\` takes a CRS pair \`(srcSRS, dstSRS)\` plus the shared \`WithRaster*\` options from PR 3 and reprojects pixels via \`gdal.Warp\`. Cookie-cutter clipping via \`WithRasterCutline\` is now wired (gdal_translate doesn't support cutlines, so the option was no-op until this PR).

### New public surface

\`\`\`go
func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterConvertOption) error
\`\`\`

No new option type — reuses \`RasterConvertOption\` from PR 3.

### Two semantic differences from ConvertRaster

- \`WithRasterOutputBounds\` renders to \`-te\` (target-CRS, \`xmin ymin xmax ymax\`) here, vs. \`-projwin\` (source-CRS, \`ulx uly lrx lry\` — y-flip) on the Translate side. Matches gdalwarp's convention.
- \`WithRasterCutline\` takes effect: emits \`-cutline\` + \`-cl\` + \`-crop_to_cutline\`.

### Tests

- **Unit (7 cases, table-driven)** — \`buildWarpArgs\` mapping: minimal SRS, format + creation option, output bounds (\`-te\`), resampling + tr, cutline with and without explicit layer, raw-options pass-through.
- **Unit** — empty SRS rejected with \`ErrConvertFailed\` envelope (both \`srcSRS\` and \`dstSRS\`).
- **Unit** — ctx-canceled fails fast.
- **Unit** — source-open error wrapped with \`ErrConvertFailed\` (\`Op=\"ReprojectRaster\"\`).
- **Integration** — \`RGB.byte.tif\` (EPSG:32618) → EPSG:3857 with bilinear resampling; asserts the destination WKT contains a Web Mercator marker.

## Test plan

- [x] \`make build\` — green
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` (local, GeoServer 2.28.0) — green
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green