### PR TITLE
refactor(publish): wrap ensure{Workspace,Datastore} errors as *GISError

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -38,6 +38,57 @@ func TestGISError_As(t *testing.T) {
 	}
 }
 
+// TestGISError_NestedChain locks in the contract for the nested-*GISError
+// chain produced by [PublishGeoserverLayer] when an
+// [ensureWorkspace] / [ensureDatastore] helper fails: each helper
+// returns a *GISError (Op="ensureWorkspace" / "ensureDatastore",
+// Sentinel=ErrGeoServerPublish), which PublishGeoserverLayer re-wraps
+// in its own *GISError (Op="PublishGeoserverLayer",
+// Sentinel=ErrGeoServerPublish). Callers must be able to:
+//
+//   - match the publish-failure sentinel at any level;
+//   - reach the outer envelope via errors.As (Op shows the public
+//     entry point);
+//   - reach the inner helper-level envelope via Unwrap+errors.As (Op
+//     shows which helper produced the failure for finer-grained
+//     triage);
+//   - reach the underlying upstream cause (e.g. *geoserver.APIError)
+//     via errors.As walking the full chain.
+func TestGISError_NestedChain(t *testing.T) {
+	upstream := errors.New("simulated *geoserver.APIError 500")
+	inner := newGISError("ensureWorkspace", "demo-ws", ErrGeoServerPublish, upstream)
+	outer := newGISError("PublishGeoserverLayer", "demo-ws", ErrGeoServerPublish, inner)
+
+	if !errors.Is(outer, ErrGeoServerPublish) {
+		t.Errorf("errors.Is(outer, ErrGeoServerPublish) = false; want true")
+	}
+	if !errors.Is(outer, upstream) {
+		t.Errorf("errors.Is(outer, upstream) = false; want true (chain walk)")
+	}
+
+	var top *GISError
+	if !errors.As(outer, &top) {
+		t.Fatalf("errors.As(outer, &top) did not match")
+	}
+	if top.Op != "PublishGeoserverLayer" {
+		t.Errorf("outer Op = %q; want PublishGeoserverLayer", top.Op)
+	}
+
+	var helper *GISError
+	if !errors.As(top.Unwrap(), &helper) {
+		t.Fatalf("errors.As(top.Unwrap(), &helper) did not match a nested *GISError")
+	}
+	if helper.Op != "ensureWorkspace" {
+		t.Errorf("inner Op = %q; want ensureWorkspace", helper.Op)
+	}
+	if helper.Source != "demo-ws" {
+		t.Errorf("inner Source = %q; want demo-ws", helper.Source)
+	}
+	if !errors.Is(helper.Cause, upstream) {
+		t.Errorf("inner Cause = %v; want errors.Is match against upstream", helper.Cause)
+	}
+}
+
 func TestGISError_ErrorFormatsByCombination(t *testing.T) {
 	cases := []struct {
 		name string

--- a/layer.go
+++ b/layer.go
@@ -108,24 +108,36 @@ func (manager *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *
 	return nil
 }
 
+// ensureWorkspace looks up the GeoServer workspace by name and creates it
+// if missing. Errors are wrapped as *GISError with Op="ensureWorkspace"
+// and Sentinel=ErrGeoServerPublish so that errors.Is(...,
+// ErrGeoServerPublish) succeeds at every layer of the chain and the
+// underlying *geoserver.APIError remains recoverable via errors.As.
+// Callers (notably PublishGeoserverLayer) typically re-wrap the returned
+// *GISError with their own Op for the public-facing error envelope; the
+// inner GISError remains reachable via Unwrap for finer-grained triage.
 func ensureWorkspace(ctx context.Context, c *geoserver.Client, name string) error {
 	if _, err := c.Workspaces.Get(ctx, name); err == nil {
 		return nil
 	} else if !errors.Is(err, geoserver.ErrNotFound) {
-		return fmt.Errorf("get workspace %q: %w", name, err)
+		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
 	}
 	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: name}); err != nil {
-		return fmt.Errorf("create workspace %q: %w", name, err)
+		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
 	}
 	return nil
 }
 
+// ensureDatastore looks up the PostGIS-backed datastore in the given
+// workspace and creates it if missing. Same error-wrapping contract as
+// [ensureWorkspace] — errors are *GISError with Op="ensureDatastore" and
+// Sentinel=ErrGeoServerPublish.
 func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds DatastoreConfig) error {
 	scoped := c.Datastores.InWorkspace(ws)
 	if _, err := scoped.Get(ctx, ds.Name); err == nil {
 		return nil
 	} else if !errors.Is(err, geoserver.ErrNotFound) {
-		return fmt.Errorf("get datastore %q: %w", ds.Name, err)
+		return newGISError("ensureDatastore", ds.Name, ErrGeoServerPublish, err)
 	}
 	conn := datastores.PostGIS{
 		Name:     ds.Name,
@@ -136,7 +148,7 @@ func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds Dat
 		Password: ds.DBPass,
 	}
 	if err := scoped.Create(ctx, conn); err != nil {
-		return fmt.Errorf("create datastore %q: %w", ds.Name, err)
+		return newGISError("ensureDatastore", ds.Name, ErrGeoServerPublish, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Replace bare \`fmt.Errorf("...%w", ...)\` returns in \`ensureWorkspace\` / \`ensureDatastore\` with \`newGISError(<helper-name>, source, ErrGeoServerPublish, err)\`. Helpers now return a typed \`*GISError\`; \`PublishGeoserverLayer\` continues to re-wrap with its own envelope.
- Resulting chain: \`*GISError(Op=PublishGeoserverLayer) → *GISError(Op=ensureWorkspace|ensureDatastore) → *geoserver.APIError\`. Each layer is walkable by \`errors.Is\` / \`errors.As\`.
- Public-facing \`Op\` stays \`"PublishGeoserverLayer"\` — no behavioral change for callers who match on it. The inner helper-level \`*GISError\` is reachable via \`Unwrap\` for finer-grained triage.

**Not a contract fix.** \`errors.Is(err, ErrGeoServerPublish)\` and \`errors.As\` against \`*geoserver.APIError\` already worked end-to-end before this PR — \`PublishGeoserverLayer\` was wrapping the helpers' \`fmt.Errorf\` returns into \`*GISError\` with the right sentinel. The original audit's \"HIGH-severity contract violation\" framing didn't survive close reading. The change earns its keep on **stylistic consistency** + **finer-grained triage** + **type preservation** (no string-formatted prefix layer between \`*GISError\` and the wrapped \`*geoserver.APIError\`).

This is item #2 of the [improvement plan](https://github.com/hishamkaram/gismanager/issues).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green, race-detector clean (new \`TestGISError_NestedChain\` covers the nested-chain contract)
- [x] \`make test-integration\` against GeoServer 2.28.0 + PostGIS — green (10s)
- [ ] CI: GeoServer 2.27 LTS leg (matrix runs on push)
- [ ] CI: GeoServer 2.28 stable leg (matrix runs on push)