### PR TITLE
feat(convert): Rasterize (vector → raster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ## [Unreleased]
 
+### Added
+
+- **`Rasterize(ctx, vectorSrc, rasterDst, opts...) error`** — vector → raster (the `gdal_rasterize` equivalent). Burn constant values via `WithRasterizeBurnValues` or per-feature attribute values via `WithRasterizeAttribute`; control output via `WithRasterizeFormat` / `WithRasterizeOutputType` / `WithRasterizeTargetResolution` / `WithRasterizeOutputSize` / `WithRasterizeOutputBounds` / `WithRasterizeLayer` / `WithRasterizeWhere` / `WithRasterizeCreationOption` / `WithRasterizeRawOptions`. Errors wrap `ErrConvertFailed` with `Op="Rasterize"`. (PR 1 of v1.3)
+
 ## [1.2.0] — 2026-05-05
 
 ### Context

--- a/convert_rasterize.go
+++ b/convert_rasterize.go
@@ -1,0 +1,238 @@
+package gismanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/lukeroth/gdal"
+)
+
+// RasterizeOption configures a [Rasterize] call. Construct via the
+// [WithRasterize*] helpers below; pass any number of options in any
+// order. Each helper mutates a private config struct; nil options are
+// tolerated.
+type RasterizeOption func(*rasterizeConfig)
+
+type rasterizeConfig struct {
+	logger          *slog.Logger
+	format          string
+	burnValues      []float64
+	attribute       string
+	targetResX      float64
+	targetResY      float64
+	hasTargetRes    bool
+	extent          *rasterBounds
+	sizeX           int
+	sizeY           int
+	hasSize         bool
+	layer           string
+	where           string
+	creationOptions []string
+	outputType      string
+	rawOptions      []string
+}
+
+func newRasterizeConfig(opts []RasterizeOption) *rasterizeConfig {
+	c := &rasterizeConfig{logger: GetLogger()}
+	for _, o := range opts {
+		if o != nil {
+			o(c)
+		}
+	}
+	return c
+}
+
+// WithRasterizeLogger sets the structured logger used during rasterization.
+// nil falls back to [GetLogger].
+func WithRasterizeLogger(l *slog.Logger) RasterizeOption {
+	return func(c *rasterizeConfig) {
+		if l == nil {
+			c.logger = GetLogger()
+			return
+		}
+		c.logger = l
+	}
+}
+
+// WithRasterizeFormat selects the output GDAL driver by name (e.g.
+// "GTiff", "COG", "PNG"). Maps to gdal_rasterize's `-of`. When empty,
+// GDAL infers from the destination path.
+func WithRasterizeFormat(driver string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.format = driver }
+}
+
+// WithRasterizeBurnValues sets per-band burn values. One value per
+// output band. Mutually exclusive with [WithRasterizeAttribute] —
+// callers should use one or the other. Maps to repeated `-burn`.
+func WithRasterizeBurnValues(values ...float64) RasterizeOption {
+	return func(c *rasterizeConfig) { c.burnValues = append([]float64(nil), values...) }
+}
+
+// WithRasterizeAttribute burns the named attribute field's value into
+// the raster (numeric attributes only). Mutually exclusive with
+// [WithRasterizeBurnValues]. Maps to `-a`.
+func WithRasterizeAttribute(name string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.attribute = name }
+}
+
+// WithRasterizeTargetResolution sets the output pixel size in target-CRS
+// units. Maps to `-tr xRes yRes`. Mutually exclusive with
+// [WithRasterizeOutputSize].
+func WithRasterizeTargetResolution(xRes, yRes float64) RasterizeOption {
+	return func(c *rasterizeConfig) {
+		c.targetResX = xRes
+		c.targetResY = yRes
+		c.hasTargetRes = true
+	}
+}
+
+// WithRasterizeOutputSize sets the output dimensions in pixels. Maps
+// to `-ts`. Mutually exclusive with [WithRasterizeTargetResolution].
+func WithRasterizeOutputSize(xSize, ySize int) RasterizeOption {
+	return func(c *rasterizeConfig) {
+		c.sizeX = xSize
+		c.sizeY = ySize
+		c.hasSize = true
+	}
+}
+
+// WithRasterizeOutputBounds restricts the output to the given bounding
+// box in the *source* CRS units. Maps to `-te xmin ymin xmax ymax`.
+// When omitted, GDAL uses the source layer's extent.
+func WithRasterizeOutputBounds(minX, minY, maxX, maxY float64) RasterizeOption {
+	return func(c *rasterizeConfig) {
+		c.extent = &rasterBounds{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
+	}
+}
+
+// WithRasterizeLayer picks one named layer from a multi-layer source
+// (e.g. a GeoPackage). Default is to rasterize all layers, which can
+// produce unexpected output when the source has more than one layer.
+// Maps to `-l`.
+func WithRasterizeLayer(name string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.layer = name }
+}
+
+// WithRasterizeWhere applies an OGR SQL WHERE filter to the source
+// features (without the WHERE keyword). Maps to `-where`.
+func WithRasterizeWhere(sql string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.where = sql }
+}
+
+// WithRasterizeCreationOption appends a single driver-specific
+// creation option (e.g. "COMPRESS=DEFLATE"). May be called multiple
+// times. Maps to repeated `-co KEY=VAL`.
+func WithRasterizeCreationOption(key, val string) RasterizeOption {
+	return func(c *rasterizeConfig) {
+		c.creationOptions = append(c.creationOptions, fmt.Sprintf("%s=%s", key, val))
+	}
+}
+
+// WithRasterizeOutputType sets the output pixel data type (e.g.
+// "Byte", "UInt16", "Float32"). Maps to `-ot`.
+func WithRasterizeOutputType(t string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.outputType = t }
+}
+
+// WithRasterizeRawOptions appends raw `gdal_rasterize`-style flag
+// tokens to the generated argument list. Use this to reach flags
+// the typed helpers do not expose (e.g. `-init`, `-a_nodata`,
+// `-add`).
+func WithRasterizeRawOptions(args ...string) RasterizeOption {
+	return func(c *rasterizeConfig) { c.rawOptions = append(c.rawOptions, args...) }
+}
+
+// Rasterize burns the vector geometries from vectorSrc into the raster
+// destination at rasterDst. Thin wrapper around the GDAL C entry
+// point behind `gdal_rasterize` ([gdal.Rasterize]).
+//
+// Pick one of [WithRasterizeBurnValues] (constant value per band) or
+// [WithRasterizeAttribute] (per-feature value from an attribute field).
+// Without either, GDAL defaults to burning value 255 into a single
+// band — almost certainly not what callers want; the binding does
+// not error in that case.
+//
+// Pick one of [WithRasterizeTargetResolution] (pixel size in CRS
+// units) or [WithRasterizeOutputSize] (pixel dimensions). Without
+// either, GDAL chooses an arbitrary 256x256 default.
+//
+// Errors are wrapped with [ErrConvertFailed]; recover via
+// [errors.As] into [*GISError]. The Op field is "Rasterize".
+//
+// Same binding gaps documented on [ConvertVector] apply: ctx is
+// honored only at the function boundary, and the underlying CGo call
+// is synchronous.
+func Rasterize(ctx context.Context, vectorSrc, rasterDst string, opts ...RasterizeOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg := newRasterizeConfig(opts)
+
+	srcDS, err := gdal.OpenEx(vectorSrc, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		cfg.logger.Error("Rasterize: open source", "src", vectorSrc, "err", err)
+		return newGISError("Rasterize", vectorSrc, ErrConvertFailed, err)
+	}
+	defer srcDS.Close()
+
+	args := buildRasterizeArgs(cfg)
+	cfg.logger.Debug("Rasterize: invoking",
+		"src", vectorSrc, "dst", rasterDst, "args", args)
+
+	out, rErr := gdal.Rasterize(rasterDst, srcDS, args)
+	if rErr != nil {
+		return newGISError("Rasterize", fmt.Sprintf("%s -> %s", vectorSrc, rasterDst),
+			ErrConvertFailed, rErr)
+	}
+	out.Close()
+	return nil
+}
+
+// buildRasterizeArgs renders cfg into the []string gdal_rasterize-style
+// argument list. Unit-tested separately so the option->arg mapping is
+// locked in without CGo.
+func buildRasterizeArgs(cfg *rasterizeConfig) []string {
+	var args []string
+	if cfg.format != "" {
+		args = append(args, "-of", cfg.format)
+	}
+	if cfg.outputType != "" {
+		args = append(args, "-ot", cfg.outputType)
+	}
+	for _, v := range cfg.burnValues {
+		args = append(args, "-burn", formatFloat(v))
+	}
+	if cfg.attribute != "" {
+		args = append(args, "-a", cfg.attribute)
+	}
+	if cfg.layer != "" {
+		args = append(args, "-l", cfg.layer)
+	}
+	if cfg.where != "" {
+		args = append(args, "-where", cfg.where)
+	}
+	if cfg.hasTargetRes {
+		args = append(args, "-tr",
+			formatFloat(cfg.targetResX),
+			formatFloat(cfg.targetResY))
+	}
+	if cfg.hasSize {
+		args = append(args, "-ts",
+			strconv.Itoa(cfg.sizeX),
+			strconv.Itoa(cfg.sizeY))
+	}
+	if cfg.extent != nil {
+		args = append(args, "-te",
+			formatFloat(cfg.extent.MinX),
+			formatFloat(cfg.extent.MinY),
+			formatFloat(cfg.extent.MaxX),
+			formatFloat(cfg.extent.MaxY))
+	}
+	for _, co := range cfg.creationOptions {
+		args = append(args, "-co", co)
+	}
+	args = append(args, cfg.rawOptions...)
+	return args
+}

--- a/convert_rasterize_integration_test.go
+++ b/convert_rasterize_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package gismanager_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestRasterize_PolygonsToGeoTIFF_Integration burns the Africa subset
+// of Natural Earth countries into a 256x256 GeoTIFF mask. Asserts the
+// destination opens, has the expected dimensions, and has at least one
+// non-zero pixel (i.e. the burn actually wrote data).
+func TestRasterize_PolygonsToGeoTIFF_Integration(t *testing.T) {
+	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
+	dst := filepath.Join(t.TempDir(), "africa_mask.tif")
+
+	if err := gismanager.Rasterize(context.Background(), src, dst,
+		gismanager.WithRasterizeFormat("GTiff"),
+		gismanager.WithRasterizeOutputType("Byte"),
+		gismanager.WithRasterizeBurnValues(1.0),
+		gismanager.WithRasterizeWhere("CONTINENT = 'Africa'"),
+		// Africa-ish bbox in 4326.
+		gismanager.WithRasterizeOutputBounds(-25, -40, 60, 40),
+		gismanager.WithRasterizeOutputSize(256, 256),
+		gismanager.WithRasterizeCreationOption("COMPRESS", "DEFLATE"),
+	); err != nil {
+		t.Fatalf("Rasterize: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	if got := dsOut.RasterXSize(); got != 256 {
+		t.Errorf("RasterXSize = %d, want 256", got)
+	}
+	if got := dsOut.RasterYSize(); got != 256 {
+		t.Errorf("RasterYSize = %d, want 256", got)
+	}
+	if dsOut.Driver().ShortName() != "GTiff" {
+		t.Errorf("expected GTiff driver, got %q", dsOut.Driver().ShortName())
+	}
+}
+
+// TestRasterize_AttributeBurn_Integration burns the POP_EST attribute
+// (population estimate) from the source features instead of a fixed
+// constant. Asserts the destination is a Float32 raster (population
+// counts don't fit in a Byte).
+func TestRasterize_AttributeBurn_Integration(t *testing.T) {
+	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
+	dst := filepath.Join(t.TempDir(), "pop_attr.tif")
+
+	if err := gismanager.Rasterize(context.Background(), src, dst,
+		gismanager.WithRasterizeFormat("GTiff"),
+		gismanager.WithRasterizeOutputType("Float32"),
+		gismanager.WithRasterizeAttribute("POP_EST"),
+		gismanager.WithRasterizeOutputSize(360, 180),
+	); err != nil {
+		t.Fatalf("Rasterize: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	if dsOut.RasterCount() == 0 {
+		t.Fatal("destination has no raster bands")
+	}
+}

--- a/convert_rasterize_test.go
+++ b/convert_rasterize_test.go
@@ -1,0 +1,145 @@
+package gismanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildRasterizeArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []RasterizeOption
+		want []string
+	}{
+		{
+			name: "empty config yields empty args",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "format + output type",
+			opts: []RasterizeOption{
+				WithRasterizeFormat("GTiff"),
+				WithRasterizeOutputType("Byte"),
+			},
+			want: []string{"-of", "GTiff", "-ot", "Byte"},
+		},
+		{
+			name: "burn values emit one -burn per value",
+			opts: []RasterizeOption{
+				WithRasterizeBurnValues(1.0, 2.5, 3.75),
+			},
+			want: []string{"-burn", "1", "-burn", "2.5", "-burn", "3.75"},
+		},
+		{
+			name: "attribute field",
+			opts: []RasterizeOption{WithRasterizeAttribute("HEIGHT")},
+			want: []string{"-a", "HEIGHT"},
+		},
+		{
+			name: "layer + where filter",
+			opts: []RasterizeOption{
+				WithRasterizeLayer("admin"),
+				WithRasterizeWhere("CONTINENT = 'Africa'"),
+			},
+			want: []string{"-l", "admin", "-where", "CONTINENT = 'Africa'"},
+		},
+		{
+			name: "target resolution",
+			opts: []RasterizeOption{WithRasterizeTargetResolution(0.01, 0.01)},
+			want: []string{"-tr", "0.01", "0.01"},
+		},
+		{
+			name: "output size in pixels",
+			opts: []RasterizeOption{WithRasterizeOutputSize(512, 512)},
+			want: []string{"-ts", "512", "512"},
+		},
+		{
+			name: "output bounds (-te in source CRS)",
+			opts: []RasterizeOption{
+				WithRasterizeOutputBounds(-180, -90, 180, 90),
+			},
+			want: []string{"-te", "-180", "-90", "180", "90"},
+		},
+		{
+			name: "creation options preserve order",
+			opts: []RasterizeOption{
+				WithRasterizeCreationOption("COMPRESS", "DEFLATE"),
+				WithRasterizeCreationOption("TILED", "YES"),
+			},
+			want: []string{"-co", "COMPRESS=DEFLATE", "-co", "TILED=YES"},
+		},
+		{
+			name: "raw options append at end",
+			opts: []RasterizeOption{
+				WithRasterizeFormat("GTiff"),
+				WithRasterizeRawOptions("-init", "0", "-a_nodata", "255"),
+			},
+			want: []string{"-of", "GTiff", "-init", "0", "-a_nodata", "255"},
+		},
+		{
+			name: "full pipeline: format + ot + attr + layer + where + tr + te + co",
+			opts: []RasterizeOption{
+				WithRasterizeFormat("GTiff"),
+				WithRasterizeOutputType("Float32"),
+				WithRasterizeAttribute("ELEV"),
+				WithRasterizeLayer("contours"),
+				WithRasterizeWhere("ELEV > 0"),
+				WithRasterizeTargetResolution(0.001, 0.001),
+				WithRasterizeOutputBounds(-10, -10, 10, 10),
+				WithRasterizeCreationOption("COMPRESS", "ZSTD"),
+			},
+			want: []string{
+				"-of", "GTiff",
+				"-ot", "Float32",
+				"-a", "ELEV",
+				"-l", "contours",
+				"-where", "ELEV > 0",
+				"-tr", "0.001", "0.001",
+				"-te", "-10", "-10", "10", "10",
+				"-co", "COMPRESS=ZSTD",
+			},
+		},
+		{
+			name: "nil options tolerated",
+			opts: []RasterizeOption{nil, WithRasterizeFormat("GTiff"), nil},
+			want: []string{"-of", "GTiff"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newRasterizeConfig(tc.opts)
+			got := buildRasterizeArgs(cfg)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWithRasterizeLogger_NilFallsBackToDefault(t *testing.T) {
+	cfg := newRasterizeConfig([]RasterizeOption{WithRasterizeLogger(nil)})
+	assert.NotNil(t, cfg.logger)
+}
+
+func TestRasterize_CtxCancelledFailsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Rasterize(ctx, "ignored.geojson", "ignored.tif")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestRasterize_OpenError_WrapsErrConvertFailed(t *testing.T) {
+	err := Rasterize(context.Background(),
+		"./testdata/__definitely_does_not_exist__.geojson",
+		"/tmp/should_not_be_created.tif")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConvertFailed))
+
+	var gerr *GISError
+	assert.True(t, errors.As(err, &gerr))
+	assert.Equal(t, "Rasterize", gerr.Op)
+}


### PR DESCRIPTION
## Summary

PR 1 of the v1.3 series. Ships **\`Rasterize\`** — the \`gdal_rasterize\` equivalent. Burn vector geometries into a raster grid, either with constant burn values or per-feature attribute values.

### New public surface

\`\`\`go
func Rasterize(ctx context.Context, vectorSrc, rasterDst string, opts ...RasterizeOption) error

// 12 WithRasterize* helpers: Logger, Format, BurnValues, Attribute,
// TargetResolution, OutputSize, OutputBounds, Layer, Where,
// CreationOption, OutputType, RawOptions
\`\`\`

Mirrors the v1.2 modality-prefix design (separate option type, \`With<Op>*\` prefix) for type-safe API + \`Op\`-disambiguation in \`*GISError\`.

### Implementation

Thin wrapper around \`gdal.Rasterize\` (utilities.go:216 in lukeroth/gdal). Each helper maps 1:1 to a CLI flag; \`buildRasterizeArgs\` is unit-tested separately.

### Tests

- **Unit (12 cases, table-driven)** — option → arg mapping
- **Unit** — logger nil fallback, ctx-canceled fast-fail, source-open error wrapped with \`ErrConvertFailed\` (\`Op=\"Rasterize\"\`)
- **Integration** — Africa countries → 256×256 Byte GeoTIFF mask via burn-value 1 + \`-where\` filter
- **Integration** — country \`POP_EST\` attribute → 360×180 Float32 raster

## Test plan

- [x] \`make build\` — green
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` (local, GeoServer 2.28.0) — green
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green