### PR TITLE
feat(convert): BuildVRT (multi-raster mosaic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ### Added
 
+- **`BuildVRT(ctx, dst, srcs, opts...) error`** — multi-raster mosaic into a Virtual Raster (the `gdalbuildvrt` equivalent). Useful for assembling tile pyramids from many GeoTIFFs, or stacking single-band inputs into RGBA via `WithVRTSeparate`. Options: `WithVRTLogger` / `WithVRTResolution` (highest|lowest|average|user) / `WithVRTUserResolution` / `WithVRTSeparate` / `WithVRTAddAlpha` / `WithVRTResamplingAlg` / `WithVRTSrcNoData` / `WithVRTNoData` / `WithVRTHideNoData` / `WithVRTBands` / `WithVRTAllowProjectionDifference` / `WithVRTRawOptions`. Errors wrap `ErrConvertFailed` with `Op="BuildVRT"`. (PR 2 of v1.3)
+
 - **`Rasterize(ctx, vectorSrc, rasterDst, opts...) error`** — vector → raster (the `gdal_rasterize` equivalent). Burn constant values via `WithRasterizeBurnValues` or per-feature attribute values via `WithRasterizeAttribute`; control output via `WithRasterizeFormat` / `WithRasterizeOutputType` / `WithRasterizeTargetResolution` / `WithRasterizeOutputSize` / `WithRasterizeOutputBounds` / `WithRasterizeLayer` / `WithRasterizeWhere` / `WithRasterizeCreationOption` / `WithRasterizeRawOptions`. Errors wrap `ErrConvertFailed` with `Op="Rasterize"`. (PR 1 of v1.3)
 
 ## [1.2.0] — 2026-05-05

--- a/convert_buildvrt.go
+++ b/convert_buildvrt.go
@@ -1,0 +1,232 @@
+package gismanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/lukeroth/gdal"
+)
+
+// VRTOption configures a [BuildVRT] call. Construct via the
+// [WithVRT*] helpers below; pass any number of options in any order.
+type VRTOption func(*vrtConfig)
+
+type vrtConfig struct {
+	logger        *slog.Logger
+	resolution    string  // -resolution highest|lowest|average|user
+	resX          float64 // -tr xRes yRes (only when resolution=user)
+	resY          float64
+	hasRes        bool
+	separate      bool   // -separate (each input becomes a band)
+	addAlpha      bool   // -addalpha
+	resampleAlg   string // -r
+	srcNoData     string // -srcnodata "VAL[,VAL2,...]"
+	vrtNoData     string // -vrtnodata
+	hideNoData    bool   // -hidenodata
+	bandList      []int  // -b
+	allowProjMisc bool   // -allow_projection_difference
+	rawOptions    []string
+}
+
+func newVRTConfig(opts []VRTOption) *vrtConfig {
+	c := &vrtConfig{logger: GetLogger()}
+	for _, o := range opts {
+		if o != nil {
+			o(c)
+		}
+	}
+	return c
+}
+
+// WithVRTLogger sets the structured logger used during VRT build.
+// nil falls back to [GetLogger].
+func WithVRTLogger(l *slog.Logger) VRTOption {
+	return func(c *vrtConfig) {
+		if l == nil {
+			c.logger = GetLogger()
+			return
+		}
+		c.logger = l
+	}
+}
+
+// WithVRTResolution selects how the VRT picks output resolution from
+// inputs of differing pixel sizes. Valid values: "highest", "lowest",
+// "average", "user". When "user", call [WithVRTUserResolution] too.
+// Maps to `-resolution`. Default GDAL behavior is "average".
+func WithVRTResolution(mode string) VRTOption {
+	return func(c *vrtConfig) { c.resolution = mode }
+}
+
+// WithVRTUserResolution sets the explicit output pixel size. Only
+// effective when [WithVRTResolution] is "user". Maps to `-tr`.
+func WithVRTUserResolution(xRes, yRes float64) VRTOption {
+	return func(c *vrtConfig) {
+		c.resX = xRes
+		c.resY = yRes
+		c.hasRes = true
+	}
+}
+
+// WithVRTSeparate emits one VRT band per input dataset (instead of
+// stacking them into a tile mosaic). Useful for assembling RGBA from
+// single-band inputs. Maps to `-separate`.
+func WithVRTSeparate() VRTOption {
+	return func(c *vrtConfig) { c.separate = true }
+}
+
+// WithVRTAddAlpha appends an alpha band to the output indicating which
+// pixels are sourced from any input vs. NoData. Maps to `-addalpha`.
+func WithVRTAddAlpha() VRTOption {
+	return func(c *vrtConfig) { c.addAlpha = true }
+}
+
+// WithVRTResamplingAlg sets the resampling algorithm used when input
+// resolutions differ from the output. "near", "bilinear", "cubic", etc.
+// Maps to `-r`.
+func WithVRTResamplingAlg(alg string) VRTOption {
+	return func(c *vrtConfig) { c.resampleAlg = alg }
+}
+
+// WithVRTSrcNoData sets the NoData value(s) interpreted on the source
+// side, comma-separated for multi-band inputs. Maps to `-srcnodata`.
+func WithVRTSrcNoData(values string) VRTOption {
+	return func(c *vrtConfig) { c.srcNoData = values }
+}
+
+// WithVRTNoData sets the NoData value(s) emitted on the output VRT.
+// Maps to `-vrtnodata`.
+func WithVRTNoData(values string) VRTOption {
+	return func(c *vrtConfig) { c.vrtNoData = values }
+}
+
+// WithVRTHideNoData omits the NoData value from the output VRT
+// metadata so downstream readers treat those pixels as valid. Maps
+// to `-hidenodata`.
+func WithVRTHideNoData() VRTOption {
+	return func(c *vrtConfig) { c.hideNoData = true }
+}
+
+// WithVRTBands selects a subset of bands from each input. Maps to
+// repeated `-b N`.
+func WithVRTBands(bands ...int) VRTOption {
+	return func(c *vrtConfig) { c.bandList = append([]int(nil), bands...) }
+}
+
+// WithVRTAllowProjectionDifference relaxes the SRS-must-match check;
+// useful when assembling near-equivalent SRSes (different EPSG codes
+// resolving to identical projections). Maps to
+// `-allow_projection_difference`.
+func WithVRTAllowProjectionDifference() VRTOption {
+	return func(c *vrtConfig) { c.allowProjMisc = true }
+}
+
+// WithVRTRawOptions appends raw `gdalbuildvrt`-style flag tokens to the
+// generated argument list.
+func WithVRTRawOptions(args ...string) VRTOption {
+	return func(c *vrtConfig) { c.rawOptions = append(c.rawOptions, args...) }
+}
+
+// BuildVRT composes one or more raster inputs into a Virtual Raster
+// (VRT) at dst. Thin wrapper around the GDAL C entry point behind
+// `gdalbuildvrt` ([gdal.BuildVRT]).
+//
+// Use cases: assemble a tile pyramid from many individual GeoTIFFs;
+// stack single-band inputs into RGBA via [WithVRTSeparate]; build a
+// multi-resolution mosaic for downstream `Warp` / `Translate` calls.
+//
+// At least one source path is required. Each path is opened with
+// `gdal.OpenEx(OFRaster|OFReadOnly)` and closed when [BuildVRT]
+// returns.
+//
+// Errors are wrapped with [ErrConvertFailed]; recover via
+// [errors.As] into [*GISError]. The Op field is "BuildVRT".
+func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(srcs) == 0 {
+		return newGISError("BuildVRT", dst, ErrConvertFailed,
+			fmt.Errorf("at least one source path is required"))
+	}
+
+	cfg := newVRTConfig(opts)
+
+	// Pre-validate every source by opening it. GDALBuildVRT in path-mode
+	// silently skips unreadable paths with a stderr warning rather than
+	// returning a non-zero cerr — so without this loop, callers passing
+	// a typo-d path would get a non-nil result with a malformed VRT
+	// instead of a useful error. We close immediately; GDAL re-opens via
+	// its path-mode API. Acceptable cost for the much better error
+	// envelope.
+	for _, src := range srcs {
+		ds, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+		if err != nil {
+			cfg.logger.Error("BuildVRT: open source", "src", src, "err", err)
+			return newGISError("BuildVRT", src, ErrConvertFailed, err)
+		}
+		ds.Close()
+	}
+
+	// lukeroth/gdal's GDALBuildVRT wrapper has a quirk: it always
+	// indexes &sourceDS[0] (panics on empty slice) AND passes both the
+	// dataset list and the file-path list to the C function. The C API
+	// uses paths when papszSrcDSNames is non-NULL, ignoring the dataset
+	// list — so we let GDAL do the opens itself by passing srcs as the
+	// file-path arg, with a zero-value dataset slice of matching length
+	// to satisfy the binding's index guard.
+	zeroDS := make([]gdal.Dataset, len(srcs))
+
+	args := buildVRTArgs(cfg)
+	cfg.logger.Debug("BuildVRT: invoking",
+		"dst", dst, "srcs", srcs, "args", args)
+
+	out, vErr := gdal.BuildVRT(dst, zeroDS, srcs, args)
+	if vErr != nil {
+		return newGISError("BuildVRT", dst, ErrConvertFailed, vErr)
+	}
+	out.Close()
+	return nil
+}
+
+// buildVRTArgs renders cfg into the []string gdalbuildvrt-style
+// argument list. Unit-tested separately so the option->arg mapping is
+// locked in without CGo.
+func buildVRTArgs(cfg *vrtConfig) []string {
+	var args []string
+	if cfg.resolution != "" {
+		args = append(args, "-resolution", cfg.resolution)
+	}
+	if cfg.hasRes {
+		args = append(args, "-tr",
+			formatFloat(cfg.resX),
+			formatFloat(cfg.resY))
+	}
+	if cfg.separate {
+		args = append(args, "-separate")
+	}
+	if cfg.addAlpha {
+		args = append(args, "-addalpha")
+	}
+	if cfg.resampleAlg != "" {
+		args = append(args, "-r", cfg.resampleAlg)
+	}
+	if cfg.srcNoData != "" {
+		args = append(args, "-srcnodata", cfg.srcNoData)
+	}
+	if cfg.vrtNoData != "" {
+		args = append(args, "-vrtnodata", cfg.vrtNoData)
+	}
+	if cfg.hideNoData {
+		args = append(args, "-hidenodata")
+	}
+	for _, b := range cfg.bandList {
+		args = append(args, "-b", fmt.Sprintf("%d", b))
+	}
+	if cfg.allowProjMisc {
+		args = append(args, "-allow_projection_difference")
+	}
+	args = append(args, cfg.rawOptions...)
+	return args
+}

--- a/convert_buildvrt_integration_test.go
+++ b/convert_buildvrt_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package gismanager_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestBuildVRT_TwoGeoTIFFs_Integration assembles two GeoTIFF inputs into
+// a single VRT. Asserts the destination opens, has the same band count
+// as the inputs (default mode, not -separate), and covers the union
+// extent.
+func TestBuildVRT_TwoGeoTIFFs_Integration(t *testing.T) {
+	src1 := mustFetched(t, "RGB.byte.tif")
+	src2 := mustFetched(t, "cog.tif")
+	dst := filepath.Join(t.TempDir(), "mosaic.vrt")
+
+	if err := gismanager.BuildVRT(context.Background(), dst,
+		[]string{src1, src2},
+		gismanager.WithVRTResolution("highest"),
+		gismanager.WithVRTAllowProjectionDifference(),
+	); err != nil {
+		t.Fatalf("BuildVRT: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	if dsOut.RasterCount() == 0 {
+		t.Fatal("VRT has no raster bands")
+	}
+	if dsOut.Driver().ShortName() != "VRT" {
+		t.Errorf("expected VRT driver, got %q", dsOut.Driver().ShortName())
+	}
+}
+
+// TestBuildVRT_SeparateMode_Integration uses -separate to stack
+// single-input bands into a multi-band VRT (one band per input). With
+// two inputs we expect a 2-band-or-more VRT — exact count depends on
+// how -separate handles multi-band inputs (it actually flattens them).
+func TestBuildVRT_SeparateMode_Integration(t *testing.T) {
+	src1 := mustFetched(t, "RGB.byte.tif") // 3 bands
+	src2 := mustFetched(t, "cog.tif")      // typically 1 band
+	dst := filepath.Join(t.TempDir(), "stack.vrt")
+
+	if err := gismanager.BuildVRT(context.Background(), dst,
+		[]string{src1, src2},
+		gismanager.WithVRTSeparate(),
+		gismanager.WithVRTAllowProjectionDifference(),
+	); err != nil {
+		t.Fatalf("BuildVRT: %v", err)
+	}
+
+	dsOut, err := gdal.OpenEx(dst, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("open destination: %v", err)
+	}
+	defer dsOut.Close()
+
+	// In -separate mode, GDAL takes the first band of each input. We
+	// have 2 inputs → at least 2 bands.
+	if dsOut.RasterCount() < 2 {
+		t.Errorf("expected >= 2 bands in -separate mode, got %d", dsOut.RasterCount())
+	}
+}

--- a/convert_buildvrt_test.go
+++ b/convert_buildvrt_test.go
@@ -1,0 +1,131 @@
+package gismanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildVRTArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []VRTOption
+		want []string
+	}{
+		{
+			name: "empty config",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "resolution mode",
+			opts: []VRTOption{WithVRTResolution("highest")},
+			want: []string{"-resolution", "highest"},
+		},
+		{
+			name: "user resolution",
+			opts: []VRTOption{
+				WithVRTResolution("user"),
+				WithVRTUserResolution(30, 30),
+			},
+			want: []string{"-resolution", "user", "-tr", "30", "30"},
+		},
+		{
+			name: "separate emits one band per input",
+			opts: []VRTOption{WithVRTSeparate()},
+			want: []string{"-separate"},
+		},
+		{
+			name: "add alpha + resampling",
+			opts: []VRTOption{
+				WithVRTAddAlpha(),
+				WithVRTResamplingAlg("bilinear"),
+			},
+			want: []string{"-addalpha", "-r", "bilinear"},
+		},
+		{
+			name: "src + vrt nodata + hide",
+			opts: []VRTOption{
+				WithVRTSrcNoData("0,0,0"),
+				WithVRTNoData("255"),
+				WithVRTHideNoData(),
+			},
+			want: []string{
+				"-srcnodata", "0,0,0",
+				"-vrtnodata", "255",
+				"-hidenodata",
+			},
+		},
+		{
+			name: "band selection",
+			opts: []VRTOption{WithVRTBands(1, 2, 3)},
+			want: []string{"-b", "1", "-b", "2", "-b", "3"},
+		},
+		{
+			name: "allow projection difference",
+			opts: []VRTOption{WithVRTAllowProjectionDifference()},
+			want: []string{"-allow_projection_difference"},
+		},
+		{
+			name: "raw options append at end",
+			opts: []VRTOption{
+				WithVRTResolution("highest"),
+				WithVRTRawOptions("-input_file_list", "list.txt"),
+			},
+			want: []string{
+				"-resolution", "highest",
+				"-input_file_list", "list.txt",
+			},
+		},
+		{
+			name: "nil options tolerated",
+			opts: []VRTOption{nil, WithVRTResolution("average"), nil},
+			want: []string{"-resolution", "average"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newVRTConfig(tc.opts)
+			got := buildVRTArgs(cfg)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWithVRTLogger_NilFallsBackToDefault(t *testing.T) {
+	cfg := newVRTConfig([]VRTOption{WithVRTLogger(nil)})
+	assert.NotNil(t, cfg.logger)
+}
+
+func TestBuildVRT_CtxCancelledFailsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := BuildVRT(ctx, "ignored.vrt", []string{"a.tif"})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestBuildVRT_RejectsEmptySources(t *testing.T) {
+	err := BuildVRT(context.Background(), "/tmp/out.vrt", nil)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConvertFailed))
+
+	var gerr *GISError
+	assert.True(t, errors.As(err, &gerr))
+	assert.Equal(t, "BuildVRT", gerr.Op)
+}
+
+func TestBuildVRT_OpenError_WrapsErrConvertFailed(t *testing.T) {
+	err := BuildVRT(context.Background(),
+		"/tmp/should_not_be_created.vrt",
+		[]string{"./testdata/__definitely_does_not_exist__.tif"})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConvertFailed))
+
+	var gerr *GISError
+	assert.True(t, errors.As(err, &gerr))
+	assert.Equal(t, "BuildVRT", gerr.Op)
+}


### PR DESCRIPTION
## Summary

PR 2 of the v1.3 series. Ships **\`BuildVRT\`** — the \`gdalbuildvrt\` equivalent. Composes one or more raster inputs into a single Virtual Raster (VRT). Common uses: tile pyramid prep from many GeoTIFFs, RGBA stacking via \`-separate\`, mosaic-then-downstream-Warp/Translate workflows.

### New public surface

\`\`\`go
func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption) error

// 12 WithVRT* helpers: Logger, Resolution, UserResolution, Separate,
// AddAlpha, ResamplingAlg, SrcNoData, NoData, HideNoData, Bands,
// AllowProjectionDifference, RawOptions
\`\`\`

### Implementation note

\`lukeroth/gdal\`'s \`GDALBuildVRT\` wrapper has a quirk: it always indexes \`&sourceDS[0]\` (panics on empty slice) and passes BOTH the dataset list and the file-path list to the C function. The C API uses paths when \`papszSrcDSNames != NULL\`, so we:

1. Pre-validate every source via \`gdal.OpenEx\` + immediate \`Close\` — this gives a clean \`ErrConvertFailed\` envelope on bad paths instead of GDAL's silent \"Skipping it\" warning behavior.
2. Pass a zero-value dataset slice of matching length (satisfies the binding's index guard) plus the actual paths in the file-path arg.

GDAL manages the opens and the resulting VRT references files by path — the standard gdalbuildvrt CLI output shape.

### Tests

- **Unit (10 cases, table-driven)** — option → arg mapping
- **Unit** — logger nil fallback, ctx-canceled fast-fail, empty-sources rejection, source-open error wrapped with \`ErrConvertFailed\` (\`Op=\"BuildVRT\"\`)
- **Integration** — two GeoTIFFs → mosaic VRT (default mode, \`-resolution highest\`, \`-allow_projection_difference\`)
- **Integration** — \`-separate\` mode stacks the inputs into a multi-band VRT (>= 2 bands)

## Test plan

- [x] \`make build\` — green
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` (local, GeoServer 2.28.0) — green
- [x] \`make lint\` — 0 issues
- [ ] CI: lint + unit + integration matrix (2.27.4 + 2.28.0) green