### PR TITLE
chore(make): make ci umbrella + make benchmark targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ARGS ?=
 GEOSERVER_VERSION ?= 2.28.0
 
 .PHONY: help dev shell build build-cli test test-unit test-integration lint lint-fix \
-        vuln tidy fmt vet image clean fetch-testdata \
+        vuln tidy fmt vet image clean fetch-testdata ci benchmark \
         compose-up compose-down compose-test-up compose-test-down compose-test-logs
 
 help: ## show this help
@@ -68,6 +68,20 @@ test-unit: ## go test -race ./... (no integration tag)
 
 test-integration: fetch-testdata ## go test -tags=integration ./... inside the test-runner container against the compose-test stack (requires compose-test-up first)
 	$(COMPOSE_TEST) run --rm -T test-runner go test -race -tags=integration -timeout=15m -count=1 $(ARGS) ./...
+
+# CI umbrella: the four checks every PR's CI matrix runs in ~3 min.
+# Excludes test-integration on purpose — that needs a live stack and
+# is its own `make test-integration` target. Run that separately via
+# `make compose-test-up && make test-integration && make compose-test-down`
+# (or via the `/integration-test` slash command).
+ci: lint vet test-unit vuln ## fast CI proxy: lint + vet + unit + vuln (no integration)
+
+# Benchmarks. The repo currently has no `func Benchmark*` cases, but
+# `make benchmark` is wired so a future `BenchmarkPublishAll` /
+# `BenchmarkConvertVector` can be exercised the same way as the rest
+# of the test surface. Pass `-benchtime=`, `-cpu=`, etc. via ARGS.
+benchmark: ## go test -bench=. -benchmem ./... (no benchmarks yet; placeholder for future)
+	$(RUN) go test -bench=. -benchmem -run='^$$' $(ARGS) ./...
 
 fetch-testdata: ## download/refresh testdata fixtures listed in testdata/manifest.sha256 (idempotent; runs on host since curl + sha256sum are stdlib)
 	@bash scripts/fetch-testdata.sh


### PR DESCRIPTION
## Summary

Two small DX additions to the Makefile, both purely additive:

- **\`make ci\`** — fast CI proxy that runs \`lint + vet + test-unit + vuln\` in sequence (~3 min). Mirrors the four CI jobs every PR passes through, **minus integration** (which needs a live stack and is its own \`make compose-test-up && make test-integration\` flow). Contributors wanting to preflight before push can now run \`make ci\` instead of remembering the four individual targets.
- **\`make benchmark\`** — wires \`go test -bench=. -benchmem -run='^\$' ./...\` so any future \`Benchmark*\` function (e.g. \`BenchmarkPublishAll\`, \`BenchmarkConvertVector\`, \`BenchmarkBuildVectorTranslateArgs\`) is exercisable without anyone having to remember the magic invocation. **No benchmarks exist yet**; this is the placeholder so adding one is a code-only change.

Both targets added to \`.PHONY\` and documented in \`make help\`. No code changes; no behavior changes to existing targets.

This is the third item from the v1.4 backlog (after PRs #43 \`errors.Join\` and #44 \`--json\` layerSchema).

## Test plan

- [x] \`make help\` lists the two new targets with their docstrings
- [x] \`make ci\` smoke-tested locally — runs lint → vet → test-unit → vuln, all green
- [x] \`make benchmark\` smoke-tested — exits clean (no benchmarks defined; \`-run='^\$'\` is the standard skip-tests-run-only-bench idiom)
- [ ] CI: full matrix runs on push (workflow files unchanged; this is a Makefile-only change)