### PR TITLE
feat(publish): bounded-concurrency GeoServer publish in PublishAll

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -116,6 +116,14 @@ func (manager *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *
 // Callers (notably PublishGeoserverLayer) typically re-wrap the returned
 // *GISError with their own Op for the public-facing error envelope; the
 // inner GISError remains reachable via Unwrap for finer-grained triage.
+//
+// Concurrent-call safety: when N goroutines all hit the Get-not-found
+// branch simultaneously, only the first Create wins; the rest receive
+// 409 Conflict ([geoserver.ErrConflict]). That outcome is operationally
+// equivalent to "workspace exists" — exactly what the ensure semantics
+// promise — so we treat ErrConflict as success rather than propagating
+// the race up to the caller. PublishAll's worker-pool publish path
+// depends on this idempotency.
 func ensureWorkspace(ctx context.Context, c *geoserver.Client, name string) error {
 	if _, err := c.Workspaces.Get(ctx, name); err == nil {
 		return nil
@@ -123,15 +131,19 @@ func ensureWorkspace(ctx context.Context, c *geoserver.Client, name string) erro
 		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
 	}
 	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: name}); err != nil {
+		if errors.Is(err, geoserver.ErrConflict) {
+			return nil
+		}
 		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
 	}
 	return nil
 }
 
 // ensureDatastore looks up the PostGIS-backed datastore in the given
-// workspace and creates it if missing. Same error-wrapping contract as
-// [ensureWorkspace] — errors are *GISError with Op="ensureDatastore" and
-// Sentinel=ErrGeoServerPublish.
+// workspace and creates it if missing. Same error-wrapping contract and
+// same concurrent-create idempotency (ErrConflict treated as success)
+// as [ensureWorkspace] — errors are *GISError with Op="ensureDatastore"
+// and Sentinel=ErrGeoServerPublish.
 func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds DatastoreConfig) error {
 	scoped := c.Datastores.InWorkspace(ws)
 	if _, err := scoped.Get(ctx, ds.Name); err == nil {
@@ -148,6 +160,9 @@ func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds Dat
 		Password: ds.DBPass,
 	}
 	if err := scoped.Create(ctx, conn); err != nil {
+		if errors.Is(err, geoserver.ErrConflict) {
+			return nil
+		}
 		return newGISError("ensureDatastore", ds.Name, ErrGeoServerPublish, err)
 	}
 	return nil

--- a/walk.go
+++ b/walk.go
@@ -4,9 +4,25 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"sync"
 
 	"github.com/lukeroth/gdal"
 )
+
+// defaultPublishConcurrency caps how many GeoServer feature-type
+// creations PublishAll dispatches in parallel. The publish step is
+// HTTP-only (no GDAL CGo, no PostGIS connection from gismanager —
+// GeoServer queries PostGIS itself), so it parallelizes cleanly. The
+// upstream walk and the LayerToPostgis CopyLayer call stay serial
+// because both touch the shared *gdal.DataSource and the underlying
+// CGo handle is not reentrancy-safe across goroutines.
+//
+// Default 8 was picked from typical observation: GeoServer FeatureType
+// creation is ~100-500ms per call, so 8 parallel takes ~50ms aggregate
+// per layer instead of ~250ms. Higher concurrency mostly bottlenecks
+// on GeoServer's own thread pool rather than gismanager. Expose as a
+// functional option in v1.5+ if there's demand to tune.
+const defaultPublishConcurrency = 8
 
 // WalkItem is one yielded element of [(*ManagerConfig).Walk]: a
 // (path, layer) pair the caller can consume.
@@ -114,6 +130,20 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 // (re-using it across every file's layers), so the caller doesn't pay
 // the per-file PostGIS-open cost.
 //
+// Concurrency model (since v1.4):
+//
+//   - Walk and LayerToPostgis are SERIAL across the whole call. Both
+//     touch the shared *gdal.DataSource (the PostGIS target) and the
+//     underlying CGo handle is not reentrancy-safe across goroutines.
+//   - PublishGeoserverLayer (HTTP-only — GeoServer queries PostGIS
+//     itself; gismanager just registers the feature type) runs in a
+//     bounded worker pool of [defaultPublishConcurrency] goroutines.
+//     Layers with publish-side latency (typical GeoServer
+//     FeatureType.Create is 100-500ms) overlap, so a 50-layer publish
+//     takes O(N/8 * latency) instead of O(N * latency).
+//   - The publish-side ordering is therefore non-deterministic, but
+//     that has never been part of PublishAll's contract.
+//
 // Error semantics (since v1.4):
 //
 //   - Setup failures abort the operation. If [(*ManagerConfig).OpenSource]
@@ -121,7 +151,8 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 //     error directly without attempting any layer.
 //   - Per-layer failures (walk errors, PostGIS load errors, GeoServer
 //     publish errors) do NOT abort the loop. Each is logged via the
-//     manager's logger AND collected for aggregation.
+//     manager's logger AND collected for aggregation. Aggregation is
+//     mutex-protected since publish goroutines run concurrently.
 //   - The final return value is [errors.Join] of every collected
 //     per-layer error, or nil if every layer succeeded.
 //
@@ -158,28 +189,82 @@ func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 	}
 	defer target.Destroy()
 
-	var perLayerErrs []error
+	// Pre-warm the workspace + datastore once, serially, BEFORE
+	// dispatching the parallel publish goroutines. Without this, N
+	// publish goroutines hit the Get-not-found branch of ensure*
+	// simultaneously and race to Create. For workspaces that surfaces
+	// as a clean 409 Conflict (geoserver.ErrConflict), but for
+	// datastores GeoServer instead returns 500 with "already exists"
+	// in the body — a non-idempotent wire-format quirk that's hard to
+	// match defensively. Pre-warming sidesteps the race entirely:
+	// every per-layer ensureWorkspace / ensureDatastore call finds
+	// the resource on the Get and short-circuits. (The conflict
+	// tolerance in ensureWorkspace is still useful as defense-in-depth
+	// for callers invoking PublishGeoserverLayer directly without
+	// going through PublishAll.)
+	catalog, catErr := manager.GetGeoserverCatalog()
+	if catErr != nil {
+		return newGISError("PublishAll", "", ErrGeoServerPublish, catErr)
+	}
+	if wsErr := ensureWorkspace(ctx, catalog, manager.Geoserver.WorkspaceName); wsErr != nil {
+		return wsErr
+	}
+	if dsErr := ensureDatastore(ctx, catalog, manager.Geoserver.WorkspaceName, manager.Datastore); dsErr != nil {
+		return dsErr
+	}
+
+	// Bounded worker pool for the publish step. The semaphore acts as
+	// the concurrency gate; wg ensures we wait for every dispatched
+	// publish before returning. errsMu protects perLayerErrs from
+	// concurrent writes by the publish goroutines.
+	sem := make(chan struct{}, defaultPublishConcurrency)
+	var wg sync.WaitGroup
+	var errsMu sync.Mutex
+	perLayerErrs := []error{}
+
+	recordErr := func(err error) {
+		errsMu.Lock()
+		perLayerErrs = append(perLayerErrs, err)
+		errsMu.Unlock()
+	}
+
 	for item, walkErr := range manager.Walk(ctx) {
 		if walkErr != nil {
 			logger.Error("walk", "err", walkErr)
-			perLayerErrs = append(perLayerErrs, walkErr)
+			recordErr(walkErr)
 			continue
 		}
 		newLayer, postgisErr := item.Layer.LayerToPostgis(target, manager, true)
 		if postgisErr != nil {
 			logger.Error("load to postgis", "file", item.Path, "err", postgisErr)
-			perLayerErrs = append(perLayerErrs, postgisErr)
+			recordErr(postgisErr)
 			continue
 		}
 		if newLayer == nil || newLayer.Layer == nil {
 			continue
 		}
-		if pubErr := manager.PublishGeoserverLayer(ctx, newLayer); pubErr != nil {
-			logger.Error("publish", "file", item.Path, "err", pubErr)
-			perLayerErrs = append(perLayerErrs, pubErr)
-			continue
-		}
-		logger.Info("published", "file", item.Path, "layer", newLayer.Name())
+
+		// Dispatch the publish step into the worker pool. Acquiring
+		// the semaphore here (BEFORE go func) means a producer that
+		// outpaces the publishers blocks on the channel send rather
+		// than spawning unbounded goroutines.
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(item WalkItem, newLayer *GdalLayer) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if pubErr := manager.PublishGeoserverLayer(ctx, newLayer); pubErr != nil {
+				logger.Error("publish", "file", item.Path, "err", pubErr)
+				recordErr(pubErr)
+				return
+			}
+			logger.Info("published", "file", item.Path, "layer", newLayer.Name())
+		}(item, newLayer)
 	}
+
+	// Drain the worker pool before reading the error slice. wg.Wait()
+	// is the synchronization point that publishes every recordErr
+	// write to the goroutine reading perLayerErrs below.
+	wg.Wait()
 	return errors.Join(perLayerErrs...)
 }


### PR DESCRIPTION
## Summary

\`PublishAll\` now dispatches GeoServer \`FeatureType.Create\` calls into a bounded worker pool of 8 goroutines. The walk + \`LayerToPostgis\` steps stay serial (both touch the shared \`*gdal.DataSource\` and the CGo handle isn't reentrancy-safe across goroutines), but the publish step is HTTP-only — GeoServer queries PostGIS itself when serving the feature type — so it parallelizes cleanly.

**Typical impact:** GeoServer \`FeatureType.Create\` is 100–500ms per call. A 50-layer publish that previously ran serially in O(N × latency) now runs in O(N/8 × latency). Publish-side ordering is non-deterministic, but that has never been part of PublishAll's contract.

## Two races discovered + fixed under the integration suite

1. **Workspace 409.** Concurrent \`ensureWorkspace\` calls hit \`Get-not-found\` in the same burst and all race to \`Create\`. First wins; the rest receive 409 Conflict (\`geoserver.ErrConflict\`). **Fix:** \`ensureWorkspace\` now tolerates \`ErrConflict\` as success — the workspace exists either way, which is exactly what the \"ensure\" name promises.
2. **Datastore 500.** Same race, but GeoServer returns **500 Internal Server Error** with \`Store … already exists\` in the body, not 409 — a wire-format quirk that's hard to match defensively at the helper level.

**The robust fix for both:** \`PublishAll\` now **pre-warms** the workspace + datastore once, serially, before dispatching any publish goroutines. Every per-layer \`ensureWorkspace\` / \`ensureDatastore\` call then finds the resource on the \`Get\` and short-circuits. The \`ErrConflict\` tolerance is kept as defense-in-depth for callers invoking \`PublishGeoserverLayer\` directly without going through \`PublishAll\`.

The 500-quirk handling in \`ensureDatastore\` is deferred to a follow-up — pre-warming makes it unnecessary in the \`PublishAll\` path, and direct-concurrent \`PublishGeoserverLayer\` is documented as **not yet goroutine-safe**.

## Implementation

- \`defaultPublishConcurrency = 8\` in \`walk.go\` — picked from typical observation; comment notes \"expose as Option in v1.5+ if there's demand to tune\".
- Bounded worker pool via stdlib \`sync.WaitGroup\` + buffered channel semaphore — **no new runtime dep** (per CLAUDE.md the project keeps its dep surface intentionally small).
- Per-layer error collection mutex-protected via a small \`recordErr\` helper.
- \`wg.Wait()\` before reading \`perLayerErrs\` is the synchronization point.
- \`PublishAll\` docstring gains a \"Concurrency model\" section.

This is the sixth item from the v1.4 backlog (after PRs #43–#47).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green
- [x] \`make test-integration\` against GeoServer 2.28.0 + PostGIS — green (10s; the existing 5-layer integration test exercises 5 concurrent publish goroutines, which surfaced both races on the first try before the pre-warm fix landed)
- [ ] CI: full matrix runs on push