### PR TITLE
docs+test(convert): cloud-aware I/O reference + /vsimem/ unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ### Added
 
+- **`docs/conversions.md`** — full reference for the v1.2 conversion subsystem with vector + raster + reprojection examples and the cloud-I/O VFS matrix (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`). Linked from the README. (PR 5 of v1.2)
+- **README "Conversion" section** — top-level overview pointing at `docs/conversions.md`. (PR 5 of v1.2)
+- **`/vsimem/` destination unit test** for `ConvertVector` — proves the cloud-aware I/O works in-process without network or filesystem write. (PR 5 of v1.2)
+
 - **`ReprojectRaster(ctx, src, dst, srcSRS, dstSRS, opts...) error`** — raster reprojection (the `gdalwarp` equivalent). Pairs with the EPSG:4326↔EPSG:3857 web-tile workflow but accepts any GDAL-friendly CRS. Reuses the `RasterConvertOption` type — chain with `WithRasterResamplingAlg`, `WithRasterTargetResolution`, `WithRasterCutline` for the typical "warp + clip" pipeline. Cutline support emits `-cutline` + `-cl` + `-crop_to_cutline`. (PR 4 of v1.2)
 - **`ConvertRaster(ctx, src, dst, opts...) error`** — generic raster format conversion (GeoTIFF → COG, GeoTIFF → PNG, band-subset, output-window). Thin wrapper around the C entry point behind `gdal_translate` (`gdal.Translate`). (PR 3 of v1.2)
 - **`ToCOG(ctx, src, dst, opts...) error`** — convenience wrapper that pre-fills `WithRasterFormat("COG")` plus sane defaults (`COMPRESS=DEFLATE`, `BLOCKSIZE=512`, `OVERVIEW_RESAMPLING=NEAREST`). Caller-supplied options override defaults — pass `WithRasterCreationOption("COMPRESS", "ZSTD")` to swap codecs. (PR 3 of v1.2)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It exists because the path from "I have a shapefile" to "I have a published GeoS
 - [Install](#install)
 - [Quick start](#quick-start)
 - [Worked example: publish a directory of GIS files](#worked-example-publish-a-directory-of-gis-files)
+- [Conversion](#conversion)
 - [Errors](#errors)
 - [Configuration](#configuration)
 - [Library use](#library-use)
@@ -115,6 +116,42 @@ make compose-test-down
 ```
 
 Same idea programmatically (the integration suite is a worked example — see [`publish_integration_test.go`](publish_integration_test.go) `TestPublishGeoJSON_EndToEnd_Integration`).
+
+## Conversion
+
+Beyond the publish pipeline, gismanager (since v1.2) ships a stateless conversion subsystem that mirrors GDAL's three command-line workhorses:
+
+| Function | Wraps | Use case |
+|---|---|---|
+| `ConvertVector` | `ogr2ogr` | format conversion + reproject + bbox clip + attribute filter + simplify |
+| `ConvertRaster` | `gdal_translate` | format conversion + band subset + output window |
+| `ToCOG` | `gdal_translate -of COG` | Cloud-Optimized GeoTIFF (sane defaults pre-applied) |
+| `ReprojectRaster` | `gdalwarp` | raster reprojection + cookie-cutter clip via cutline |
+
+All four are top-level package functions — no `*ManagerConfig` required — and accept `/vsi*/`-prefixed paths transparently (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`).
+
+```go
+// Vector: 4326 GeoJSON → 3857 GeoPackage, clipped to Africa, simplified.
+err := gismanager.ConvertVector(ctx, "world.geojson", "africa.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+    gismanager.WithVectorOverwrite(),
+    gismanager.WithVectorTargetSRS("EPSG:3857"),
+    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
+    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
+    gismanager.WithVectorSimplify(100),
+)
+
+// Raster: GeoTIFF → COG with the canonical defaults.
+err = gismanager.ToCOG(ctx, "scene.tif", "scene.cog.tif")
+
+// Raster reprojection: UTM → Web Mercator.
+err = gismanager.ReprojectRaster(ctx, "utm.tif", "wm.tif",
+    "EPSG:32618", "EPSG:3857",
+    gismanager.WithRasterResamplingAlg("bilinear"),
+)
+```
+
+Full reference, more examples, and the cloud-I/O matrix: [`docs/conversions.md`](docs/conversions.md).
 
 ## Errors
 

--- a/convert_vector_vsimem_test.go
+++ b/convert_vector_vsimem_test.go
@@ -1,0 +1,51 @@
+package gismanager_test
+
+// Note: this file lives under the _test.go non-integration build tag so it
+// runs in the unit suite. It exercises GDAL's /vsimem/ in-process VFS
+// (no network, no filesystem write) using a tracked legacy fixture as
+// the source and /vsimem/ as the destination — proving the conversion
+// surface is cloud-aware (any /vsi*/ prefix flows through).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestConvertVector_VsiMemDestination_Unit confirms ConvertVector accepts
+// a /vsimem/ destination path and the resulting in-process dataset is
+// readable. The source is the tracked legacy fixture so this test stays
+// in the unit suite (no `make fetch-testdata` prerequisite).
+func TestConvertVector_VsiMemDestination_Unit(t *testing.T) {
+	src := "./testdata/neighborhood_names_gis.geojson"
+	dst := "/vsimem/test_convert_vector.gpkg"
+	// /vsimem/ entries are freed when the test process exits; the
+	// lukeroth/gdal binding doesn't wrap VSIUnlink so we let GC + EOL
+	// cleanup handle it. WithVectorOverwrite() above makes the test
+	// re-runnable in -count=N mode.
+
+	if err := gismanager.ConvertVector(context.Background(), src, dst,
+		gismanager.WithVectorFormat("GPKG"),
+		gismanager.WithVectorOverwrite(),
+	); err != nil {
+		t.Fatalf("ConvertVector to /vsimem/: %v", err)
+	}
+
+	ds, err := gdal.OpenEx(dst, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open /vsimem/ destination: %v", err)
+	}
+	defer ds.Close()
+
+	layer := ds.LayerByIndex(0)
+	count, ok := layer.FeatureCount(true)
+	if !ok {
+		t.Fatal("feature count read failed")
+	}
+	if count == 0 {
+		t.Fatal("destination has zero features")
+	}
+}

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -1,0 +1,180 @@
+# Conversions
+
+`gismanager` v1.2 ships a small, stateless conversion subsystem covering
+the four most common GDAL/OGR operations:
+
+- **`ConvertVector`** — vector format conversion (the `ogr2ogr` equivalent)
+- **`ConvertRaster`** — raster format conversion (the `gdal_translate` equivalent)
+- **`ToCOG`** — Cloud-Optimized GeoTIFF generation (a thin wrapper over `ConvertRaster`)
+- **`ReprojectRaster`** — raster reprojection (the `gdalwarp` equivalent)
+
+Each is a top-level package function; none requires a `*ManagerConfig`.
+Configuration goes through functional options (`WithVector*` or
+`WithRaster*` modality prefix to avoid name collisions).
+
+## Vector conversion
+
+### Shapefile → GeoPackage
+
+```go
+err := gismanager.ConvertVector(ctx,
+    "/vsizip//data/countries.zip", // /vsizip/ for zipped Shapefile bundles
+    "/data/countries.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+    gismanager.WithVectorOverwrite(),
+)
+```
+
+### GeoJSON → GeoPackage with reprojection, bbox clip, and attribute filter
+
+```go
+err := gismanager.ConvertVector(ctx,
+    "/data/world.geojson",
+    "/data/africa_3857.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+    gismanager.WithVectorOverwrite(),
+    gismanager.WithVectorTargetSRS("EPSG:3857"),
+    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
+    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
+    gismanager.WithVectorSimplify(100),
+    gismanager.WithVectorLayerName("africa"),
+)
+```
+
+### Vector field selection
+
+```go
+err := gismanager.ConvertVector(ctx, src, dst,
+    gismanager.WithVectorFormat("FlatGeobuf"),
+    gismanager.WithVectorSelectFields("NAME", "POP_EST", "CONTINENT"),
+)
+```
+
+## Raster conversion
+
+### GeoTIFF → Cloud-Optimized GeoTIFF
+
+```go
+err := gismanager.ToCOG(ctx, "/data/scene.tif", "/data/scene.cog.tif")
+```
+
+`ToCOG` defaults to `COMPRESS=DEFLATE`, `BLOCKSIZE=512`,
+`OVERVIEW_RESAMPLING=NEAREST`. Override any of them by passing your own
+`WithRasterCreationOption`:
+
+```go
+err := gismanager.ToCOG(ctx, src, dst,
+    gismanager.WithRasterCreationOption("COMPRESS", "ZSTD"),
+    gismanager.WithRasterCreationOption("PREDICTOR", "2"),
+)
+```
+
+### GeoTIFF → PNG thumbnail
+
+```go
+err := gismanager.ConvertRaster(ctx, "/data/scene.tif", "/data/preview.png",
+    gismanager.WithRasterFormat("PNG"),
+    gismanager.WithRasterBands(1, 2, 3),
+)
+```
+
+### Raster reprojection (UTM → Web Mercator)
+
+```go
+err := gismanager.ReprojectRaster(ctx,
+    "/data/scene_utm.tif",
+    "/data/scene_3857.tif",
+    "EPSG:32618", "EPSG:3857",
+    gismanager.WithRasterFormat("GTiff"),
+    gismanager.WithRasterResamplingAlg("bilinear"),
+)
+```
+
+### Raster reprojection with cookie-cutter clipping
+
+```go
+err := gismanager.ReprojectRaster(ctx, src, dst,
+    "EPSG:4326", "EPSG:3857",
+    gismanager.WithRasterCutline("/data/aoi.geojson", "outline"),
+)
+```
+
+`WithRasterCutline` adds `-cutline` + `-cl` + `-crop_to_cutline` to the
+warp command — pixels outside the polygon become NoData and the output
+extent shrinks to the polygon's envelope.
+
+## Cloud I/O via GDAL Virtual File Systems
+
+All four conversion entry points pass paths straight through to GDAL,
+so any of GDAL's virtual file system prefixes work transparently:
+
+| Prefix | Source | Notes |
+|---|---|---|
+| `/vsis3/` | Amazon S3 | Set `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` env vars (or use the EC2/ECS instance role) |
+| `/vsigs/` | Google Cloud Storage | Set `GS_ACCESS_KEY_ID` + `GS_SECRET_ACCESS_KEY` or use ADC |
+| `/vsiaz/` | Azure Blob Storage | Set `AZURE_STORAGE_ACCOUNT` + `AZURE_STORAGE_ACCESS_KEY` |
+| `/vsicurl/` | Any HTTP/HTTPS URL | Read-only; supports range requests for COG / FlatGeobuf |
+| `/vsizip/` | A `.zip` archive | Required for zipped Shapefile bundles — bare `.zip` paths do NOT auto-prefix |
+| `/vsimem/` | In-process memory | Useful for tests and intermediate steps without disk I/O |
+
+### Example: read a remote COG from S3 and reproject locally
+
+```go
+err := gismanager.ReprojectRaster(ctx,
+    "/vsis3/satellite-archive/2024/scene.tif",
+    "/data/scene.local.tif",
+    "EPSG:32618", "EPSG:3857",
+)
+```
+
+### Example: convert a remote GeoJSON over HTTP
+
+```go
+err := gismanager.ConvertVector(ctx,
+    "/vsicurl/https://example.com/data/admin.geojson",
+    "/data/admin.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+    gismanager.WithVectorOverwrite(),
+)
+```
+
+### Example: in-memory pipeline with `/vsimem/`
+
+```go
+gismanager.ConvertVector(ctx,
+    "/vsimem/in.geojson",   // populated upstream via gdal.VSIFileFromMemBuffer
+    "/vsimem/out.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+)
+```
+
+## Error handling
+
+Every conversion entry point wraps GDAL's error in a `*GISError`. Branch
+on the sentinel to detect category:
+
+```go
+err := gismanager.ConvertVector(ctx, src, dst, opts...)
+if errors.Is(err, gismanager.ErrConvertFailed) {
+    var gerr *gismanager.GISError
+    if errors.As(err, &gerr) {
+        log.Printf("conversion %s failed: %v", gerr.Op, gerr.Cause)
+    }
+}
+```
+
+`gerr.Op` is one of `"ConvertVector"`, `"ConvertRaster"`, or
+`"ReprojectRaster"` (`ToCOG` delegates to `ConvertRaster` so it surfaces
+as `"ConvertRaster"`).
+
+## Known gaps
+
+- **Progress callbacks** — `lukeroth/gdal`'s utility wrappers don't
+  thread `pfnProgress` through. Long conversions are opaque from the Go
+  side. Tracked for v1.3 (needs an upstream patch).
+- **Cancellation mid-conversion** — `ctx` is honored at the function
+  boundary (before `OpenEx`), not inside the synchronous CGo call. A
+  conversion that's already running cannot be aborted.
+- **Unknown driver silent-pass** — see the doc comment on
+  `ConvertVector` and `ConvertRaster`. Pre-validate driver names if you
+  need a hard guarantee.


### PR DESCRIPTION
## Summary

PR 5 of the v1.2 conversion-feature series. Documentation and a single unit test that proves the conversion surface is cloud-aware.

- **New: \`docs/conversions.md\`** — full reference covering the v1.2 conversion API: vector + raster + reprojection examples, the cloud-I/O VFS matrix (\`/vsis3/\`, \`/vsicurl/\`, \`/vsimem/\`, \`/vsizip/\`, \`/vsigs/\`, \`/vsiaz/\`), and the known-gaps section (no progress callbacks, no mid-conversion ctx-cancel).
- **README "Conversion" section** — top-level discoverability for the new surface, with one-liner examples and a link to the full docs.
- **New: \`convert_vector_vsimem_test.go\`** — unit test that converts a tracked legacy fixture (\`testdata/neighborhood_names_gis.geojson\`) into \`/vsimem/test_convert_vector.gpkg\` and reads it back via \`gdal.OpenEx\`. No network, no filesystem write, no fetched-fixture dependency.

No new exported symbols.

## Test plan

- [x] \`make build\` — green
- [x] \`make test-unit\` — green (new \`TestConvertVector_VsiMemDestination_Unit\` passes)
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green