### PR TITLE
docs(readme,architecture): refresh stale v1.0 framing for v1.2 surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ gismanager is **context-first**: every exported method on `*Manager` takes `ctx 
 - **Never commit directly to `master`.** Always create a feature branch, push it, open a PR, wait for CI to go green, then squash-merge.
 - **Never add Claude (or any AI assistant) as a git co-author.** Do not append `Co-Authored-By: Claude ...` trailers. Commit messages are authored by the user only.
 - **Never commit planning markdowns** — design docs, revival plans, research notes belong in `~/.claude/plans/`, not in this repo.
-- **No panics in library code.** gismanager library code (root + `internal/`) must contain zero `panic(` calls. The two CLIs (`cmd/gismanager`, `cmd/layerSchema`) may panic at the entry point only when a config error is fatal.
+- **No panics in library code.** gismanager library code (root + `internal/`) must contain zero `panic(` calls. The three CLIs (`cmd/gismanager`, `cmd/layerSchema`, `cmd/gisconvert`) may panic at the entry point only when a config error is fatal.
 - **No new runtime dependencies** without prior discussion. The dependency surface is intentionally small: `lukeroth/gdal`, `lib/pq`, `hishamkaram/geoserver/v2`, `gopkg.in/yaml.v3`, stdlib.
 - **No `mholt/archiver`** — deprecated upstream; use `internal/zipx` (stdlib `archive/zip`).
 - **Don't auto-tag releases** and don't merge a PR with red or pending CI — both are explicit user actions.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ It exists because the path from "I have a shapefile" to "I have a published GeoS
 
 ## What this tool does
 
-Two CLI binaries plus a small Go library:
+Three CLI binaries plus a Go library covering two GIS workflows:
 
-- **`gismanager`** — full pipeline. Walks `source.path`, picks every supported GIS file, copies its layers into PostGIS via OGR's PostgreSQL driver, then publishes each PostGIS table as a GeoServer feature type. Idempotent: workspace, datastore, and feature-type creation all check existence first via the `geoserver/v2` client's `Get` + `errors.Is(err, geoserver.ErrNotFound)` idiom.
+- **`gismanager`** — full publish pipeline. Walks `source.path`, picks every supported GIS file, copies its layers into PostGIS via OGR's PostgreSQL driver, then publishes each PostGIS table as a GeoServer feature type. Idempotent: workspace, datastore, and feature-type creation all check existence first via the `geoserver/v2` client's `Get` + `errors.Is(err, geoserver.ErrNotFound)` idiom.
 - **`layerSchema`** — read-only schema inspector. Walks `source.path`, opens each GIS file via GDAL, and prints the geometry column + attribute fields for every layer it finds. No PostGIS, no GeoServer.
-- **`package gismanager`** — the same flow as a Go library. Construct a `*ManagerConfig` (today via `gismanager.FromConfig(yamlPath)`; functional-options constructor planned), then call `OpenSource` / `LayerToPostgis` / `PublishGeoserverLayer` directly.
+- **`gisconvert`** *(v1.2+)* — data-conversion CLI: vector format conversion (`ogr2ogr` equivalent), raster format conversion (`gdal_translate` equivalent), Cloud-Optimized GeoTIFF generation, and raster reprojection (`gdalwarp` equivalent). See [Conversion](#conversion).
+- **`package gismanager`** — both flows as a Go library:
+  - **Publish**: construct a `*ManagerConfig` via `gismanager.New(opts ...Option)` (functional-options) or the YAML-driven `gismanager.FromConfig(yamlPath)`, then call `Walk` / `PublishAll` or the lower-level `OpenSource` / `LayerToPostgis` / `PublishGeoserverLayer` primitives.
+  - **Convert** *(v1.2+)*: stateless `ConvertVector` / `ConvertRaster` / `ToCOG` / `ReprojectRaster` package functions. No `*ManagerConfig` required.
 
 ### Supported source formats
 
@@ -205,6 +208,8 @@ A working config used by the integration suite lives at [`testdata/test_config.y
 
 ## Library use
 
+### Publish pipeline
+
 ```go
 import (
     "context"
@@ -248,6 +253,33 @@ func main() {
 ```
 
 > **Resource lifecycle:** `*gdal.DataSource` returned by `OpenSource` owns a CGo-side handle that must be released via `.Destroy()` to avoid leaks. `Walk` and `PublishAll` do this automatically (`defer source.Destroy()` per file). Direct callers of `OpenSource` are responsible for calling `Destroy()` themselves — the binding has no `Close()` method; `Destroy()` is the canonical release primitive in `lukeroth/gdal`.
+
+### Conversion *(v1.2+)*
+
+The conversion entry points are top-level package functions — no `*ManagerConfig` required, no GeoServer/PostGIS state held.
+
+```go
+// Reproject + clip + filter + simplify in one call.
+err := gismanager.ConvertVector(ctx, "world.geojson", "africa.gpkg",
+    gismanager.WithVectorFormat("GPKG"),
+    gismanager.WithVectorOverwrite(),
+    gismanager.WithVectorTargetSRS("EPSG:3857"),
+    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
+    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
+    gismanager.WithVectorSimplify(100),
+)
+
+// Cloud-Optimized GeoTIFF with sane defaults.
+err = gismanager.ToCOG(ctx, "scene.tif", "scene.cog.tif")
+
+// UTM → Web Mercator with bilinear resampling.
+err = gismanager.ReprojectRaster(ctx, "utm.tif", "wm.tif",
+    "EPSG:32618", "EPSG:3857",
+    gismanager.WithRasterResamplingAlg("bilinear"),
+)
+```
+
+A complete 30-line program lives in [`examples/convert_pipeline/main.go`](examples/convert_pipeline/main.go); full reference and the cloud-I/O VFS matrix in [`docs/conversions.md`](docs/conversions.md).
 
 ## Version compatibility
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,14 +35,16 @@ The package wires the three together with a `*ManagerConfig` that holds the GeoS
 |---|---|
 | `github.com/hishamkaram/gismanager` | Public API — `*ManagerConfig`, `*GdalLayer`, `*GISError`, sentinels, public method receivers |
 | `github.com/hishamkaram/gismanager/internal/zipx` | stdlib `archive/zip` extractor with zip-slip rejection + per-entry size cap. Used to auto-extract zipped shapefile bundles before the OGR open. Internal — not importable |
-| `github.com/hishamkaram/gismanager/cmd/gismanager` | Full-pipeline CLI |
+| `github.com/hishamkaram/gismanager/cmd/gismanager` | Full publish-pipeline CLI |
 | `github.com/hishamkaram/gismanager/cmd/layerSchema` | Read-only schema-printing CLI |
+| `github.com/hishamkaram/gismanager/cmd/gisconvert` | v1.2+ conversion CLI (`ogr2ogr` / `gdal_translate` / `gdalwarp` / COG) |
+| `github.com/hishamkaram/gismanager/examples/convert_pipeline` | 30-line worked example of `ConvertVector` with reproject + clip + filter |
 
 A single Go module at the repo root. No `/v2` semantic-import-versioning suffix because gismanager has no released versions to preserve — v1.0.0 is the first stable tag.
 
 ## Public API
 
-The lead type is `*ManagerConfig` (currently constructed from YAML via `gismanager.FromConfig(path)`; functional-options constructor planned). Methods:
+The lead type is `*ManagerConfig`, constructed via `gismanager.New(opts ...Option)` (functional options — `WithLogger`, `WithGeoserver`, `WithDatastore`, `WithSource`) or the YAML-driven `gismanager.FromConfig(path)`. Methods:
 
 ```go
 // Build a v2 GeoServer client from the configured endpoint + credentials.
@@ -70,6 +72,29 @@ func (m *ManagerConfig) PublishAll(ctx context.Context) error
 // advances; replaces the deprecated GetFeatures() []*gdal.Feature shape.
 func (l *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature]
 ```
+
+### Conversion subsystem (v1.2+)
+
+A second, **stateless** surface alongside the publish pipeline. No `*ManagerConfig` required — these are top-level package functions that wrap GDAL's three command-line workhorses:
+
+```go
+// Vector format conversion + reproject + filter + simplify (ogr2ogr equivalent).
+func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOption) error
+
+// Raster format conversion (gdal_translate equivalent).
+func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterConvertOption) error
+
+// Cloud-Optimized GeoTIFF — thin convenience over ConvertRaster with sane defaults.
+func ToCOG(ctx context.Context, src, dst string, opts ...RasterConvertOption) error
+
+// Raster reprojection (gdalwarp equivalent), with optional cookie-cutter clipping
+// via WithRasterCutline.
+func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterConvertOption) error
+```
+
+Options use a modality prefix (`WithVector*` / `WithRaster*`) to avoid name collisions in the same package. Each helper renders to a single `ogr2ogr` / `gdal_translate` / `gdalwarp` CLI flag — the `buildVectorTranslateArgs` / `buildTranslateArgs` / `buildWarpArgs` renderers are unit-tested separately so the mapping is locked in without needing CGo. Errors are wrapped with `ErrConvertFailed`; the `GISError.Op` field disambiguates the entry point.
+
+All conversion entry points pass paths transparently to GDAL, so any `/vsi*/` prefix (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`) works without special handling. Full reference: [`conversions.md`](conversions.md).
 
 All methods that can fail return errors wrapping a sentinel from [`../errors.go`](../errors.go) — see the README's [Errors](../README.md#errors) section for the matching idiom.
 


### PR DESCRIPTION
## Summary

Catches three stale spots that PR #22 (docs/conversions.md + README \"Conversion\" section) and PR #24 (CHANGELOG consolidation) didn't pick up:

- **README \"What this tool does\"** still said \"Two CLI binaries\" and \"functional-options constructor planned\". Both outdated — v1.1.0 shipped \`New()\` and v1.2.0 added \`cmd/gisconvert\`. Now describes three CLIs + two workflows (publish + convert).
- **README \"Library use\"** only showed the publish flow. Now has a \"Conversion (v1.2+)\" subsection with 3 examples mirroring \`docs/conversions.md\`.
- **\`docs/architecture.md\`**:
  - Package-shape table now lists \`cmd/gisconvert\` and \`examples/convert_pipeline\`.
  - \"Public API\" prose updated for v1.1's \`New()\` constructor.
  - New \"Conversion subsystem (v1.2+)\" section documenting the stateless top-level entry points.
- **\`CLAUDE.md\`** \"No panics\" rule: three CLIs, not two.

This is documentation only — no code or test changes.

## Test plan

- [x] \`make build\` — green (no code changes)
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green