### PR TITLE
feat(publish): aggregate per-layer failures via errors.Join in PublishAll

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -89,6 +89,72 @@ func TestGISError_NestedChain(t *testing.T) {
 	}
 }
 
+// TestGISError_JoinedAggregation locks in the v1.4 [PublishAll] error
+// contract: each per-layer failure is appended to a slice, and the final
+// return value is errors.Join(slice...) — nil when empty, otherwise an
+// aggregate that walks through every wrapped GISError. Callers must be
+// able to:
+//
+//   - match any sentinel via errors.Is(joined, sentinel) regardless of
+//     which entry in the slice carries it;
+//   - extract the first matching *GISError via errors.As (typical
+//     "give me one example to log" path);
+//   - enumerate every per-layer failure via the unwrap-multiple
+//     interface (`interface{ Unwrap() []error }`).
+//
+// The test constructs a representative joined error directly rather than
+// driving a real PublishAll, since PublishAll requires PostGIS +
+// GeoServer; the errors.Join + GISError mechanics this guards are
+// independent of that infrastructure.
+func TestGISError_JoinedAggregation(t *testing.T) {
+	a := newGISError("PublishGeoserverLayer", "ws/ds/A", ErrGeoServerPublish, errors.New("500 Internal Server Error"))
+	b := newGISError("LayerToPostgis", "ds-B", ErrPostGISConnect, errors.New("dial tcp: refused"))
+	c := newGISError("PublishGeoserverLayer", "ws/ds/C", ErrGeoServerPublish, errors.New("conflict"))
+
+	// Empty join is nil — locks in the "no-failures returns nil"
+	// branch of PublishAll.
+	if errors.Join() != nil {
+		t.Errorf("errors.Join() with no args = non-nil; want nil")
+	}
+
+	joined := errors.Join(a, b, c)
+	if joined == nil {
+		t.Fatal("errors.Join(a,b,c) = nil; want non-nil")
+	}
+
+	if !errors.Is(joined, ErrGeoServerPublish) {
+		t.Errorf("errors.Is(joined, ErrGeoServerPublish) = false; want true (a or c carries it)")
+	}
+	if !errors.Is(joined, ErrPostGISConnect) {
+		t.Errorf("errors.Is(joined, ErrPostGISConnect) = false; want true (b carries it)")
+	}
+	if errors.Is(joined, ErrUnsupportedFormat) {
+		t.Errorf("errors.Is(joined, ErrUnsupportedFormat) = true; want false")
+	}
+
+	// errors.As surfaces the FIRST *GISError in the joined chain (Go's
+	// stdlib walks left-to-right). For PublishAll this is always
+	// useful: callers usually just want one example to log.
+	var first *GISError
+	if !errors.As(joined, &first) {
+		t.Fatal("errors.As did not extract a *GISError from the joined chain")
+	}
+	if first.Op != "PublishGeoserverLayer" || first.Source != "ws/ds/A" {
+		t.Errorf("errors.As surfaced the wrong leaf: Op=%q Source=%q", first.Op, first.Source)
+	}
+
+	// Enumerate via the unwrap-multiple interface — the documented
+	// path for "show me every failure" callers (e.g. CLI summaries
+	// or batch dashboards).
+	var multi interface{ Unwrap() []error }
+	if !errors.As(joined, &multi) {
+		t.Fatal("errors.As to the multi-Unwrap interface failed")
+	}
+	if got := len(multi.Unwrap()); got != 3 {
+		t.Errorf("Unwrap() returned %d errors; want 3", got)
+	}
+}
+
 func TestGISError_ErrorFormatsByCombination(t *testing.T) {
 	cases := []struct {
 		name string

--- a/walk.go
+++ b/walk.go
@@ -2,6 +2,7 @@ package gismanager
 
 import (
 	"context"
+	"errors"
 	"iter"
 
 	"github.com/lukeroth/gdal"
@@ -111,14 +112,41 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 //
 // PublishAll opens the configured PostGIS datastore once at the top
 // (re-using it across every file's layers), so the caller doesn't pay
-// the per-file PostGIS-open cost. Per-file failures are logged via the
-// manager's logger and the loop continues.
+// the per-file PostGIS-open cost.
 //
-// The returned error is non-nil only when a setup step fails (e.g.
-// the PostGIS datastore cannot be opened). Per-layer publish failures
-// are logged and skipped — see the manager's logger output for
-// diagnostics. Future versions may aggregate per-layer errors; the
-// current shape matches `cmd/gismanager`'s pre-PR-3 behavior.
+// Error semantics (since v1.4):
+//
+//   - Setup failures abort the operation. If [(*ManagerConfig).OpenSource]
+//     can't open the PostGIS datastore, PublishAll returns the wrapped
+//     error directly without attempting any layer.
+//   - Per-layer failures (walk errors, PostGIS load errors, GeoServer
+//     publish errors) do NOT abort the loop. Each is logged via the
+//     manager's logger AND collected for aggregation.
+//   - The final return value is [errors.Join] of every collected
+//     per-layer error, or nil if every layer succeeded.
+//
+// Callers can branch on the aggregated result with
+// `errors.Is(err, ErrGeoServerPublish)` / `errors.Is(err, ErrPostGISConnect)`
+// — the joined error walks through every collected failure, so any
+// match in the chain returns true. To enumerate per-layer failures
+// individually, type-assert via `errors.As(err, &gerr)` repeatedly or
+// use a small unwrap walker:
+//
+//	if err := mgr.PublishAll(ctx); err != nil {
+//	    var u interface{ Unwrap() []error }
+//	    if errors.As(err, &u) {
+//	        for _, e := range u.Unwrap() {
+//	            // inspect each per-layer failure
+//	        }
+//	    }
+//	}
+//
+// Pre-v1.4 callers that did `if err := mgr.PublishAll(ctx); err != nil`
+// continue to work — the change strictly adds information. Callers that
+// relied on PublishAll returning nil even when individual layers failed
+// will now see those failures surface; that previous behavior was an
+// acknowledged silent-failure mode (see the v1.3 doc comment) and the
+// aggregated form is the documented path forward.
 func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 	logger := manager.logger
 	if logger == nil {
@@ -130,14 +158,17 @@ func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 	}
 	defer target.Destroy()
 
-	for item, err := range manager.Walk(ctx) {
-		if err != nil {
-			logger.Error("walk", "err", err)
+	var perLayerErrs []error
+	for item, walkErr := range manager.Walk(ctx) {
+		if walkErr != nil {
+			logger.Error("walk", "err", walkErr)
+			perLayerErrs = append(perLayerErrs, walkErr)
 			continue
 		}
 		newLayer, postgisErr := item.Layer.LayerToPostgis(target, manager, true)
 		if postgisErr != nil {
 			logger.Error("load to postgis", "file", item.Path, "err", postgisErr)
+			perLayerErrs = append(perLayerErrs, postgisErr)
 			continue
 		}
 		if newLayer == nil || newLayer.Layer == nil {
@@ -145,9 +176,10 @@ func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 		}
 		if pubErr := manager.PublishGeoserverLayer(ctx, newLayer); pubErr != nil {
 			logger.Error("publish", "file", item.Path, "err", pubErr)
+			perLayerErrs = append(perLayerErrs, pubErr)
 			continue
 		}
 		logger.Info("published", "file", item.Path, "layer", newLayer.Name())
 	}
-	return nil
+	return errors.Join(perLayerErrs...)
 }


### PR DESCRIPTION
## Summary

Closes the silent-failure mode the v1.3 doc comment explicitly flagged:

> *"Future versions may aggregate per-layer errors; the current shape matches \`cmd/gismanager\`'s pre-PR-3 behavior."*

\`PublishAll\` now collects every per-layer failure (walk errors, \`LayerToPostgis\` failures, \`PublishGeoserverLayer\` failures) into a slice and returns \`errors.Join(slice...)\` from the final return. Setup failures (PostGIS datastore can't be opened) still abort early and surface directly.

## Caller-facing implications

- \`if err := mgr.PublishAll(ctx); err != nil\` keeps working — the change strictly **enriches** the envelope. Pre-v1.4 callers who saw \`err == nil\` despite individual layer failures will now see those failures surface; that previous "silently nil" path was the documented bug.
- \`errors.Is(err, ErrGeoServerPublish)\` / \`errors.Is(err, ErrPostGISConnect)\` walk through every collected failure.
- For full enumeration: use the multi-\`Unwrap\` interface (\`interface{ Unwrap() []error }\`).

## Test

New \`TestGISError_JoinedAggregation\` locks in the \`errors.Join\` + \`GISError\` contract: empty join → nil, populated join supports \`errors.Is\` for every constituent sentinel, \`errors.As\` surfaces the first \`*GISError\`, multi-\`Unwrap\` enumerates every failure.

First item from the v1.4 backlog (after the top-10 shipped in PRs #32–#42).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` against GeoServer 2.28.0 — green (12s)
- [ ] CI: full matrix runs on push