### PR TITLE
feat(cli): cmd/gisconvert binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ### Added
 
+- **`cmd/gisconvert`** — CLI counterpart to the v1.2 conversion library. Vector mode covers Shapefile/GeoJSON/GPKG/KML/FlatGeobuf format conversion plus reprojection, bbox clip, attribute filter, simplification, field-select, and layer rename. Raster mode covers GeoTIFF/COG/PNG/JPEG conversion, band subsetting, output windows, target resolution, COG shortcut (`-cog`), and reprojection (`-s-srs` + `-t-srs`) with cookie-cutter clipping (`-cutline`). Stdlib `flag` only — no new runtime deps. (PR 6 of v1.2)
+
 - **`docs/conversions.md`** — full reference for the v1.2 conversion subsystem with vector + raster + reprojection examples and the cloud-I/O VFS matrix (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`). Linked from the README. (PR 5 of v1.2)
 - **README "Conversion" section** — top-level overview pointing at `docs/conversions.md`. (PR 5 of v1.2)
 - **`/vsimem/` destination unit test** for `ConvertVector` — proves the cloud-aware I/O works in-process without network or filesystem write. (PR 5 of v1.2)

--- a/cmd/gisconvert/gisconvert.go
+++ b/cmd/gisconvert/gisconvert.go
@@ -1,0 +1,249 @@
+// Command gisconvert exposes gismanager's conversion subsystem as a CLI:
+// vector format conversion (the ogr2ogr equivalent), raster format
+// conversion (the gdal_translate equivalent), Cloud-Optimized GeoTIFF
+// generation, and raster reprojection (the gdalwarp equivalent).
+//
+// Usage:
+//
+//	gisconvert -mode vector -src in.shp -dst out.gpkg -format GPKG
+//	gisconvert -mode vector -src in.geojson -dst out.gpkg \
+//	    -t-srs EPSG:3857 -bbox -25,-40,60,40 -where "CONTINENT='Africa'"
+//	gisconvert -mode raster -src in.tif -dst out.png -format PNG -bands 1,2,3
+//	gisconvert -mode raster -src in.tif -dst out.cog.tif -cog
+//	gisconvert -mode raster -src in.tif -dst out.warp.tif \
+//	    -s-srs EPSG:32618 -t-srs EPSG:3857 -resample bilinear
+//
+// gisconvert is a thin shell over [gismanager.ConvertVector],
+// [gismanager.ConvertRaster], [gismanager.ToCOG], and
+// [gismanager.ReprojectRaster]. It uses the stdlib `flag` package — no
+// runtime dependency beyond the gismanager library itself.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		slog.Error("gisconvert", "err", err)
+		os.Exit(1)
+	}
+}
+
+// run is the entry point separated from main() so it can be tested
+// directly with arbitrary argument slices.
+func run(args []string) error {
+	fs := flag.NewFlagSet("gisconvert", flag.ContinueOnError)
+	mode := fs.String("mode", "", "conversion mode: 'vector' or 'raster'")
+	src := fs.String("src", "", "source path (file or /vsi*/-prefixed URL)")
+	dst := fs.String("dst", "", "destination path (file or /vsi*/-prefixed URL)")
+	format := fs.String("format", "", "output driver name (GPKG, GeoJSON, GTiff, COG, PNG, ...). When empty, GDAL infers from -dst extension.")
+
+	// Vector flags.
+	tSRS := fs.String("t-srs", "", "target SRS (e.g. EPSG:3857). Required for 'raster' mode reproject; optional for 'vector' mode reproject.")
+	sSRS := fs.String("s-srs", "", "source SRS override (rarely needed)")
+	bbox := fs.String("bbox", "", "bounding box 'minX,minY,maxX,maxY' (vector: source CRS, raster reproject: target CRS)")
+	where := fs.String("where", "", "OGR SQL WHERE filter, vector mode only")
+	simplify := fs.Float64("simplify", 0, "Douglas-Peucker simplification tolerance, vector mode only")
+	selectFields := fs.String("select", "", "comma-separated attribute fields to keep (vector mode only)")
+	layer := fs.String("layer", "", "destination layer name (vector mode only)")
+	overwrite := fs.Bool("overwrite", false, "overwrite the destination if it exists (vector mode only)")
+
+	// Raster flags.
+	bands := fs.String("bands", "", "comma-separated 1-based band indices to keep (raster mode only)")
+	resample := fs.String("resample", "", "resampling algorithm (near, bilinear, cubic, ...) (raster mode only)")
+	tr := fs.String("tr", "", "target resolution 'xRes,yRes' (raster mode only)")
+	cog := fs.Bool("cog", false, "raster shortcut: emit a Cloud-Optimized GeoTIFF using ToCOG defaults")
+	cutlineDS := fs.String("cutline", "", "vector dataset path used as a cookie-cutter for raster reprojection")
+	cutlineLayer := fs.String("cutline-layer", "", "layer name within -cutline (optional)")
+
+	// Repeated -co flags (creation options) for raster mode.
+	var cos rasterCreationOptions
+	fs.Var(&cos, "co", "raster creation option, KEY=VAL (repeatable)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *mode == "" || *src == "" || *dst == "" {
+		return errors.New("gisconvert: -mode, -src, and -dst are all required")
+	}
+
+	ctx := context.Background()
+	switch *mode {
+	case "vector":
+		return runVector(ctx, *src, *dst, *format, *sSRS, *tSRS, *bbox,
+			*where, *simplify, *selectFields, *layer, *overwrite)
+	case "raster":
+		return runRaster(ctx, *src, *dst, *format, *sSRS, *tSRS, *bbox,
+			*bands, *resample, *tr, *cog, *cutlineDS, *cutlineLayer, []string(cos))
+	default:
+		return fmt.Errorf("gisconvert: -mode must be 'vector' or 'raster', got %q", *mode)
+	}
+}
+
+func runVector(ctx context.Context, src, dst, format, sSRS, tSRS, bbox,
+	where string, simplify float64, selectFields, layer string, overwrite bool,
+) error {
+	opts := []gismanager.VectorConvertOption{}
+	if format != "" {
+		opts = append(opts, gismanager.WithVectorFormat(format))
+	}
+	if sSRS != "" {
+		opts = append(opts, gismanager.WithVectorSourceSRS(sSRS))
+	}
+	if tSRS != "" {
+		opts = append(opts, gismanager.WithVectorTargetSRS(tSRS))
+	}
+	if bbox != "" {
+		minX, minY, maxX, maxY, err := parseBBox(bbox)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, gismanager.WithVectorBoundingBox(minX, minY, maxX, maxY))
+	}
+	if where != "" {
+		opts = append(opts, gismanager.WithVectorWhere(where))
+	}
+	if simplify > 0 {
+		opts = append(opts, gismanager.WithVectorSimplify(simplify))
+	}
+	if selectFields != "" {
+		fields := strings.Split(selectFields, ",")
+		opts = append(opts, gismanager.WithVectorSelectFields(fields...))
+	}
+	if layer != "" {
+		opts = append(opts, gismanager.WithVectorLayerName(layer))
+	}
+	if overwrite {
+		opts = append(opts, gismanager.WithVectorOverwrite())
+	}
+	return gismanager.ConvertVector(ctx, src, dst, opts...)
+}
+
+func runRaster(ctx context.Context, src, dst, format, sSRS, tSRS, bbox,
+	bands, resample, tr string, cog bool,
+	cutlineDS, cutlineLayer string, creationOpts []string,
+) error {
+	opts := []gismanager.RasterConvertOption{}
+	if format != "" {
+		opts = append(opts, gismanager.WithRasterFormat(format))
+	}
+	for _, co := range creationOpts {
+		k, v, ok := strings.Cut(co, "=")
+		if !ok {
+			return fmt.Errorf("gisconvert: -co value %q must be KEY=VAL", co)
+		}
+		opts = append(opts, gismanager.WithRasterCreationOption(k, v))
+	}
+	if bbox != "" {
+		minX, minY, maxX, maxY, err := parseBBox(bbox)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, gismanager.WithRasterOutputBounds(minX, minY, maxX, maxY))
+	}
+	if bands != "" {
+		bs, err := parseBands(bands)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, gismanager.WithRasterBands(bs...))
+	}
+	if resample != "" {
+		opts = append(opts, gismanager.WithRasterResamplingAlg(resample))
+	}
+	if tr != "" {
+		xRes, yRes, err := parseRes(tr)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, gismanager.WithRasterTargetResolution(xRes, yRes))
+	}
+	if cutlineDS != "" {
+		opts = append(opts, gismanager.WithRasterCutline(cutlineDS, cutlineLayer))
+	}
+
+	// Reproject mode: both -s-srs and -t-srs supplied (or just -t-srs;
+	// gdalwarp can pick up the source SRS from the input).
+	if tSRS != "" {
+		if sSRS == "" {
+			return errors.New("gisconvert: raster reprojection requires both -s-srs and -t-srs")
+		}
+		return gismanager.ReprojectRaster(ctx, src, dst, sSRS, tSRS, opts...)
+	}
+
+	// COG shortcut.
+	if cog {
+		return gismanager.ToCOG(ctx, src, dst, opts...)
+	}
+
+	return gismanager.ConvertRaster(ctx, src, dst, opts...)
+}
+
+// parseBBox parses "minX,minY,maxX,maxY" into four float64s.
+func parseBBox(s string) (minX, minY, maxX, maxY float64, err error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return 0, 0, 0, 0, fmt.Errorf("gisconvert: -bbox must be minX,minY,maxX,maxY (4 floats), got %q", s)
+	}
+	floats := make([]float64, 4)
+	for i, p := range parts {
+		v, parseErr := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if parseErr != nil {
+			return 0, 0, 0, 0, fmt.Errorf("gisconvert: -bbox: bad float %q: %w", p, parseErr)
+		}
+		floats[i] = v
+	}
+	return floats[0], floats[1], floats[2], floats[3], nil
+}
+
+// parseBands parses "1,2,3" into []int.
+func parseBands(s string) ([]int, error) {
+	parts := strings.Split(s, ",")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		v, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			return nil, fmt.Errorf("gisconvert: -bands: bad int %q: %w", p, err)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// parseRes parses "xRes,yRes" into (x, y) float64s.
+func parseRes(s string) (xRes, yRes float64, err error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("gisconvert: -tr must be xRes,yRes, got %q", s)
+	}
+	xRes, err = strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("gisconvert: -tr xRes: %w", err)
+	}
+	yRes, err = strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("gisconvert: -tr yRes: %w", err)
+	}
+	return xRes, yRes, nil
+}
+
+// rasterCreationOptions implements flag.Value so users can pass `-co`
+// repeatedly to accumulate creation options.
+type rasterCreationOptions []string
+
+func (r *rasterCreationOptions) String() string { return strings.Join(*r, " ") }
+
+func (r *rasterCreationOptions) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}

--- a/cmd/gisconvert/main_test.go
+++ b/cmd/gisconvert/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBBox(t *testing.T) {
+	cases := []struct {
+		in   string
+		ok   bool
+		want [4]float64
+	}{
+		{"-25,-40,60,40", true, [4]float64{-25, -40, 60, 40}},
+		{" -180.5 , -90 , 180.5 , 90 ", true, [4]float64{-180.5, -90, 180.5, 90}},
+		{"1,2,3", false, [4]float64{}},
+		{"a,b,c,d", false, [4]float64{}},
+		{"", false, [4]float64{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			minX, minY, maxX, maxY, err := parseBBox(tc.in)
+			if !tc.ok {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want[0], minX)
+			assert.Equal(t, tc.want[1], minY)
+			assert.Equal(t, tc.want[2], maxX)
+			assert.Equal(t, tc.want[3], maxY)
+		})
+	}
+}
+
+func TestParseBands(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		got, err := parseBands("1,2,3")
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+	t.Run("with whitespace", func(t *testing.T) {
+		got, err := parseBands(" 1 , 2 , 3 ")
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+	t.Run("bad int", func(t *testing.T) {
+		_, err := parseBands("1,not-a-number,3")
+		assert.Error(t, err)
+	})
+}
+
+func TestParseRes(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		x, y, err := parseRes("30,30")
+		assert.NoError(t, err)
+		assert.Equal(t, 30.0, x)
+		assert.Equal(t, 30.0, y)
+	})
+	t.Run("non-square", func(t *testing.T) {
+		x, y, err := parseRes("0.0001,0.00005")
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0001, x)
+		assert.Equal(t, 0.00005, y)
+	})
+	t.Run("missing comma", func(t *testing.T) {
+		_, _, err := parseRes("30")
+		assert.Error(t, err)
+	})
+}
+
+func TestRasterCreationOptions_AccumulatesAcrossSet(t *testing.T) {
+	var r rasterCreationOptions
+	assert.NoError(t, r.Set("COMPRESS=DEFLATE"))
+	assert.NoError(t, r.Set("BLOCKSIZE=512"))
+	assert.NoError(t, r.Set("OVERVIEW_RESAMPLING=NEAREST"))
+	assert.Equal(t, []string{"COMPRESS=DEFLATE", "BLOCKSIZE=512", "OVERVIEW_RESAMPLING=NEAREST"}, []string(r))
+	// String() formats as space-joined for flag-help display.
+	assert.Equal(t, "COMPRESS=DEFLATE BLOCKSIZE=512 OVERVIEW_RESAMPLING=NEAREST", r.String())
+}
+
+func TestRun_RejectsMissingArgs(t *testing.T) {
+	t.Run("no mode", func(t *testing.T) {
+		err := run([]string{"-src", "in.shp", "-dst", "out.gpkg"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "-mode")
+	})
+	t.Run("no src", func(t *testing.T) {
+		err := run([]string{"-mode", "vector", "-dst", "out.gpkg"})
+		assert.Error(t, err)
+	})
+	t.Run("no dst", func(t *testing.T) {
+		err := run([]string{"-mode", "vector", "-src", "in.shp"})
+		assert.Error(t, err)
+	})
+	t.Run("unknown mode", func(t *testing.T) {
+		err := run([]string{"-mode", "satellite", "-src", "in", "-dst", "out"})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "-mode must be"))
+	})
+}
+
+func TestRun_RejectsRasterReprojectWithoutBothSRS(t *testing.T) {
+	// Only -t-srs supplied; gisconvert requires both -s-srs and -t-srs.
+	err := run([]string{
+		"-mode", "raster",
+		"-src", "in.tif",
+		"-dst", "out.tif",
+		"-t-srs", "EPSG:3857",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "-s-srs and -t-srs")
+}


### PR DESCRIPTION
## Summary

PR 6 of the v1.2 conversion-feature series. Ships \`cmd/gisconvert\`, the third gismanager binary — alongside \`cmd/gismanager\` (publish pipeline) and \`cmd/layerSchema\` (schema inspector). \`cmd/gisconvert\` is a thin shell over the v1.2 conversion library: \`ConvertVector\`, \`ConvertRaster\`, \`ToCOG\`, \`ReprojectRaster\`.

### Usage

\`\`\`sh
# Vector: format conversion
gisconvert -mode vector -src in.shp -dst out.gpkg -format GPKG -overwrite

# Vector: reproject + bbox + where + simplify + rename
gisconvert -mode vector -src in.geojson -dst out.gpkg \\
  -format GPKG -overwrite -t-srs EPSG:3857 \\
  -bbox -25,-40,60,40 -where \"CONTINENT='Africa'\" -layer africa

# Raster: GeoTIFF -> COG with defaults
gisconvert -mode raster -src in.tif -dst out.cog.tif -cog

# Raster: GeoTIFF -> PNG with band selection
gisconvert -mode raster -src in.tif -dst out.png -format PNG -bands 1,2,3

# Raster reprojection (UTM -> Web Mercator)
gisconvert -mode raster -src utm.tif -dst wm.tif \\
  -s-srs EPSG:32618 -t-srs EPSG:3857 -resample bilinear
\`\`\`

Stdlib \`flag\` only — no new runtime deps, matching the \`cmd/gismanager\` precedent.

### Tests

- \`parseBBox\` — 4-float parser, whitespace tolerance, bad-input rejection
- \`parseBands\` — comma-separated int slice + bad-int rejection
- \`parseRes\` — 2-float xRes,yRes parser + missing-comma rejection
- \`rasterCreationOptions\` — \`flag.Value\` accumulator across repeated \`-co\`
- \`run\` — rejects missing \`-mode\`/\`-src\`/\`-dst\`, unknown \`-mode\`, and raster reprojection requested with only one of \`-s-srs\` / \`-t-srs\`

### Smoke-tested end-to-end

Inside the dev container:

\`\`\`sh
gisconvert -mode vector \\
  -src ./testdata-fetched/ne_110m_admin_0_countries.geojson \\
  -dst /tmp/africa.gpkg -format GPKG -overwrite \\
  -t-srs EPSG:3857 -bbox -25,-40,60,40 \\
  -where \"CONTINENT='Africa'\" -layer africa
ogrinfo /tmp/africa.gpkg
# 1: africa
\`\`\`

## Test plan

- [x] \`make build\` — green (binary builds clean)
- [x] \`make test-unit\` — 9 new test cases all pass
- [x] \`make lint\` — 0 issues
- [x] End-to-end smoke test: real GeoJSON → reprojected GPKG via the CLI
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green