### PR TITLE
fix(release): replace buildx --output=local with docker create+cp for amd64 binary extract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,30 +97,45 @@ jobs:
 
       # ---------- Raw amd64 binaries --------------------------------------
       #
-      # We rebuild the binaries on the host runner (with a static GDAL
-      # apt-installed) rather than copying out of the multi-arch image,
-      # because docker buildx --platform=linux/amd64,linux/arm64 stores
-      # both arches in a manifest list and `docker create` to extract
-      # binaries works on a single-arch image only. Building once more
-      # for amd64 with the same Dockerfile build stage is the simplest
-      # path and re-uses the already-warm Buildx cache.
+      # Strategy: re-run buildx for the single linux/amd64 target=runtime
+      # stage with `load: true` so the resulting image is hydrated into
+      # the local Docker daemon's image store (multi-arch buildx with
+      # --push doesn't populate the local daemon, so we'd otherwise have
+      # to re-pull from ghcr.io to extract). Then `docker create` +
+      # `docker cp` pulls just the three binaries — fast (~10s) because
+      # docker cp doesn't copy unrelated layers. The cache-from scope is
+      # the same as the multi-arch step so the GHA layer cache is warm
+      # and the rebuild is mostly a relink rather than a full Go build.
+      #
+      # Why not `--output type=local,dest=./...`? That extracts the
+      # entire build-stage filesystem (~4 GB on ubuntu-full), which on
+      # the v1.4.0 cut hung the runner past the 60-min monitor window.
+      # docker cp scoped to /usr/local/bin/<binary> is two orders of
+      # magnitude faster.
 
-      - name: Build amd64 binaries (extract from single-arch build)
+      - name: Build amd64 runtime image into local Docker daemon
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          load: true
+          tags: gismanager:amd64-extract
+          cache-from: type=gha,scope=runtime-image
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            DATE=${{ env.DATE }}
+
+      - name: Extract amd64 binaries via docker create + docker cp
         run: |
           set -ex
           mkdir -p dist
-          docker buildx build \
-            --platform linux/amd64 \
-            --target build \
-            --build-arg "VERSION=${VERSION}" \
-            --build-arg "COMMIT=${COMMIT}" \
-            --build-arg "DATE=${DATE}" \
-            --output type=local,dest=./dist-build \
-            .
-          # The build stage writes binaries to /out; --output=local copies
-          # the entire image fs, so we pull the three binaries from /out.
+          container_id=$(docker create gismanager:amd64-extract)
+          trap 'docker rm "${container_id}" >/dev/null || true' EXIT
           for bin in gismanager layerSchema gisconvert; do
-            cp "dist-build/out/${bin}" "dist/${bin}"
+            docker cp "${container_id}:/usr/local/bin/${bin}" "dist/${bin}"
             chmod +x "dist/${bin}"
           done
           ls -la dist/


### PR DESCRIPTION
## Summary

The v1.4.0 cut hung \`release.yml\` past the 60-min monitor window on the binary-extract step (run [25441840804](https://github.com/hishamkaram/gismanager/actions/runs/25441840804)). The image stage finished cleanly (multi-arch + cosign-signed); the binary stage was the design issue. Cancelled the run cleanly and shipped v1.4.0 manually with image-as-primary-artifact.

This PR fixes the workflow so v1.4.1+ ship binary tarballs end-to-end.

## Root cause

\`\`\`yaml
docker buildx build --target=build --platform=linux/amd64 \\
    --output type=local,dest=./dist-build .
\`\`\`

\`--output type=local\` extracts the **entire build-stage filesystem** (~4 GB on ubuntu-full base). We only need three binaries (~150 MB total). Two orders of magnitude of unnecessary I/O.

## Fix

Two-step replacement using the standard "build-and-cp" CI pattern:

1. **Build the single-arch runtime image into the local Docker daemon** via \`docker/build-push-action@v6\` with \`platforms: linux/amd64\` + \`load: true\`. Reuses the \`type=gha,scope=runtime-image\` cache from the multi-arch step, so the rebuild is mostly a re-link. Image is ~2 GB (target=runtime, no dev cruft).
2. **\`docker create\` + \`docker cp\`** to extract each binary from \`/usr/local/bin/\`. Each cp pulls one ~30-50 MB file, not the entire image filesystem.

Net change: ~10s extract instead of >60 min hang.

## Why not pull from ghcr.io

\`docker buildx --push\` doesn't populate the local daemon's image store with the pushed layers; a subsequent \`docker pull\` would re-fetch over the network. The single-arch \`load: true\` build is faster end-to-end.

## Validation

- [x] \`actionlint .github/workflows/release.yml\` — clean (exit 0)
- [ ] **End-to-end exercise via \`v1.4.1-rc.1\` after merge** — first real test of the fixed pipeline. If green, cut \`v1.4.1\` proper.

Phase 0 of the v2 restructure plan ([\`~/.claude/plans/how-can-we-improve-steady-emerson.md\`](#)) — must land before any v2 work.