### PR TITLE
ci: hardening bundle — coverage gate, log artifact, .dockerignore, image digest pins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Files excluded from the Docker build context.
+#
+# Background: every `docker build` (or `docker buildx build`) sends the
+# entire context to the Docker daemon, even files no FROM stage references.
+# Without a .dockerignore the dev image build pulls in `.git/` (large
+# history), `testdata-fetched/` (fetched fixtures, hundreds of MB), and
+# the bash-only `.claude/` subtree — all wasted bandwidth and cache churn.
+#
+# Keep this list in sync with what `Dockerfile` and `docker/Dockerfile`
+# actually need. The build stage runs `COPY . /workspace`, so anything
+# not excluded here ends up baked into the build cache.
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# CI / GitHub metadata (workflows aren't read at build time)
+.github/
+
+# Dev-only IDE config
+.devcontainer/
+.vscode/
+.idea/
+
+# Claude Code per-project config
+.claude/
+
+# Compose configs (used by `make compose-test-up`, not by docker build)
+docker-compose.yml
+docker-compose.test.yml
+
+# Testdata that's fetched on demand by `make fetch-testdata`. Large; not
+# needed for `go build`. Unit/integration tests inside the dev container
+# use the volume mount, not the baked-in copy.
+testdata-fetched/
+
+# Local build artifacts
+bin/
+dist/
+*.test
+*.out
+coverage.html
+coverage.txt
+*.cover
+
+# OS / editor leftovers
+.DS_Store
+._*
+*.swp
+*~
+
+# Operator-only local config
+local_config.yaml
+play/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,19 @@ jobs:
         run: go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -n 1
+      - name: Coverage gate (>= 65%)
+        # Baseline at item #6 ship (May 2026): 69.3%. Threshold set at
+        # 65% gives ~4pp headroom for legitimate refactors that
+        # incidentally drop coverage; raise this whenever real coverage
+        # increases meaningfully (track in CHANGELOG when bumped).
+        run: |
+          set -ex
+          pct=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}' | tr -d '%')
+          echo "Total coverage: ${pct}%"
+          awk -v p="$pct" -v t=65 'BEGIN { exit (p+0 < t) ? 1 : 0 }' || {
+            echo "::error::Total coverage ${pct}% is below threshold 65%."
+            exit 1
+          }
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -109,9 +109,24 @@ jobs:
       - name: Run integration tests
         run: docker compose -f docker-compose.test.yml run --rm -T test-runner go test -race -tags=integration -timeout=15m -count=1 ./...
 
-      - name: Compose logs (on failure)
+      - name: Capture compose logs (on failure)
         if: failure()
-        run: docker compose -f docker-compose.test.yml logs --no-color --tail=400
+        run: |
+          set -ex
+          mkdir -p ./compose-logs
+          docker compose -f docker-compose.test.yml logs --no-color --tail=400 \
+            > "./compose-logs/compose-logs-${{ matrix.geoserver }}.txt" 2>&1 || true
+          # Keep a tail in the workflow log too for quick triage.
+          tail -n 200 "./compose-logs/compose-logs-${{ matrix.geoserver }}.txt" || true
+
+      - name: Upload compose logs artifact (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-logs-${{ matrix.geoserver }}
+          path: ./compose-logs/compose-logs-${{ matrix.geoserver }}.txt
+          retention-days: 14
+          if-no-files-found: warn
 
       - name: Tear down
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,23 @@ ARG GO_VERSION=1.25.9
 ARG GOLANGCI_LINT_VERSION=v2.12.1
 ARG GOVULNCHECK_VERSION=latest
 
+# Base image is digest-pinned to immunize the build from upstream re-tags
+# (the OSGeo image is occasionally re-pushed for security patches; without a
+# digest pin a "no-op" CI re-run can suddenly pull a different filesystem).
+# Tag-equivalent at pin time: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4 (multi-arch
+# manifest list covering linux/amd64 and linux/arm64).
+#
+# To re-pin (when bumping GDAL_VERSION or pulling in upstream patches):
+#   docker buildx imagetools inspect ghcr.io/osgeo/gdal:ubuntu-small-<new>
+# captures the manifest list digest. Update both the digest and GDAL_VERSION
+# together — they must stay in sync since downstream tooling (e.g. CGo
+# linker) reads the GDAL version from the actual image.
+ARG GDAL_BASE_DIGEST=sha256:9acfdf967ece13a9a1d9622a494d726aad6b9759aeaae40bbd4d8cb74c843971
+
 # ---------------------------------------------------------------------------
 # Stage 1: dev — Go + GDAL dev headers + tooling
 # ---------------------------------------------------------------------------
-FROM ghcr.io/osgeo/gdal:ubuntu-small-${GDAL_VERSION} AS dev
+FROM ghcr.io/osgeo/gdal@${GDAL_BASE_DIGEST} AS dev
 
 ARG GO_VERSION
 ARG GOLANGCI_LINT_VERSION
@@ -118,7 +131,7 @@ RUN set -eux; \
 # ---------------------------------------------------------------------------
 # Stage 3: runtime — minimal image for shipping
 # ---------------------------------------------------------------------------
-FROM ghcr.io/osgeo/gdal:ubuntu-small-${GDAL_VERSION} AS runtime
+FROM ghcr.io/osgeo/gdal@${GDAL_BASE_DIGEST} AS runtime
 
 # No apt-install: the OSGeo base already provides ca-certificates +
 # libpq5 (lib/pq's runtime dep). Skipping apt makes the runtime stage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,17 @@
 # client's integration suite has those; gismanager does not).
 
 ARG TOMCAT_TAG=9-jdk17-temurin
-FROM tomcat:${TOMCAT_TAG}
+
+# Base image is digest-pinned to immunize the test stack from upstream
+# re-tags. Tag-equivalent at pin time: tomcat:9-jdk17-temurin (multi-arch
+# manifest list).
+#
+# To re-pin (when bumping TOMCAT_TAG or pulling in upstream patches):
+#   docker buildx imagetools inspect tomcat:<new-tag>
+# captures the manifest list digest.
+ARG TOMCAT_BASE_DIGEST=sha256:57536fa59652ece9df8d744749fa5a424136388f2eb934ddc8741918a51afd56
+
+FROM tomcat@${TOMCAT_BASE_DIGEST}
 
 LABEL maintainer="Hesham Karm<hishamwaleedkaram@gmail.com>"
 


### PR DESCRIPTION
## Summary

Four small but compounding gaps in the CI / build surface, bundled because each is too small for its own review cycle and they share a theme (supply-chain hardening + post-mortem visibility).

### 1. Coverage gate (>= 65%)

\`ci.yml\` collected coverage already but never failed on regression. New step parses \`go tool cover -func=coverage.out\` and fails the build below 65%.

| Package | Coverage |
|---------|----------|
| gismanager | 78.3% |
| cmd/internal/cli | 77.3% |
| internal/zipx | 66.0% |
| cmd/gisconvert | 52.7% |
| cmd/gismanager | 0.0% (no tests yet) |
| cmd/layerSchema | 0.0% (no tests yet) |
| **Total** | **69.3%** |

Threshold = 65% gives ~4pp headroom. Raise whenever real coverage improves; track in CHANGELOG.

### 2. Integration log artifact upload (on failure)

\`integration.yml\` previously printed compose logs to stdout on failure, which evaporated with the workflow's run retention. Now captures to \`compose-logs-<geoserver-version>.txt\` and uploads via \`actions/upload-artifact@v4\` (14-day retention, matching the coverage artifact policy). 200-line tail still prints inline for triage.

### 3. \`.dockerignore\`

Docker builds previously sent the entire repo to the daemon — \`.git/\`, \`testdata-fetched/\` (hundreds of MB), \`.github/\`, \`.claude/\`, compose YAMLs. New \`.dockerignore\` excludes everything not consumed by \`Dockerfile\` or \`docker/Dockerfile\`.

### 4. Image digest pins

Both Dockerfiles pulled bases by tag; a silent upstream re-tag could change build results without any commit. New \`GDAL_BASE_DIGEST\` and \`TOMCAT_BASE_DIGEST\` ARGs pin manifest list digests; FROM lines reference them via \`image@\${digest}\`. Multi-arch resolution still works (the pinned digests ARE the manifest list digests). Re-pin recipe documented inline:

\`\`\`
docker buildx imagetools inspect ghcr.io/osgeo/gdal:<new-tag>
\`\`\`

This is item #6 of the [improvement plan](https://github.com/hishamkaram/gismanager/issues).

## Validation

- [x] \`actionlint\` clean on both modified workflows
- [x] \`docker build --target=dev\` succeeds with digest pin (resolves the manifest list, pulls the right arch)
- [x] \`make lint\` and \`make test-unit\` both green (no Go code changed)
- [ ] CI: full matrix runs on push — coverage gate self-tests; integration legs prove the log-artifact step doesn't fire (only on failure)