### PR TITLE
ci(workflows): trigger on release/v* branches; document maintenance-branch policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, "release/v*"]
   pull_request:
-    branches: [master]
+    branches: [master, "release/v*"]
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ name: Integration tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, "release/v*"]
   workflow_dispatch:
     inputs:
       geoserver:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,9 @@ name: Security scans
 
 on:
   push:
-    branches: [master]
+    branches: [master, "release/v*"]
   pull_request:
-    branches: [master]
+    branches: [master, "release/v*"]
   schedule:
     # Sundays at 04:23 UTC — outside common deploy windows; offset 1 hour
     # from integration.yml's Sunday cron so the two don't compete for

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,6 +103,52 @@ After the workflow finishes:
 Open a tracking issue or PR for next-cycle items if relevant. The next
 `[Unreleased]` block accumulates entries until the next cut.
 
+## Maintenance branches
+
+When master diverges from a stable release line — e.g. master is leading
+edge of v2 work but v1.x users still need security/CVE patches — the
+project keeps a `release/vX.x` long-lived branch (one per major-version
+line) for back-porting fixes.
+
+### Current state
+
+- **`master`** — leading edge. As of the v2 restructure (see
+  `~/.claude/plans/how-can-we-improve-steady-emerson.md`), master is the
+  v2 development line. v1 users should NOT pull from master.
+- **`release/v1.x`** — v1.x patch line, branched from `v1.4.1`. Any v1
+  patch release (`v1.4.2`, `v1.5.0`, etc.) is cut from this branch.
+
+### CI coverage on maintenance branches
+
+`.github/workflows/{ci,integration,security}.yml` trigger on both
+`master` and `release/v*` for `push` and `pull_request` events. PRs
+opened against `release/v1.x` get the full matrix (lint + unit +
+integration on GeoServer 2.27 LTS + 2.28 stable + Trivy + CodeQL +
+govulncheck) just like master PRs.
+
+### Cutting a v1 patch
+
+1. Branch off `release/v1.x`: `git checkout release/v1.x && git pull`.
+2. Open a feature branch off that and PR back to `release/v1.x`.
+3. After CI green + merge, update `CHANGELOG.md` `[Unreleased]`
+   on the maintenance branch into a `[1.4.2]` (or whatever) stanza,
+   commit, push.
+4. Tag `v1.4.2` from the `release/v1.x` HEAD: `git tag -s v1.4.2 …`
+   (or `-a` if no GPG configured), `git push origin v1.4.2`. The
+   release.yml workflow runs from the tag's commit (not master) so
+   the artifact build uses the maintenance-branch source.
+5. Smoke test (same as master release).
+
+### Forward-porting fixes
+
+For fixes that must land on BOTH master and `release/v1.x`, prefer:
+- Land on `release/v1.x` first, then cherry-pick to master.
+- Or land on master first, then cherry-pick to `release/v1.x`.
+
+The cherry-pick direction depends on how invasive the fix is on master
+vs. the maintenance branch. Either way, document the cherry-pick
+relationship in the second commit's message (`cherry-picked from <sha>`).
+
 ## Yanking a bad release
 
 If a release goes out broken:


### PR DESCRIPTION
## Summary

Phase 0 **PR-B** of the v2 restructure plan. Now that master is about to diverge into v2 work, v1.x security/CVE patches need their own long-lived branch with full CI coverage.

## Branch structure post-PR

- **\`master\`** — leading edge (v2 development line, starting Phase 1 next)
- **\`release/v1.x\`** — already pushed, branched from \`v1.4.1\`; v1 patch line

## Changes

1. **Workflow trigger updates** — \`.github/workflows/{ci,integration,security}.yml\` now trigger on \`branches: [master, "release/v*"]\` for both \`push\` and \`pull_request\` events. PRs opened against \`release/v1.x\` get the full matrix (lint + unit + integration on GeoServer 2.27 LTS + 2.28 stable + Trivy + CodeQL + govulncheck) just like master PRs.
2. **\`RELEASING.md\`** — new "Maintenance branches" section documenting:
   - Current state (master = v2 line; release/v1.x = v1 patch line)
   - CI coverage policy
   - Cut-a-v1-patch runbook (branch off, PR back, tag from branch HEAD)
   - Forward-port guidance for fixes that must land on both lines

## What this enables

Phase 1 of the v2 plan can start landing on master without breaking v1 users — they pull from \`release/v1.x\` for any v1.4.2 / v1.5.0 patches.

## Validation

- [x] \`actionlint\` clean on all three modified workflows
- [ ] CI: full matrix on this PR (workflows are exercised for the first time WITH the new branch trigger; if anything broke, this PR's own CI catches it)