### PR TITLE
ci(release): tag-triggered release workflow (multi-arch image + signed binaries + SBOM)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,188 @@
+name: Release
+
+# This workflow runs ONLY on tag push (v*.*.*), never on master or PRs.
+# Per CLAUDE.md, tagging is an explicit user action — Claude / CI never
+# runs `git tag` autonomously. The cut steps for a maintainer live in
+# RELEASING.md at the repo root.
+#
+# Outputs per release:
+#   - Multi-arch Docker images (linux/amd64 + linux/arm64) at
+#     ghcr.io/<owner>/<repo>:<vX.Y.Z> and :latest, cosign-signed keyless
+#     via the GitHub Actions OIDC identity.
+#   - Linux amd64 raw binaries (gismanager, layerSchema, gisconvert),
+#     each with version metadata baked in via -ldflags, packaged as a
+#     single tar.gz alongside SHA-256 checksums and a cosign signature
+#     of those checksums.
+#   - SBOM (SPDX-JSON, syft-generated) covering the binary archive.
+#   - GitHub Release whose body is extracted from CHANGELOG.md's
+#     [Unreleased] stanza — the maintainer is expected to have moved
+#     the [Unreleased] entries into the new [<version>] stanza in a
+#     pre-tag commit, leaving [Unreleased] empty for the next cycle.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write       # create the GitHub Release + upload assets
+  packages: write       # push to ghcr.io
+  id-token: write       # cosign keyless via OIDC
+  attestations: write   # provenance attestations on the image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Release ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so `git describe` resolves
+
+      - name: Set version env
+        run: |
+          set -ex
+          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      # ---------- Docker image (multi-arch) -------------------------------
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute lowercase image ref
+        id: lc
+        run: echo "image=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build + push image (linux/amd64,linux/arm64)
+        id: build_image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          sbom: true
+          tags: |
+            ${{ steps.lc.outputs.image }}:${{ env.VERSION }}
+            ${{ steps.lc.outputs.image }}:latest
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            DATE=${{ env.DATE }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Cosign sign image (keyless via OIDC)
+        run: |
+          cosign sign --yes \
+            "${{ steps.lc.outputs.image }}@${{ steps.build_image.outputs.digest }}"
+
+      # ---------- Raw amd64 binaries --------------------------------------
+      #
+      # We rebuild the binaries on the host runner (with a static GDAL
+      # apt-installed) rather than copying out of the multi-arch image,
+      # because docker buildx --platform=linux/amd64,linux/arm64 stores
+      # both arches in a manifest list and `docker create` to extract
+      # binaries works on a single-arch image only. Building once more
+      # for amd64 with the same Dockerfile build stage is the simplest
+      # path and re-uses the already-warm Buildx cache.
+
+      - name: Build amd64 binaries (extract from single-arch build)
+        run: |
+          set -ex
+          mkdir -p dist
+          docker buildx build \
+            --platform linux/amd64 \
+            --target build \
+            --build-arg "VERSION=${VERSION}" \
+            --build-arg "COMMIT=${COMMIT}" \
+            --build-arg "DATE=${DATE}" \
+            --output type=local,dest=./dist-build \
+            .
+          # The build stage writes binaries to /out; --output=local copies
+          # the entire image fs, so we pull the three binaries from /out.
+          for bin in gismanager layerSchema gisconvert; do
+            cp "dist-build/out/${bin}" "dist/${bin}"
+            chmod +x "dist/${bin}"
+          done
+          ls -la dist/
+
+      - name: Package binary tarball + checksums
+        run: |
+          set -ex
+          cd dist
+          tar czf "../gismanager_${VERSION}_linux_amd64.tar.gz" \
+            gismanager layerSchema gisconvert
+          cd ..
+          sha256sum "gismanager_${VERSION}_linux_amd64.tar.gz" > checksums.txt
+          cat checksums.txt
+
+      - name: Generate SBOM (syft, SPDX-JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist/
+          format: spdx-json
+          output-file: gismanager_${{ env.VERSION }}_sbom.spdx.json
+
+      - name: Cosign sign-blob the checksums file (keyless via OIDC)
+        run: |
+          cosign sign-blob --yes \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            checksums.txt
+
+      # ---------- GitHub Release ------------------------------------------
+
+      - name: Extract release notes from CHANGELOG [Unreleased] / current version stanza
+        id: notes
+        run: |
+          # The maintainer is expected to have moved [Unreleased] entries
+          # into the new [<version>] stanza in a pre-tag commit. We try the
+          # version stanza first; if empty, fall back to [Unreleased].
+          set -ex
+          v="${VERSION#v}"
+          awk -v v="$v" '
+            $0 ~ "^## \\[" v "\\]" {flag=1; next}
+            flag && /^## \[/ {flag=0}
+            flag {print}
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' \
+              CHANGELOG.md > release-notes.md
+          fi
+          if [ ! -s release-notes.md ]; then
+            echo "Release ${VERSION}." > release-notes.md
+          fi
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+          body_path: release-notes.md
+          fail_on_unmatched_files: true
+          files: |
+            gismanager_${{ env.VERSION }}_linux_amd64.tar.gz
+            checksums.txt
+            checksums.txt.sig
+            checksums.txt.pem
+            gismanager_${{ env.VERSION }}_sbom.spdx.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,10 +97,23 @@ CMD ["bash"]
 # ---------------------------------------------------------------------------
 FROM dev AS build
 
+# Version metadata baked in via -ldflags. Defaults work for `make image`
+# locally; the release workflow (.github/workflows/release.yml) overrides
+# all three from the tag.
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+
 COPY . /workspace
-RUN go mod download \
-    && go build -trimpath -ldflags="-s -w" -o /out/gismanager ./cmd/gismanager \
-    && go build -trimpath -ldflags="-s -w" -o /out/layerSchema ./cmd/layerSchema
+RUN set -eux; \
+    LDFLAGS="-s -w \
+      -X github.com/hishamkaram/gismanager/cmd/internal/cli.Version=${VERSION} \
+      -X github.com/hishamkaram/gismanager/cmd/internal/cli.Commit=${COMMIT} \
+      -X github.com/hishamkaram/gismanager/cmd/internal/cli.Date=${DATE}"; \
+    go mod download; \
+    for bin in gismanager layerSchema gisconvert; do \
+      go build -trimpath -ldflags="$LDFLAGS" -o "/out/$bin" "./cmd/$bin"; \
+    done
 
 # ---------------------------------------------------------------------------
 # Stage 3: runtime — minimal image for shipping
@@ -113,5 +126,6 @@ FROM ghcr.io/osgeo/gdal:ubuntu-small-${GDAL_VERSION} AS runtime
 
 COPY --from=build /out/gismanager /usr/local/bin/gismanager
 COPY --from=build /out/layerSchema /usr/local/bin/layerSchema
+COPY --from=build /out/gisconvert /usr/local/bin/gisconvert
 
 ENTRYPOINT ["/usr/local/bin/gismanager"]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,139 @@
+# Releasing gismanager
+
+This document is the canonical cut-a-release runbook. Releases are an
+explicit human action — neither Claude nor CI ever runs `git tag`
+autonomously (per `CLAUDE.md` "Don't auto-tag releases").
+
+## What a release produces
+
+The `.github/workflows/release.yml` workflow runs on every `v*.*.*` tag
+push and assembles:
+
+- **Multi-arch Docker image** — `ghcr.io/hishamkaram/gismanager:<vX.Y.Z>`
+  and `:latest`, built for `linux/amd64` + `linux/arm64`, cosign-signed
+  keyless via the GitHub Actions OIDC identity, with provenance + SBOM
+  attestations attached by buildx.
+- **Linux amd64 binary tarball** — `gismanager_<vX.Y.Z>_linux_amd64.tar.gz`
+  containing `gismanager`, `layerSchema`, and `gisconvert`, each
+  reporting the released version via `-version` (the `cmd/internal/cli`
+  package is populated at build time via `-ldflags`).
+- **`checksums.txt`** — SHA-256 of the tarball, with `checksums.txt.sig`
+  and `checksums.txt.pem` from a keyless `cosign sign-blob`.
+- **SBOM** — `gismanager_<vX.Y.Z>_sbom.spdx.json`, syft-generated SPDX-JSON.
+- **GitHub Release** — body is the matching CHANGELOG stanza (see below).
+
+Linux is the only supported runtime for raw binaries — gismanager links
+CGo against `libgdal`, so binaries must run on a host with a compatible
+GDAL installed. Users who can't satisfy that should use the Docker image.
+
+## Cut steps (maintainer)
+
+### 0. Pre-conditions
+
+- `master` is green on CI (full matrix).
+- You are an admin / maintainer on the `hishamkaram/gismanager` repo.
+- Your local checkout is on `master`, fully synced with `origin/master`,
+  and clean (`git status` reports nothing).
+- You have signing keys configured for `git commit -S` and `git tag -s`
+  (the project does not currently *enforce* signed commits but signed
+  tags are a strong convention).
+
+### 1. Update CHANGELOG
+
+Move every entry under `## [Unreleased]` into a new
+`## [<version>] — <YYYY-MM-DD>` stanza. Keep the `[Unreleased]` heading
+in place but empty its body — that's the marker the next cycle starts
+populating.
+
+The `release.yml` workflow extracts the `[<version>]` body as the
+GitHub Release notes; if missing, it falls back to whatever is left
+under `[Unreleased]`. So the consolidation step is what makes the
+release page useful.
+
+Commit:
+
+```
+git add CHANGELOG.md
+git commit -S -m "docs(changelog): consolidate Unreleased into [vX.Y.Z] — YYYY-MM-DD stanza"
+git push origin master
+```
+
+Wait for CI on `master` to go green. Don't skip this — release.yml
+doesn't re-run unit/integration tests.
+
+### 2. Tag
+
+```
+git tag -s "vX.Y.Z" -m "Release vX.Y.Z"
+git push origin "vX.Y.Z"
+```
+
+The push triggers `.github/workflows/release.yml`. Watch it under the
+Actions tab — typical end-to-end runtime is 10–15 minutes (multi-arch
+buildx is the slow leg via QEMU emulation for arm64).
+
+### 3. Smoke test the release
+
+After the workflow finishes:
+
+- **Docker image:** `docker pull ghcr.io/hishamkaram/gismanager:vX.Y.Z`,
+  then `docker run --rm ghcr.io/hishamkaram/gismanager:vX.Y.Z -version`
+  — should print `gismanager version=vX.Y.Z commit=… built=…`.
+- **Cosign verify image:**
+  ```
+  cosign verify ghcr.io/hishamkaram/gismanager:vX.Y.Z \
+    --certificate-identity-regexp 'https://github.com/hishamkaram/gismanager/.github/workflows/release.yml@refs/tags/vX.Y.Z' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  ```
+- **Binary tarball:** download from the Release page, extract,
+  `./gismanager -version`.
+- **Verify checksums:** `sha256sum -c checksums.txt`.
+- **Cosign verify checksums:**
+  ```
+  cosign verify-blob \
+    --certificate checksums.txt.pem \
+    --signature checksums.txt.sig \
+    --certificate-identity-regexp 'https://github.com/hishamkaram/gismanager/.github/workflows/release.yml@refs/tags/vX.Y.Z' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    checksums.txt
+  ```
+
+### 4. Post-release
+
+Open a tracking issue or PR for next-cycle items if relevant. The next
+`[Unreleased]` block accumulates entries until the next cut.
+
+## Yanking a bad release
+
+If a release goes out broken:
+
+1. Delete the GitHub Release (web UI or `gh release delete vX.Y.Z`).
+   This removes the binary assets but keeps the tag and the Docker
+   image — both are immutable by design.
+2. Mark the bad release as "yanked" in `CHANGELOG.md` under a
+   short `### Yanked` subsection of the `[<version>]` stanza,
+   explaining what was wrong and what users should upgrade to.
+3. Do NOT delete the tag — that breaks anyone who pinned to it via
+   `go get`. The Go module cache is content-addressed and a deleted
+   tag with replaced contents would be a supply-chain hazard.
+4. Cut a fresh patch release (`vX.Y.Z+1`) that fixes the issue.
+
+## Why not goreleaser?
+
+The plan considered goreleaser but chose a hand-rolled GitHub Actions
+workflow because:
+
+- gismanager links CGo against libgdal, which goreleaser-cross handles
+  awkwardly — the cross-compiler images don't bundle GDAL and the GDAL
+  ecosystem's preferred distribution path is Docker, not raw binaries.
+- The project already has a multi-stage Dockerfile that produces both
+  the dev environment and the runtime image. The release workflow
+  reuses those stages directly via `buildx --target=runtime` and
+  `--target=build`, avoiding a parallel build configuration.
+- Multi-arch Docker images via `docker buildx build --platform=...`
+  are the 2026-current standard for CGo Go binaries; goreleaser-cross
+  multi-arch was not adding signal vs. the cost of a second build path.
+
+If a future maintainer wants to add goreleaser for richer changelog
+generation or raw-binary support across more platforms, that's a
+welcome follow-up — but the current MVP covers the v1.4 release contract.


### PR DESCRIPTION
## Summary

Adds the v1.4-ready release pipeline. Triggered **only** on \`v*.*.*\` tag push (per CLAUDE.md, tagging stays an explicit user action — Claude and CI never run \`git tag\` autonomously).

Per release the workflow produces:

- **Multi-arch Docker image** at \`ghcr.io/<owner>/<repo>:<vX.Y.Z>\` and \`:latest\`, built \`linux/amd64\` + \`linux/arm64\` via Buildx + QEMU, with provenance + SBOM attestations attached by buildx, then cosign-signed keyless via the GitHub Actions OIDC identity.
- **Linux amd64 binary tarball** (\`gismanager\` + \`layerSchema\` + \`gisconvert\`), each carrying version metadata baked in via \`-ldflags\` (the \`cmd/internal/cli\` package vars from item #3).
- **\`checksums.txt\`** of the tarball, plus a cosign \`sign-blob\` signature and certificate.
- **SBOM** via \`anchore/sbom-action\` (syft, SPDX-JSON).
- **GitHub Release** auto-created from the matching CHANGELOG stanza (or \`[Unreleased]\` fallback) with all of the above attached.

## Dockerfile changes

- New \`ARG VERSION\` / \`COMMIT\` / \`DATE\` on the build stage; \`-ldflags\` now bake them into every binary via \`cmd/internal/cli.{Version,Commit,Date}\`. Defaults remain \`dev\` / \`unknown\` so \`make image\` keeps working without ARG injection.
- Build stage now produces \`gisconvert\` too (it shipped in v1.2 but had been missing from the runtime image — closing that gap).
- Runtime stage COPYs \`gisconvert\` alongside the others.

## RELEASING.md

New maintainer runbook covering: cut steps, smoke test (incl. \`cosign verify\` commands), yank procedure (delete release assets / mark CHANGELOG / **do not delete tag** — that breaks \`go get\` pinned modules), and the rationale for going hand-rolled over goreleaser (CGo + libgdal + multi-arch Docker is what goreleaser-cross handles awkwardly).

This is item #5 of the [improvement plan](https://github.com/hishamkaram/gismanager/issues).

## Validation

- [x] \`actionlint .github/workflows/release.yml\` — clean (exit 0)
- [x] YAML syntax verified via \`python3 -c 'yaml.safe_load(...)'\`
- [x] \`make lint\` — 0 issues (no Go code changed; sanity gate)
- [x] \`make test-unit\` — green
- [ ] **End-to-end workflow run is exercised only on the next tag push.** Per RELEASING.md, the first cut should be \`v1.4.0-rc.1\` against a fork to validate the full pipeline before tagging stable.

## Test plan

- [ ] CI green on PR (CodeQL, Lint, govulncheck, unit, integration matrix — all unrelated to release.yml but must stay green)
- [ ] After merge: tag a \`-rc.1\` against a fork to dry-run the workflow end-to-end (out of scope for this PR; lives in the next release-cut event)