### PR TITLE
feat(config): ManagerConfig.Validate() + ${VAR} env interpolation in FromConfig

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -2,7 +2,9 @@ package gismanager
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -32,6 +34,90 @@ type ManagerConfig struct {
 	Datastore DatastoreConfig `yaml:"datastore"`
 	Source    SourceConfig    `yaml:"source"`
 	logger    *slog.Logger
+}
+
+// Validate checks that every required field on a ManagerConfig is set
+// to a non-zero value and reports the missing fields in a single error.
+// The error wraps [ErrConfigInvalid]; recover the field list via
+// [errors.As] into [*GISError] and inspect Cause.Error().
+//
+// Validate covers the publish-pipeline contract — every field needed
+// for the walk → PostGIS-load → GeoServer-publish flow. Programmatic
+// callers using only a subset of the manager's surface (e.g.
+// OpenSource for ad-hoc reads) can skip Validate entirely; only
+// [FromConfig] calls it automatically, since YAML callers signal
+// "I intend a full publish setup" by writing the YAML in the first
+// place.
+func (c *ManagerConfig) Validate() error {
+	var problems []string
+	if c.Geoserver.ServerURL == "" {
+		problems = append(problems, "geoserver.url is required")
+	}
+	if c.Geoserver.WorkspaceName == "" {
+		problems = append(problems, "geoserver.workspace is required")
+	}
+	if c.Geoserver.Username == "" {
+		problems = append(problems, "geoserver.username is required")
+	}
+	if c.Geoserver.Password == "" {
+		problems = append(problems, "geoserver.password is required")
+	}
+	if c.Datastore.Host == "" {
+		problems = append(problems, "datastore.host is required")
+	}
+	if c.Datastore.Port == 0 {
+		problems = append(problems, "datastore.port is required (and non-zero)")
+	}
+	if c.Datastore.DBName == "" {
+		problems = append(problems, "datastore.database is required")
+	}
+	if c.Datastore.DBUser == "" {
+		problems = append(problems, "datastore.username is required")
+	}
+	if c.Datastore.DBPass == "" {
+		problems = append(problems, "datastore.password is required")
+	}
+	if c.Datastore.Name == "" {
+		problems = append(problems, "datastore.name is required")
+	}
+	if c.Source.Path == "" {
+		problems = append(problems, "source.path is required")
+	}
+	if len(problems) > 0 {
+		return newGISError("Validate", "", ErrConfigInvalid,
+			errors.New(strings.Join(problems, "; ")))
+	}
+	return nil
+}
+
+// expandEnv applies os.ExpandEnv (`$VAR` and `${VAR}` substitution) to
+// every operator-supplied string field on the manager config. Used
+// internally by [FromConfig] after YAML decode and before validation,
+// so YAML files can reference secrets without inlining them:
+//
+//	geoserver:
+//	  password: ${GEOSERVER_PASSWORD}
+//	datastore:
+//	  password: ${PG_PASSWORD}
+//
+// Variables that aren't set in the environment resolve to empty strings
+// (matching os.ExpandEnv); Validate then rejects the empty result with a
+// useful field-name error message.
+//
+// Datastore.Port (uint) is not expanded — port numbers should come from
+// config, not env vars; if a user truly needs a parameterized port they
+// should set it via the [WithDatastore] option in code.
+func (c *ManagerConfig) expandEnv() {
+	c.Geoserver.ServerURL = os.ExpandEnv(c.Geoserver.ServerURL)
+	c.Geoserver.WorkspaceName = os.ExpandEnv(c.Geoserver.WorkspaceName)
+	c.Geoserver.Username = os.ExpandEnv(c.Geoserver.Username)
+	c.Geoserver.Password = os.ExpandEnv(c.Geoserver.Password)
+	c.Datastore.Host = os.ExpandEnv(c.Datastore.Host)
+	c.Datastore.DBName = os.ExpandEnv(c.Datastore.DBName)
+	c.Datastore.DBUser = os.ExpandEnv(c.Datastore.DBUser)
+	c.Datastore.DBPass = os.ExpandEnv(c.Datastore.DBPass)
+	c.Datastore.Name = os.ExpandEnv(c.Datastore.Name)
+	c.Source.Path = os.ExpandEnv(c.Source.Path)
 }
 
 // GetGeoserverCatalog returns a GeoServer v2 client configured against the

--- a/testdata/test_config_envvars.yml
+++ b/testdata/test_config_envvars.yml
@@ -1,0 +1,17 @@
+# Demo config that exercises ${VAR} interpolation. FromConfig substitutes
+# os-env values for every operator-supplied string field before
+# validating; see TestFromConfig_ExpandsEnvVars for the lock-in.
+geoserver:
+  url: ${GISMGR_TEST_GS_URL}
+  username: ${GISMGR_TEST_GS_USER}
+  password: ${GISMGR_TEST_GS_PASS}
+  workspace: golang
+datastore:
+  host: ${GISMGR_TEST_PG_HOST}
+  port: 5432
+  database: gis
+  username: ${GISMGR_TEST_PG_USER}
+  password: ${GISMGR_TEST_PG_PASS}
+  name: gismanager_data
+source:
+  path: ${GISMGR_TEST_SRC_PATH}

--- a/testdata/test_config_missing.yml
+++ b/testdata/test_config_missing.yml
@@ -1,0 +1,11 @@
+# Deliberately incomplete: missing geoserver.password, datastore.host,
+# datastore.username, source.path. Drives TestFromConfig_RejectsMissing.
+geoserver:
+  url: http://localhost:8080/geoserver
+  username: admin
+  workspace: golang
+datastore:
+  port: 5432
+  database: gis
+  password: golang
+  name: gismanager_data

--- a/utils.go
+++ b/utils.go
@@ -38,12 +38,24 @@ func FromConfig(configFile string) (*ManagerConfig, error) {
 		logger.Error("unmarshal yaml", "path", absPath, "err", unmarshalErr)
 		return nil, newGISError("FromConfig", absPath, ErrConfigInvalid, unmarshalErr)
 	}
-	return New(
+	// Apply ${VAR} substitution to operator-supplied string fields
+	// before validation so a YAML referencing $PG_PASSWORD doesn't
+	// trip the "password is required" check.
+	decoded.expandEnv()
+	m, err := New(
 		WithLogger(logger),
 		WithGeoserver(decoded.Geoserver),
 		WithDatastore(decoded.Datastore),
 		WithSource(decoded.Source),
 	)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.Validate(); err != nil {
+		logger.Error("validate config", "path", absPath, "err", err)
+		return nil, err
+	}
+	return m, nil
 }
 
 func isSupported(ext string) bool {

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,216 @@
+package gismanager
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fullConfig returns a ManagerConfig with every required field
+// populated to a sane non-zero value. Tests start from this and
+// blank out one field at a time to exercise Validate's error paths.
+func fullConfig() *ManagerConfig {
+	return &ManagerConfig{
+		Geoserver: GeoserverConfig{
+			ServerURL:     "http://localhost:8080/geoserver",
+			Username:      "admin",
+			Password:      "geoserver",
+			WorkspaceName: "golang",
+		},
+		Datastore: DatastoreConfig{
+			Host:   "postgis",
+			Port:   5432,
+			DBName: "gis",
+			DBUser: "golang",
+			DBPass: "golang",
+			Name:   "gismanager_data",
+		},
+		Source: SourceConfig{Path: "./testdata"},
+	}
+}
+
+func TestManagerConfig_Validate_HappyPath(t *testing.T) {
+	if err := fullConfig().Validate(); err != nil {
+		t.Fatalf("Validate() on full config: want nil, got %v", err)
+	}
+}
+
+func TestManagerConfig_Validate_RejectsEachMissingField(t *testing.T) {
+	cases := []struct {
+		name      string
+		mutate    func(*ManagerConfig)
+		wantInMsg string
+	}{
+		{"missing geoserver.url", func(c *ManagerConfig) { c.Geoserver.ServerURL = "" }, "geoserver.url is required"},
+		{"missing geoserver.workspace", func(c *ManagerConfig) { c.Geoserver.WorkspaceName = "" }, "geoserver.workspace is required"},
+		{"missing geoserver.username", func(c *ManagerConfig) { c.Geoserver.Username = "" }, "geoserver.username is required"},
+		{"missing geoserver.password", func(c *ManagerConfig) { c.Geoserver.Password = "" }, "geoserver.password is required"},
+		{"missing datastore.host", func(c *ManagerConfig) { c.Datastore.Host = "" }, "datastore.host is required"},
+		{"zero datastore.port", func(c *ManagerConfig) { c.Datastore.Port = 0 }, "datastore.port is required"},
+		{"missing datastore.database", func(c *ManagerConfig) { c.Datastore.DBName = "" }, "datastore.database is required"},
+		{"missing datastore.username", func(c *ManagerConfig) { c.Datastore.DBUser = "" }, "datastore.username is required"},
+		{"missing datastore.password", func(c *ManagerConfig) { c.Datastore.DBPass = "" }, "datastore.password is required"},
+		{"missing datastore.name", func(c *ManagerConfig) { c.Datastore.Name = "" }, "datastore.name is required"},
+		{"missing source.path", func(c *ManagerConfig) { c.Source.Path = "" }, "source.path is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fullConfig()
+			tc.mutate(c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("Validate(): want error, got nil")
+			}
+			if !errors.Is(err, ErrConfigInvalid) {
+				t.Errorf("errors.Is(err, ErrConfigInvalid) = false; want true. err=%v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInMsg) {
+				t.Errorf("error message missing %q\n got: %v", tc.wantInMsg, err)
+			}
+			var gerr *GISError
+			if !errors.As(err, &gerr) {
+				t.Fatalf("errors.As to *GISError: no match")
+			}
+			if gerr.Op != "Validate" {
+				t.Errorf("Op = %q; want Validate", gerr.Op)
+			}
+		})
+	}
+}
+
+// TestManagerConfig_Validate_AggregatesAllProblems confirms multiple
+// missing fields surface in a single error envelope rather than the
+// caller having to re-run Validate to find each one.
+func TestManagerConfig_Validate_AggregatesAllProblems(t *testing.T) {
+	c := fullConfig()
+	c.Geoserver.ServerURL = ""
+	c.Datastore.Host = ""
+	c.Source.Path = ""
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("want aggregated error, got nil")
+	}
+	for _, want := range []string{
+		"geoserver.url is required",
+		"datastore.host is required",
+		"source.path is required",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("aggregated error missing %q; got: %v", want, err)
+		}
+	}
+}
+
+func TestManagerConfig_ExpandEnv(t *testing.T) {
+	t.Setenv("GISMGR_TEST_GS_URL", "http://demo:8080/geoserver")
+	t.Setenv("GISMGR_TEST_GS_USER", "demo-user")
+	t.Setenv("GISMGR_TEST_GS_PASS", "demo-pass")
+	t.Setenv("GISMGR_TEST_PG_HOST", "demo-pg")
+	t.Setenv("GISMGR_TEST_PG_USER", "demo-pg-user")
+	t.Setenv("GISMGR_TEST_PG_PASS", "demo-pg-pass")
+	t.Setenv("GISMGR_TEST_SRC_PATH", "/srv/data")
+
+	c := &ManagerConfig{
+		Geoserver: GeoserverConfig{
+			ServerURL: "${GISMGR_TEST_GS_URL}",
+			Username:  "${GISMGR_TEST_GS_USER}",
+			Password:  "${GISMGR_TEST_GS_PASS}",
+		},
+		Datastore: DatastoreConfig{
+			Host:   "${GISMGR_TEST_PG_HOST}",
+			DBUser: "${GISMGR_TEST_PG_USER}",
+			DBPass: "${GISMGR_TEST_PG_PASS}",
+		},
+		Source: SourceConfig{Path: "${GISMGR_TEST_SRC_PATH}"},
+	}
+	c.expandEnv()
+
+	if c.Geoserver.ServerURL != "http://demo:8080/geoserver" {
+		t.Errorf("Geoserver.ServerURL = %q", c.Geoserver.ServerURL)
+	}
+	if c.Geoserver.Username != "demo-user" {
+		t.Errorf("Geoserver.Username = %q", c.Geoserver.Username)
+	}
+	if c.Datastore.DBPass != "demo-pg-pass" {
+		t.Errorf("Datastore.DBPass = %q", c.Datastore.DBPass)
+	}
+	if c.Source.Path != "/srv/data" {
+		t.Errorf("Source.Path = %q", c.Source.Path)
+	}
+}
+
+// TestManagerConfig_ExpandEnv_UnsetVarBecomesEmpty locks in the
+// os.ExpandEnv contract: unset variables resolve to empty strings,
+// which Validate then catches with a useful field-name error.
+func TestManagerConfig_ExpandEnv_UnsetVarBecomesEmpty(t *testing.T) {
+	t.Setenv("GISMGR_TEST_REAL", "real-value")
+
+	c := &ManagerConfig{
+		Geoserver: GeoserverConfig{
+			ServerURL: "${GISMGR_TEST_REAL}",
+			Password:  "${GISMGR_TEST_DEFINITELY_UNSET_xyzzy}",
+		},
+	}
+	c.expandEnv()
+
+	if c.Geoserver.ServerURL != "real-value" {
+		t.Errorf("set var: ServerURL = %q; want real-value", c.Geoserver.ServerURL)
+	}
+	if c.Geoserver.Password != "" {
+		t.Errorf("unset var: Password = %q; want empty (ExpandEnv default)", c.Geoserver.Password)
+	}
+}
+
+func TestFromConfig_RejectsMissingFields(t *testing.T) {
+	mgr, err := FromConfig("./testdata/test_config_missing.yml")
+	if mgr != nil {
+		t.Errorf("manager = %v; want nil on incomplete config", mgr)
+	}
+	if err == nil {
+		t.Fatal("err = nil; want validation failure")
+	}
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Errorf("errors.Is(err, ErrConfigInvalid) = false; want true. err=%v", err)
+	}
+	// The aggregated error should call out every missing field.
+	for _, want := range []string{
+		"geoserver.password is required",
+		"datastore.host is required",
+		"datastore.username is required",
+		"source.path is required",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q; got: %v", want, err)
+		}
+	}
+}
+
+func TestFromConfig_ExpandsEnvVars(t *testing.T) {
+	t.Setenv("GISMGR_TEST_GS_URL", "http://gs.demo:8080/geoserver")
+	t.Setenv("GISMGR_TEST_GS_USER", "demo-admin")
+	t.Setenv("GISMGR_TEST_GS_PASS", "demo-secret")
+	t.Setenv("GISMGR_TEST_PG_HOST", "demo-postgis")
+	t.Setenv("GISMGR_TEST_PG_USER", "demo-pg-user")
+	t.Setenv("GISMGR_TEST_PG_PASS", "demo-pg-secret")
+	t.Setenv("GISMGR_TEST_SRC_PATH", "./testdata")
+
+	mgr, err := FromConfig("./testdata/test_config_envvars.yml")
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	if got := mgr.Geoserver.ServerURL; got != "http://gs.demo:8080/geoserver" {
+		t.Errorf("Geoserver.ServerURL = %q", got)
+	}
+	if got := mgr.Geoserver.Password; got != "demo-secret" {
+		t.Errorf("Geoserver.Password = %q", got)
+	}
+	if got := mgr.Datastore.Host; got != "demo-postgis" {
+		t.Errorf("Datastore.Host = %q", got)
+	}
+	if got := mgr.Datastore.DBPass; got != "demo-pg-secret" {
+		t.Errorf("Datastore.DBPass = %q", got)
+	}
+	if got := mgr.Source.Path; got != "./testdata" {
+		t.Errorf("Source.Path = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two production-essentials added to the YAML config flow — both opt-in for programmatic callers, automatically applied for YAML-driven callers (`FromConfig`):

- **\`(*ManagerConfig).Validate()\` returns a single aggregated error** enumerating every required field that is unset or zero. The error wraps \`ErrConfigInvalid\`; recover the field list via \`errors.As\` into \`*GISError\`. Validation covers the publish-pipeline contract — every field the walk → load → publish flow reads. The conversion subsystem doesn't touch \`ManagerConfig\` and is unaffected.
- **\`FromConfig\` applies \`os.ExpandEnv\` (\`$VAR\` / \`\${VAR}\`) substitution** to every operator-supplied string field before validating, so YAML files can reference secrets via env vars:

  \`\`\`yaml
  datastore:
    password: \${PG_PASSWORD}
  \`\`\`

Unset env vars resolve to empty strings; \`Validate\` then catches the empty result with a useful field-name error message. \`Datastore.Port\` (uint) is intentionally not expanded — port numbers should come from config, not env vars.

\`Validate\` is opt-in for programmatic callers — only \`FromConfig\` calls it automatically, since YAML callers signal *"I intend a full publish setup"* by writing the YAML in the first place. Programmatic callers using only \`OpenSource\` or the conversion functions skip \`Validate\` entirely.

## Test fixtures

- \`testdata/test_config_envvars.yml\` — every operator-supplied field references a \`\${GISMGR_TEST_*}\` env var.
- \`testdata/test_config_missing.yml\` — deliberately omits four required fields.

## Tests

\`validate_test.go\` (7 tests / 11 sub-cases):
- \`TestManagerConfig_Validate_HappyPath\`
- \`TestManagerConfig_Validate_RejectsEachMissingField\` (table-driven)
- \`TestManagerConfig_Validate_AggregatesAllProblems\` (multiple missing fields → single error envelope)
- \`TestManagerConfig_ExpandEnv\` + \`TestManagerConfig_ExpandEnv_UnsetVarBecomesEmpty\`
- \`TestFromConfig_RejectsMissingFields\` (YAML → error)
- \`TestFromConfig_ExpandsEnvVars\` (YAML + env → manager)

This is item #4 of the [improvement plan](https://github.com/hishamkaram/gismanager/issues).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green, race-detector clean
- [x] \`make test-integration\` against GeoServer 2.28.0 + PostGIS — green (existing integration tests construct complete configs, so \`Validate\` passes)
- [ ] CI: full matrix runs on push