### PR TITLE
docs(readme): clarify supported formats per surface (publish vs convert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,29 @@ Three CLI binaries plus a Go library covering two GIS workflows:
 
 ### Supported source formats
 
-Driven by GDAL's OGR drivers; whatever GDAL can read, gismanager can ingest. The currently dispatched extensions:
+The two surfaces have different reach.
 
-| Extension | Driver |
+#### Publish pipeline (`cmd/gismanager`, `Walk`, `PublishAll`)
+
+Driven by an explicit extension allowlist in [`vars.go::supportedEXT`](vars.go) — only these extensions are picked up by directory walks:
+
+| Extension | OGR driver |
 |---|---|
 | `.shp`, `.zip` (zipped shapefile bundle) | ESRI Shapefile |
 | `.geojson`, `.json` | GeoJSON |
 | `.gpkg` | GeoPackage |
 | `.kml` | KML |
 
-Zipped shapefile bundles are auto-extracted into a temp directory before the OGR open — see [`internal/zipx`](internal/zipx) for the stdlib `archive/zip`-based extractor (zip-slip rejection, 2 GiB per-entry cap).
+Zipped shapefile bundles are auto-extracted into a temp directory before the OGR open — see [`internal/zipx`](internal/zipx) for the stdlib `archive/zip`-based extractor (zip-slip rejection, 2 GiB per-entry cap). Adding a new extension to the publish pipeline means adding a row to `supportedEXT` and a switch case in [`manager.go::GetDriver`](manager.go).
+
+#### Conversion entry points *(v1.2+, `cmd/gisconvert`, `ConvertVector` / `ConvertRaster` / `ToCOG` / `ReprojectRaster`)*
+
+No allowlist — the conversion functions delegate straight to GDAL's full driver registry via `gdal.OpenEx`. Whatever the underlying GDAL build can read or write, the conversion entry points accept. In the project's dev image (`ghcr.io/osgeo/gdal:ubuntu-small-3.12.4`) that includes the obvious workhorses:
+
+- **Vector** (OGR): Shapefile, GeoPackage, GeoJSON, FlatGeobuf, KML, GML, GPX, MapInfo TAB/MIF, CSV (with WKT/lon-lat geometry), DGN, S-57, PostgreSQL/PostGIS, plus the cloud-native paths via VFS (`/vsis3/`, `/vsicurl/`, `/vsizip/`, `/vsimem/`, …).
+- **Raster** (GDAL): GeoTIFF, Cloud-Optimized GeoTIFF, JP2/OpenJPEG, PNG, JPEG, NITF, HFA (Erdas .img), VRT, plus the same VFS paths.
+
+For an authoritative list against any GDAL build, run `ogrinfo --formats` (vector) and `gdalinfo --formats` (raster) inside the dev container — driver compile-time inclusion varies across GDAL builds, and the dev image is the supported baseline.
 
 ## Install
 


### PR DESCRIPTION
## Summary

You flagged that the README's \"Supported source formats\" table only described the publish pipeline's extension allowlist and said nothing about what the v1.2 conversion entry points accept. This PR splits the section into two:

- **Publish pipeline** (\`cmd/gismanager\`, \`Walk\`, \`PublishAll\`): the existing 4-extension allowlist (\`vars.go::supportedEXT\`). Now also points readers at \`vars.go\` + \`manager.go::GetDriver\` as the add-a-format extension point.
- **Conversion entry points** *(v1.2+, \`cmd/gisconvert\`, \`ConvertVector\`, \`ConvertRaster\`, \`ToCOG\`, \`ReprojectRaster\`)*: no allowlist. Lists the OGR + GDAL workhorses available in the dev image's GDAL build (verified via \`ogrinfo --formats\` / \`gdalinfo --formats\` inside the container) and points callers at those commands as the authoritative answer.

Documentation only — no code or test changes.

## Test plan

- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green