### PR TITLE
feat(cli): signal handling, --version flag, shared cmd/internal/cli helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RUN := $(COMPOSE) run --rm -T $(DEV_SERVICE)
 ARGS ?=
 GEOSERVER_VERSION ?= 2.28.0
 
-.PHONY: help dev shell build test test-unit test-integration lint lint-fix \
+.PHONY: help dev shell build build-cli test test-unit test-integration lint lint-fix \
         vuln tidy fmt vet image clean fetch-testdata \
         compose-up compose-down compose-test-up compose-test-down compose-test-logs
 
@@ -46,6 +46,20 @@ shell: dev ## alias for `make dev`
 
 build: ## go build ./...
 	$(RUN) go build $(ARGS) ./...
+
+# Version metadata injected into the cmd/internal/cli package via -ldflags.
+# Override any of these by exporting them in the environment before invoking
+# `make build-cli` — useful in release workflows that pin a specific tag.
+LDFLAGS_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS_COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS_DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS_PKG     := github.com/hishamkaram/gismanager/cmd/internal/cli
+LDFLAGS         := -X $(LDFLAGS_PKG).Version=$(LDFLAGS_VERSION) \
+                   -X $(LDFLAGS_PKG).Commit=$(LDFLAGS_COMMIT) \
+                   -X $(LDFLAGS_PKG).Date=$(LDFLAGS_DATE)
+
+build-cli: ## go build ./cmd/... with version ldflags injected
+	$(RUN) go build -ldflags='$(LDFLAGS)' $(ARGS) ./cmd/...
 
 test: test-unit ## alias for test-unit
 

--- a/cmd/gisconvert/gisconvert.go
+++ b/cmd/gisconvert/gisconvert.go
@@ -30,23 +30,35 @@ import (
 	"strings"
 
 	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/cmd/internal/cli"
 )
 
-func main() {
-	if err := run(os.Args[1:]); err != nil {
+func main() { os.Exit(realMain()) }
+
+// realMain is the testable entry point; see the matching helper in
+// cmd/gismanager/gismanager.go for rationale.
+func realMain() int {
+	ctx, cancel := cli.SignalContext(context.Background())
+	defer cancel()
+	if err := run(ctx, os.Args[1:]); err != nil {
+		if errors.Is(err, cli.ErrVersionRequested) {
+			return 0
+		}
 		slog.Error("gisconvert", "err", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // run is the entry point separated from main() so it can be tested
-// directly with arbitrary argument slices.
-func run(args []string) error {
+// directly with arbitrary argument slices and a controllable context.
+func run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("gisconvert", flag.ContinueOnError)
 	mode := fs.String("mode", "", "conversion mode: 'vector' or 'raster'")
 	src := fs.String("src", "", "source path (file or /vsi*/-prefixed URL)")
 	dst := fs.String("dst", "", "destination path (file or /vsi*/-prefixed URL)")
 	format := fs.String("format", "", "output driver name (GPKG, GeoJSON, GTiff, COG, PNG, ...). When empty, GDAL infers from -dst extension.")
+	versionFlag := fs.Bool("version", false, "print build version and exit")
 
 	// Vector flags.
 	tSRS := fs.String("t-srs", "", "target SRS (e.g. EPSG:3857). Required for 'raster' mode reproject; optional for 'vector' mode reproject.")
@@ -73,11 +85,14 @@ func run(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if *versionFlag {
+		cli.PrintVersion(os.Stdout, "gisconvert")
+		return cli.ErrVersionRequested
+	}
 	if *mode == "" || *src == "" || *dst == "" {
 		return errors.New("gisconvert: -mode, -src, and -dst are all required")
 	}
 
-	ctx := context.Background()
 	switch *mode {
 	case "vector":
 		return runVector(ctx, *src, *dst, *format, *sSRS, *tSRS, *bbox,

--- a/cmd/gisconvert/main_test.go
+++ b/cmd/gisconvert/main_test.go
@@ -84,20 +84,20 @@ func TestRasterCreationOptions_AccumulatesAcrossSet(t *testing.T) {
 
 func TestRun_RejectsMissingArgs(t *testing.T) {
 	t.Run("no mode", func(t *testing.T) {
-		err := run([]string{"-src", "in.shp", "-dst", "out.gpkg"})
+		err := run(t.Context(), []string{"-src", "in.shp", "-dst", "out.gpkg"})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "-mode")
 	})
 	t.Run("no src", func(t *testing.T) {
-		err := run([]string{"-mode", "vector", "-dst", "out.gpkg"})
+		err := run(t.Context(), []string{"-mode", "vector", "-dst", "out.gpkg"})
 		assert.Error(t, err)
 	})
 	t.Run("no dst", func(t *testing.T) {
-		err := run([]string{"-mode", "vector", "-src", "in.shp"})
+		err := run(t.Context(), []string{"-mode", "vector", "-src", "in.shp"})
 		assert.Error(t, err)
 	})
 	t.Run("unknown mode", func(t *testing.T) {
-		err := run([]string{"-mode", "satellite", "-src", "in", "-dst", "out"})
+		err := run(t.Context(), []string{"-mode", "satellite", "-src", "in", "-dst", "out"})
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "-mode must be"))
 	})
@@ -105,7 +105,7 @@ func TestRun_RejectsMissingArgs(t *testing.T) {
 
 func TestRun_RejectsRasterReprojectWithoutBothSRS(t *testing.T) {
 	// Only -t-srs supplied; gisconvert requires both -s-srs and -t-srs.
-	err := run([]string{
+	err := run(t.Context(), []string{
 		"-mode", "raster",
 		"-src", "in.tif",
 		"-dst", "out.tif",

--- a/cmd/gismanager/gismanager.go
+++ b/cmd/gismanager/gismanager.go
@@ -12,20 +12,42 @@ import (
 	"os"
 
 	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/cmd/internal/cli"
 )
 
-func main() {
-	if err := run(context.Background()); err != nil {
+func main() { os.Exit(realMain()) }
+
+// realMain is the testable entry point: it owns the signal-aware ctx,
+// honors deferred cleanup, and translates an error return into a
+// process exit code (0 for success or -version, 1 for any other
+// failure). Splitting it out from main lets the deferred `cancel()`
+// run before the os.Exit call.
+func realMain() int {
+	ctx, cancel := cli.SignalContext(context.Background())
+	defer cancel()
+	if err := run(ctx, os.Args[1:]); err != nil {
+		if errors.Is(err, cli.ErrVersionRequested) {
+			return 0
+		}
 		slog.Error("gismanager", "err", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
-func run(ctx context.Context) error {
-	configFile := flag.String("config", "", "Config File")
-	flag.Parse()
-	if *configFile == "" {
-		return errors.New("config: --config parameter is required")
+func run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("gismanager", flag.ContinueOnError)
+	configFile := fs.String("config", "", "Config File")
+	versionFlag := fs.Bool("version", false, "print build version and exit")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *versionFlag {
+		cli.PrintVersion(os.Stdout, "gismanager")
+		return cli.ErrVersionRequested
+	}
+	if err := cli.RequireFlag("gismanager", "config", *configFile); err != nil {
+		return err
 	}
 	if _, err := os.Stat(*configFile); os.IsNotExist(err) {
 		return errors.New("config: file does not exist")

--- a/cmd/internal/cli/cli.go
+++ b/cmd/internal/cli/cli.go
@@ -1,0 +1,119 @@
+// Package cli provides shared scaffolding for gismanager's command-line
+// binaries (gismanager, layerSchema, gisconvert). It is internal —
+// external consumers should use the top-level [github.com/hishamkaram/gismanager]
+// library API instead.
+//
+// The helpers here cover three concerns common to every binary:
+//
+//   - SignalContext — Ctrl-C / SIGTERM propagate cleanly through PostGIS
+//     pings, GeoServer REST calls, and any in-flight context-aware GDAL
+//     conversion (the conversion subsystem honors ctx at the boundary).
+//   - PrintVersion — operators can verify which build is running in
+//     prod via a stable single-line format.
+//   - RequireFlag — uniform error envelope for missing required flags
+//     across all three CLIs.
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"syscall"
+)
+
+// Version, Commit, and Date are populated at build time via -ldflags:
+//
+//	go build -ldflags='\
+//	    -X github.com/hishamkaram/gismanager/cmd/internal/cli.Version=v1.4.0 \
+//	    -X github.com/hishamkaram/gismanager/cmd/internal/cli.Commit=abc1234 \
+//	    -X github.com/hishamkaram/gismanager/cmd/internal/cli.Date=2026-05-06T12:00:00Z'
+//
+// When unset (e.g. plain `go run` or `go install` from source),
+// [PrintVersion] falls back to runtime/debug.ReadBuildInfo so output
+// stays useful without any build-time integration.
+var (
+	Version = ""
+	Commit  = ""
+	Date    = ""
+)
+
+// SignalContext returns a context that cancels on os.Interrupt (SIGINT,
+// e.g. Ctrl-C) or syscall.SIGTERM (e.g. `kill <pid>` or a Kubernetes
+// pod terminating). Caller must defer the returned cancel func to
+// release the signal handler.
+//
+// Use this in place of context.Background() at every CLI main() so a
+// long-running publish or conversion can be interrupted cleanly. The
+// gismanager library is context-first by design — every public method
+// honors ctx at the boundary, even if (per the v1.3 CHANGELOG) some
+// underlying CGo calls remain synchronous and uninterruptible.
+func SignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}
+
+// PrintVersion writes a single line of build metadata to w in a
+// machine-friendly format suitable for shell pipelines:
+//
+//	<name> version=<v> commit=<c> built=<d>
+//
+// Each field falls back to runtime/debug.ReadBuildInfo (vcs.revision,
+// vcs.time, Main.Version) when the corresponding ldflag value is empty,
+// and to the literal "(unknown)" only when both ldflag and build info
+// are missing.
+func PrintVersion(w io.Writer, name string) {
+	v, c, d := Version, Commit, Date
+	if v == "" || c == "" || d == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			if v == "" && info.Main.Version != "" {
+				v = info.Main.Version
+			}
+			for _, s := range info.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					if c == "" {
+						c = s.Value
+					}
+				case "vcs.time":
+					if d == "" {
+						d = s.Value
+					}
+				}
+			}
+		}
+	}
+	if v == "" {
+		v = "(unknown)"
+	}
+	if c == "" {
+		c = "(unknown)"
+	}
+	if d == "" {
+		d = "(unknown)"
+	}
+	// Discarding the write error is intentional — PrintVersion is a
+	// best-effort fire-and-forget on stdout for an operator-facing
+	// CLI; if stdout is closed the binary has bigger problems and
+	// the next slog.Error will surface them.
+	_, _ = fmt.Fprintf(w, "%s version=%s commit=%s built=%s\n", name, v, c, d)
+}
+
+// RequireFlag returns a stable error envelope for a missing required
+// CLI flag. The error message is "<binary>: --<flag> is required",
+// matching the style users see for `flag` package parse errors.
+//
+// Returns nil if value is non-empty.
+func RequireFlag(binary, flag, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s: --%s is required", binary, flag)
+	}
+	return nil
+}
+
+// ErrVersionRequested is returned by [HandleVersionFlag] when the user
+// passed -version. Callers should treat this as a clean exit (status 0,
+// no error log).
+var ErrVersionRequested = errors.New("version requested")

--- a/cmd/internal/cli/cli_test.go
+++ b/cmd/internal/cli/cli_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestPrintVersion_AllSet exercises the path where build-time ldflags
+// have populated every field — output should be deterministic.
+func TestPrintVersion_AllSet(t *testing.T) {
+	saved := Version
+	t.Cleanup(func() { Version = saved })
+	savedC := Commit
+	t.Cleanup(func() { Commit = savedC })
+	savedD := Date
+	t.Cleanup(func() { Date = savedD })
+
+	Version = "v1.4.0"
+	Commit = "abc1234"
+	Date = "2026-05-06T12:00:00Z"
+
+	var buf bytes.Buffer
+	PrintVersion(&buf, "gismanager")
+	got := buf.String()
+	want := "gismanager version=v1.4.0 commit=abc1234 built=2026-05-06T12:00:00Z\n"
+	if got != want {
+		t.Errorf("\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestPrintVersion_NeverEmptyValues guards the contract that every
+// printed field is non-empty even when no ldflag and no build info
+// apply (e.g. testing harness). The literal "(unknown)" should appear
+// in place of any field that can't be filled.
+func TestPrintVersion_NeverEmptyValues(t *testing.T) {
+	saved := Version
+	t.Cleanup(func() { Version = saved })
+	savedC := Commit
+	t.Cleanup(func() { Commit = savedC })
+	savedD := Date
+	t.Cleanup(func() { Date = savedD })
+
+	Version = ""
+	Commit = ""
+	Date = ""
+
+	var buf bytes.Buffer
+	PrintVersion(&buf, "gismanager")
+	got := buf.String()
+
+	// Fields might pick up vcs.* from `go test`'s build info; we don't
+	// hard-code them, but we DO assert the line starts with the binary
+	// name and contains all three field keys.
+	if !strings.HasPrefix(got, "gismanager version=") {
+		t.Errorf("missing version field; got %q", got)
+	}
+	if !strings.Contains(got, " commit=") {
+		t.Errorf("missing commit field; got %q", got)
+	}
+	if !strings.Contains(got, " built=") {
+		t.Errorf("missing built field; got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("missing trailing newline; got %q", got)
+	}
+	// No empty values — the contract is "(unknown)" or real value.
+	if strings.Contains(got, "version= ") || strings.Contains(got, "version=\n") {
+		t.Errorf("empty version field leaked through; got %q", got)
+	}
+}
+
+func TestRequireFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		binary    string
+		flag      string
+		value     string
+		wantError bool
+	}{
+		{"non-empty value passes", "gismanager", "config", "/etc/gm.yaml", false},
+		{"empty value errors", "gismanager", "config", "", true},
+		{"empty config flag", "layerSchema", "config", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireFlag(tc.binary, tc.flag, tc.value)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				want := tc.binary + ": --" + tc.flag + " is required"
+				if err.Error() != want {
+					t.Errorf("\n got: %q\nwant: %q", err.Error(), want)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSignalContext_CancelsOnSIGTERM confirms the returned context
+// cancels when the process receives SIGTERM. We deliberately use
+// SIGTERM rather than SIGINT here because Go's testing framework
+// catches SIGINT on its own in some configurations. Sending SIGTERM
+// to ourselves is safe — signal.NotifyContext intercepts it before
+// the default handler kills the process.
+func TestSignalContext_CancelsOnSIGTERM(t *testing.T) {
+	parent, parentCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer parentCancel()
+	ctx, cancel := SignalContext(parent)
+	defer cancel()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("kill self: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// Either context.Canceled (signal) or context.DeadlineExceeded
+		// would technically cancel; we only want the signal path.
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("ctx.Err() = %v; want context.Canceled", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ctx did not cancel within 2s of SIGTERM")
+	}
+}

--- a/cmd/layerSchema/layerSchema.go
+++ b/cmd/layerSchema/layerSchema.go
@@ -12,20 +12,39 @@ import (
 	"os"
 
 	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/cmd/internal/cli"
 )
 
-func main() {
-	if err := run(context.Background()); err != nil {
+func main() { os.Exit(realMain()) }
+
+// realMain is the testable entry point; see the matching helper in
+// cmd/gismanager/gismanager.go for rationale.
+func realMain() int {
+	ctx, cancel := cli.SignalContext(context.Background())
+	defer cancel()
+	if err := run(ctx, os.Args[1:]); err != nil {
+		if errors.Is(err, cli.ErrVersionRequested) {
+			return 0
+		}
 		slog.Error("layerSchema", "err", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
-func run(ctx context.Context) error {
-	configFile := flag.String("config", "", "Config File")
-	flag.Parse()
-	if *configFile == "" {
-		return errors.New("config: --config parameter is required")
+func run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("layerSchema", flag.ContinueOnError)
+	configFile := fs.String("config", "", "Config File")
+	versionFlag := fs.Bool("version", false, "print build version and exit")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *versionFlag {
+		cli.PrintVersion(os.Stdout, "layerSchema")
+		return cli.ErrVersionRequested
+	}
+	if err := cli.RequireFlag("layerSchema", "config", *configFile); err != nil {
+		return err
 	}
 	if _, err := os.Stat(*configFile); os.IsNotExist(err) {
 		return errors.New("config: file does not exist")


### PR DESCRIPTION
## Summary

Three production-essentials added uniformly across the three CLI binaries (gismanager, layerSchema, gisconvert):

- **Signal handling.** \`cli.SignalContext\` replaces \`context.Background()\` at every main(); Ctrl-C / SIGTERM now propagate cleanly through PostGIS pings, GeoServer REST calls, and any context-aware GDAL operation. The library is already context-first, so the signal-aware ctx flows the whole way.
- **\`-version\` flag.** Stable single-line envelope:
  \`\`\`
  gismanager version=v1.4.0 commit=abc1234 built=2026-05-06T12:00:00Z
  \`\`\`
  Values come from \`-ldflags\` at build time and fall back to \`runtime/debug.ReadBuildInfo\` so plain \`go install\` / \`go run\` still produces useful output.
- **Shared \`cmd/internal/cli\` helper.** Eliminates drift between the three binaries' flag-parsing conventions and provides one place to evolve cross-cutting CLI ergonomics (--json output, structured logging defaults) in future PRs.

## Implementation notes

- \`main() / realMain()\` split is the standard Go idiom for CLIs that need \`os.Exit\` while honoring deferred cleanup. Gocritic's \`exitAfterDefer\` rule enforces it; the deferred \`cancel()\` now runs before the process exits.
- \`gisconvert\`'s \`run()\` signature changes from \`(args []string)\` to \`(ctx context.Context, args []string)\`. The existing unit tests are updated to thread \`t.Context()\`.
- New \`make build-cli\` target injects ldflags via \`git describe\`, \`git rev-parse\`, and \`date -u\`. Override any field by exporting \`LDFLAGS_VERSION\` / \`LDFLAGS_COMMIT\` / \`LDFLAGS_DATE\` — useful for release workflows pinning a specific tag.
- New \`cmd/internal/cli/cli_test.go\` covers \`PrintVersion\` (set + fallback paths), \`RequireFlag\` (table-driven), and \`SignalContext\` (SIGTERM cancellation via \`syscall.Kill\` on the test process — \`signal.NotifyContext\` intercepts before any default kill path).

This is item #3 of the [improvement plan](https://github.com/hishamkaram/gismanager/issues).

## Test plan

- [x] \`make lint\` — 0 issues (errcheck + gocritic exitAfterDefer satisfied)
- [x] \`make test-unit\` — green, race-detector clean (new \`cmd/internal/cli\` package adds 4 test functions)
- [ ] CI: full matrix runs on push (changes are scoped to \`cmd/*\`; library API unchanged, so integration suite is a sanity gate rather than a target)