### PR TITLE
feat(layerSchema): -json output mode for shell-pipeline scripting

### DIFF
--- a/cmd/layerSchema/layerSchema.go
+++ b/cmd/layerSchema/layerSchema.go
@@ -1,10 +1,18 @@
 // Command layerSchema prints the geometry + attribute schema of every
 // supported GIS file under the configured source directory. Read-only
 // inspector — does not load to PostGIS or publish to GeoServer.
+//
+// Output modes:
+//
+//   - default (text)  — human-readable per-layer block
+//   - -json           — newline-delimited single JSON document with
+//     a top-level array of {path,name,fields[]} entries,
+//     suitable for `jq` / shell scripting / Terraform.
 package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -14,6 +22,15 @@ import (
 	"github.com/hishamkaram/gismanager"
 	"github.com/hishamkaram/gismanager/cmd/internal/cli"
 )
+
+// layerEntry is the JSON shape for one yielded layer when -json is set.
+// Field tags are explicit so the JSON keys stay stable even if the
+// underlying struct fields are renamed in a future refactor.
+type layerEntry struct {
+	Path   string                   `json:"path"`
+	Name   string                   `json:"name"`
+	Fields []*gismanager.LayerField `json:"fields"`
+}
 
 func main() { os.Exit(realMain()) }
 
@@ -36,6 +53,7 @@ func run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("layerSchema", flag.ContinueOnError)
 	configFile := fs.String("config", "", "Config File")
 	versionFlag := fs.Bool("version", false, "print build version and exit")
+	jsonFlag := fs.Bool("json", false, "emit a single JSON document on stdout instead of human-readable text")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -53,15 +71,60 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if *jsonFlag {
+		return runJSON(ctx, manager, os.Stdout)
+	}
+	return runText(ctx, manager, os.Stdout)
+}
+
+// runText emits the human-readable per-layer block format. Walk errors
+// are logged to stderr via slog (the configured logger) but don't abort
+// the loop — same behavior as pre-1.4.
+func runText(ctx context.Context, manager *gismanager.ManagerConfig, out *os.File) error {
 	for item, walkErr := range manager.Walk(ctx) {
 		if walkErr != nil {
 			slog.Error("walk", "err", walkErr)
 			continue
 		}
-		fmt.Println(item.Layer.Name())
+		// Discarding write errors is intentional — the inspector is a
+		// best-effort fire-and-forget on stdout. If the writer is
+		// closed mid-output, the next write returns and the program
+		// exits naturally; surfacing every per-line error would just
+		// spam noise.
+		_, _ = fmt.Fprintln(out, item.Layer.Name())
 		for _, f := range item.Layer.GetLayerSchema() {
-			fmt.Printf("\n%+v\n", *f)
+			_, _ = fmt.Fprintf(out, "\n%+v\n", *f)
 		}
+	}
+	return nil
+}
+
+// runJSON collects every successfully-walked layer into a slice of
+// [layerEntry] values and writes a single JSON array to out at the
+// end. Walk errors go to stderr via slog (matching the text path);
+// only readable layers appear in the JSON document.
+//
+// Compact (single-line) JSON is the default — pipe through `jq` or
+// `python -m json.tool` if a human is reading it. Compact output is
+// the right shell-pipeline default: smaller, faster to parse, and a
+// drop-in for tooling that reads stdout.
+func runJSON(ctx context.Context, manager *gismanager.ManagerConfig, out *os.File) error {
+	entries := []layerEntry{}
+	for item, walkErr := range manager.Walk(ctx) {
+		if walkErr != nil {
+			slog.Error("walk", "err", walkErr)
+			continue
+		}
+		entries = append(entries, layerEntry{
+			Path:   item.Path,
+			Name:   item.Layer.Name(),
+			Fields: item.Layer.GetLayerSchema(),
+		})
+	}
+	enc := json.NewEncoder(out)
+	if err := enc.Encode(entries); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
 	}
 	return nil
 }

--- a/cmd/layerSchema/main_test.go
+++ b/cmd/layerSchema/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hishamkaram/gismanager"
+)
+
+// TestLayerEntryJSON_Shape locks in the on-the-wire shape of the
+// `-json` output. Operators wiring layerSchema into Terraform / jq /
+// Ansible pipelines depend on these JSON keys staying stable; if a
+// future refactor renames a field it must update this test in lockstep.
+func TestLayerEntryJSON_Shape(t *testing.T) {
+	entry := layerEntry{
+		Path: "./testdata/sample.gpkg",
+		Name: "neighborhoods",
+		Fields: []*gismanager.LayerField{
+			{Name: "geom", Type: "POLYGON"},
+			{Name: "id", Type: "Integer"},
+			{Name: "name", Type: "String"},
+		},
+	}
+
+	out, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+
+	for _, want := range []string{
+		`"path":"./testdata/sample.gpkg"`,
+		`"name":"neighborhoods"`,
+		`"fields":[`,
+		`{"Name":"geom","Type":"POLYGON"}`,
+		`{"Name":"id","Type":"Integer"}`,
+		`{"Name":"name","Type":"String"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("JSON output missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+// TestLayerEntryJSON_EmptyArrayIsValid locks in the "no layers found"
+// case: runJSON initializes entries as an empty-but-non-nil slice so
+// the JSON output is `[]\n` rather than `null\n`. Downstream parsers
+// (jq, Python, Terraform) treat the two very differently — empty array
+// is the right contract.
+func TestLayerEntryJSON_EmptyArrayIsValid(t *testing.T) {
+	entries := []layerEntry{}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != `[]` {
+		t.Errorf("empty-slice marshal = %q; want []", string(out))
+	}
+
+	// Contrast: `var entries []layerEntry` (nil slice) marshals to
+	// `null`, which is the wrong shape for shell pipelines. The
+	// runJSON code path constructs `entries := []layerEntry{}`
+	// explicitly to side-step this.
+	var nilEntries []layerEntry
+	out, _ = json.Marshal(nilEntries)
+	if string(out) != `null` {
+		t.Errorf("nil-slice marshal = %q; want null (this guards the runJSON allocation choice)", string(out))
+	}
+}


### PR DESCRIPTION
## Summary

Adds a \`-json\` flag to \`cmd/layerSchema\` that emits a single top-level JSON array of \`{path, name, fields[]}\` objects, suitable for \`jq\` / Terraform / Ansible / shell scripts that want structured layer-discovery output. Compact (single-line) JSON is the default — pipe through \`jq\` for pretty-printing.

The pre-existing free-form text output (each layer's name then \`%+v\`-printed fields) is unchanged and remains the default.

## Output shape

\`\`\`json
[
  {
    "path": "./testdata/sample.gpkg",
    "name": "neighborhoods",
    "fields": [
      {"Name": "geom", "Type": "POLYGON"},
      {"Name": "id",   "Type": "Integer"}
    ]
  }
]
\`\`\`

## Stable contract

- \`layerEntry\` (the top-level wrapper) has explicit JSON tags so the contract stays stable across struct refactors.
- The \`fields\` array marshals \`gismanager.LayerField\` directly (its public \`Name\`/\`Type\` fields are already exported, no shadow type needed).
- Empty walk → \`[]\n\` (not \`null\n\`). \`runJSON\` initializes \`entries := []layerEntry{}\` explicitly to avoid the nil-slice-marshals-as-null trap.

## Tests

- \`TestLayerEntryJSON_Shape\` — locks in the on-the-wire keys.
- \`TestLayerEntryJSON_EmptyArrayIsValid\` — guards the empty-vs-nil shape (Terraform / jq / Python all treat the two very differently).

This is the second item from the v1.4 backlog (after PR #43's \`errors.Join\` PublishAll).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green; both new tests pass
- [ ] CI: full matrix runs on push