### PR TITLE
refactor(internal): extract errors → internal/errs and log → internal/slogx (compat-preserving)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,122 +1,47 @@
 package gismanager
 
-import (
-	"errors"
-	"fmt"
-)
+import "github.com/hishamkaram/gismanager/internal/errs"
 
-// Sentinel errors. Match via [errors.Is] — never compare error strings.
-//
-// These wrap higher-level failure categories. The library wraps them around
-// the underlying cause (GDAL CGo error, *geoserver.APIError, lib/pq error,
-// etc.) so callers can branch on the category while still recovering the
-// original via [errors.As].
+// This file is a v1.x compatibility shim. The actual implementation of
+// the typed-error machinery lives in [internal/errs] as of the v2
+// restructure groundwork (Phase 1). External callers continue to use
+// the gismanager-prefixed names (gismanager.GISError,
+// gismanager.ErrConvertFailed, etc.) — those work via the type
+// aliases and var aliases below. Internal callers within the root
+// package call the package-private newGISError wrapper, which
+// delegates to errs.NewGISError. v2 will drop this file when the
+// root package is emptied of all symbols.
+
+// GISError aliases [internal/errs.GISError]. See that type for full
+// documentation. v1.x users should keep importing [GISError] from
+// this package; the alias means errors.As / errors.Is / pointer
+// equality all work transparently across the boundary.
+type GISError = errs.GISError
+
+// Sentinel errors aliased from [internal/errs]. The underlying values
+// are the SAME error instances — `errors.Is(err, gismanager.ErrConvertFailed)`
+// and `errors.Is(err, errs.ErrConvertFailed)` both work because they
+// reference the same underlying *errors.errorString.
 var (
-	// ErrConfigInvalid signals that the YAML config is syntactically valid
-	// but semantically wrong (missing fields, malformed values, etc.).
-	ErrConfigInvalid = errors.New("gismanager: config invalid")
-
-	// ErrUnsupportedFormat signals that a path's extension does not map to
-	// any GDAL OGR driver gismanager knows about.
-	ErrUnsupportedFormat = errors.New("gismanager: unsupported format")
-
-	// ErrInvalidLayer signals that a *GdalLayer was nil or had a nil
-	// embedded *gdal.Layer pointer when an operation required a real layer.
-	ErrInvalidLayer = errors.New("gismanager: invalid layer")
-
-	// ErrInvalidDatasource signals that a *gdal.DataSource passed in was
-	// nil or unusable.
-	ErrInvalidDatasource = errors.New("gismanager: invalid datasource")
-
-	// ErrPostGISConnect signals that the PostGIS ping/handshake failed.
-	// The underlying *pq.Error (or driver-level error) is recoverable via
-	// [errors.As].
-	ErrPostGISConnect = errors.New("gismanager: postgis connect")
-
-	// ErrGeoServerPublish signals that the GeoServer publish flow failed
-	// at workspace, datastore, or feature-type creation. The underlying
-	// *geoserver.APIError is recoverable via [errors.As].
-	ErrGeoServerPublish = errors.New("gismanager: geoserver publish")
-
-	// ErrNoSourcesFound signals that the configured source directory
-	// contained no supported GIS files.
-	ErrNoSourcesFound = errors.New("gismanager: no sources found")
-
-	// ErrConvertFailed signals that a vector or raster conversion
-	// (ConvertVector / ConvertRaster / ToCOG / ReprojectRaster) failed.
-	// The underlying GDAL error is recoverable via [errors.As] into
-	// [*GISError]; the GISError.Op field disambiguates which entry
-	// point produced the error.
-	ErrConvertFailed = errors.New("gismanager: convert failed")
+	ErrConfigInvalid     = errs.ErrConfigInvalid
+	ErrUnsupportedFormat = errs.ErrUnsupportedFormat
+	ErrInvalidLayer      = errs.ErrInvalidLayer
+	ErrInvalidDatasource = errs.ErrInvalidDatasource
+	ErrPostGISConnect    = errs.ErrPostGISConnect
+	ErrGeoServerPublish  = errs.ErrGeoServerPublish
+	ErrNoSourcesFound    = errs.ErrNoSourcesFound
+	ErrConvertFailed     = errs.ErrConvertFailed
 )
 
-// GISError is the typed error gismanager returns for higher-level
-// operations. It carries the operation name, the source path (file, layer
-// name, or workspace as appropriate), the sentinel category, and the
-// underlying cause.
+// newGISError is the internal call-site wrapper around
+// [internal/errs.NewGISError]. Keeping it here means every existing
+// caller in the root package (manager.go / layer.go / walk.go /
+// utils.go / convert_*.go) is unchanged in Phase 1 — they continue to
+// call newGISError as before, which now delegates to the moved impl.
 //
-// Match by sentinel:
-//
-//	if errors.Is(err, gismanager.ErrUnsupportedFormat) { ... }
-//
-// Inspect for fields:
-//
-//	var gerr *gismanager.GISError
-//	if errors.As(err, &gerr) {
-//	    log.Println(gerr.Op, gerr.Source)
-//	}
-type GISError struct {
-	// Op is the operation name (e.g. "OpenSource", "PublishGeoserverLayer",
-	// "LoadToPostGIS"). Useful for logging and triage.
-	Op string
-
-	// Source identifies what the operation acted on — typically a file
-	// path, a layer name, or a workspace name. Empty if not applicable.
-	Source string
-
-	// Sentinel is one of the package-level Err* values. errors.Is(e,
-	// Sentinel) returns true.
-	Sentinel error
-
-	// Cause is the underlying error. May be nil if the failure is
-	// purely a sentinel (e.g. ErrInvalidLayer with no nested cause).
-	Cause error
-}
-
-// Error returns a stable, parseable message of the form
-//
-//	gismanager: <Op> <Source>: <sentinel>: <cause>
-//
-// Source is omitted if empty; Cause is omitted if nil.
-func (e *GISError) Error() string {
-	switch {
-	case e.Source == "" && e.Cause == nil:
-		return fmt.Sprintf("gismanager: %s: %v", e.Op, e.Sentinel)
-	case e.Source == "":
-		return fmt.Sprintf("gismanager: %s: %v: %v", e.Op, e.Sentinel, e.Cause)
-	case e.Cause == nil:
-		return fmt.Sprintf("gismanager: %s %q: %v", e.Op, e.Source, e.Sentinel)
-	default:
-		return fmt.Sprintf("gismanager: %s %q: %v: %v", e.Op, e.Source, e.Sentinel, e.Cause)
-	}
-}
-
-// Unwrap returns the underlying cause for [errors.Is] / [errors.As]
-// traversal. It walks past Sentinel — Sentinel is matched separately by
-// [GISError.Is].
-func (e *GISError) Unwrap() error { return e.Cause }
-
-// Is reports whether the error matches the given target. It returns true
-// for the GISError's Sentinel so callers can match by category:
-//
-//	errors.Is(err, gismanager.ErrUnsupportedFormat)
-func (e *GISError) Is(target error) bool {
-	return target != nil && e.Sentinel == target
-}
-
-// newGISError is the internal constructor. Callers in this package wrap
-// underlying failures with a sentinel category so the public surface is
-// consistent.
+// Phase 2+ moves the convert_*.go callers to a separate subpackage
+// where they call errs.NewGISError directly; same for Phase 3 with
+// publish/. Phase 4 drops this wrapper when no root caller remains.
 func newGISError(op, source string, sentinel, cause error) *GISError {
-	return &GISError{Op: op, Source: source, Sentinel: sentinel, Cause: cause}
+	return errs.NewGISError(op, source, sentinel, cause)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,191 +2,46 @@ package gismanager
 
 import (
 	"errors"
-	"fmt"
 	"testing"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
-func TestGISError_IsAndUnwrap(t *testing.T) {
-	cause := errors.New("underlying boom")
+// TestErrAliasChain_v1Compat confirms the v1.x compat shim resolves
+// public API symbols (gismanager.GISError, gismanager.ErrConvertFailed,
+// the package-private newGISError) to the SAME underlying types and
+// values living in [internal/errs]. The exhaustive *GISError mechanic
+// tests live in internal/errs/errs_test.go.
+//
+// This single test guards against a future refactor accidentally
+// breaking the alias chain — e.g. introducing a separate type at root
+// instead of `type GISError = errs.GISError`, which would break
+// errors.As across the alias boundary for external callers.
+func TestErrAliasChain_v1Compat(t *testing.T) {
+	cause := errors.New("underlying")
 	gerr := newGISError("OpenSource", "/tmp/foo.shp", ErrUnsupportedFormat, cause)
 
+	// Sentinel match works against both the root alias and the
+	// underlying internal/errs sentinel — they're the same instance.
 	if !errors.Is(gerr, ErrUnsupportedFormat) {
-		t.Errorf("errors.Is(gerr, ErrUnsupportedFormat) = false, want true")
+		t.Errorf("errors.Is(gerr, ErrUnsupportedFormat) = false; want true (root alias)")
 	}
-	if errors.Is(gerr, ErrInvalidLayer) {
-		t.Errorf("errors.Is(gerr, ErrInvalidLayer) = true, want false")
-	}
-	if !errors.Is(gerr, cause) {
-		t.Errorf("errors.Is(gerr, cause) = false, want true (Unwrap)")
-	}
-}
-
-func TestGISError_As(t *testing.T) {
-	cause := errors.New("underlying boom")
-	gerr := newGISError("PublishGeoserverLayer", "ws/ds/lyr", ErrGeoServerPublish, cause)
-	wrapped := fmt.Errorf("outer: %w", gerr)
-
-	var got *GISError
-	if !errors.As(wrapped, &got) {
-		t.Fatalf("errors.As did not match")
-	}
-	if got.Op != "PublishGeoserverLayer" {
-		t.Errorf("Op = %q, want PublishGeoserverLayer", got.Op)
-	}
-	if got.Source != "ws/ds/lyr" {
-		t.Errorf("Source = %q, want ws/ds/lyr", got.Source)
-	}
-}
-
-// TestGISError_NestedChain locks in the contract for the nested-*GISError
-// chain produced by [PublishGeoserverLayer] when an
-// [ensureWorkspace] / [ensureDatastore] helper fails: each helper
-// returns a *GISError (Op="ensureWorkspace" / "ensureDatastore",
-// Sentinel=ErrGeoServerPublish), which PublishGeoserverLayer re-wraps
-// in its own *GISError (Op="PublishGeoserverLayer",
-// Sentinel=ErrGeoServerPublish). Callers must be able to:
-//
-//   - match the publish-failure sentinel at any level;
-//   - reach the outer envelope via errors.As (Op shows the public
-//     entry point);
-//   - reach the inner helper-level envelope via Unwrap+errors.As (Op
-//     shows which helper produced the failure for finer-grained
-//     triage);
-//   - reach the underlying upstream cause (e.g. *geoserver.APIError)
-//     via errors.As walking the full chain.
-func TestGISError_NestedChain(t *testing.T) {
-	upstream := errors.New("simulated *geoserver.APIError 500")
-	inner := newGISError("ensureWorkspace", "demo-ws", ErrGeoServerPublish, upstream)
-	outer := newGISError("PublishGeoserverLayer", "demo-ws", ErrGeoServerPublish, inner)
-
-	if !errors.Is(outer, ErrGeoServerPublish) {
-		t.Errorf("errors.Is(outer, ErrGeoServerPublish) = false; want true")
-	}
-	if !errors.Is(outer, upstream) {
-		t.Errorf("errors.Is(outer, upstream) = false; want true (chain walk)")
+	if !errors.Is(gerr, errs.ErrUnsupportedFormat) {
+		t.Errorf("errors.Is(gerr, errs.ErrUnsupportedFormat) = false; want true (alias points at same underlying value)")
 	}
 
-	var top *GISError
-	if !errors.As(outer, &top) {
-		t.Fatalf("errors.As(outer, &top) did not match")
+	// Type alias means errors.As works for both the root-spelled type
+	// and the internal-spelled type.
+	var rootShape *GISError
+	if !errors.As(gerr, &rootShape) {
+		t.Fatalf("errors.As to root-spelled *GISError failed")
 	}
-	if top.Op != "PublishGeoserverLayer" {
-		t.Errorf("outer Op = %q; want PublishGeoserverLayer", top.Op)
+	var internalShape *errs.GISError
+	if !errors.As(gerr, &internalShape) {
+		t.Fatalf("errors.As to *errs.GISError failed (alias should permit both spellings)")
 	}
-
-	var helper *GISError
-	if !errors.As(top.Unwrap(), &helper) {
-		t.Fatalf("errors.As(top.Unwrap(), &helper) did not match a nested *GISError")
-	}
-	if helper.Op != "ensureWorkspace" {
-		t.Errorf("inner Op = %q; want ensureWorkspace", helper.Op)
-	}
-	if helper.Source != "demo-ws" {
-		t.Errorf("inner Source = %q; want demo-ws", helper.Source)
-	}
-	if !errors.Is(helper.Cause, upstream) {
-		t.Errorf("inner Cause = %v; want errors.Is match against upstream", helper.Cause)
-	}
-}
-
-// TestGISError_JoinedAggregation locks in the v1.4 [PublishAll] error
-// contract: each per-layer failure is appended to a slice, and the final
-// return value is errors.Join(slice...) — nil when empty, otherwise an
-// aggregate that walks through every wrapped GISError. Callers must be
-// able to:
-//
-//   - match any sentinel via errors.Is(joined, sentinel) regardless of
-//     which entry in the slice carries it;
-//   - extract the first matching *GISError via errors.As (typical
-//     "give me one example to log" path);
-//   - enumerate every per-layer failure via the unwrap-multiple
-//     interface (`interface{ Unwrap() []error }`).
-//
-// The test constructs a representative joined error directly rather than
-// driving a real PublishAll, since PublishAll requires PostGIS +
-// GeoServer; the errors.Join + GISError mechanics this guards are
-// independent of that infrastructure.
-func TestGISError_JoinedAggregation(t *testing.T) {
-	a := newGISError("PublishGeoserverLayer", "ws/ds/A", ErrGeoServerPublish, errors.New("500 Internal Server Error"))
-	b := newGISError("LayerToPostgis", "ds-B", ErrPostGISConnect, errors.New("dial tcp: refused"))
-	c := newGISError("PublishGeoserverLayer", "ws/ds/C", ErrGeoServerPublish, errors.New("conflict"))
-
-	// Empty join is nil — locks in the "no-failures returns nil"
-	// branch of PublishAll.
-	if errors.Join() != nil {
-		t.Errorf("errors.Join() with no args = non-nil; want nil")
-	}
-
-	joined := errors.Join(a, b, c)
-	if joined == nil {
-		t.Fatal("errors.Join(a,b,c) = nil; want non-nil")
-	}
-
-	if !errors.Is(joined, ErrGeoServerPublish) {
-		t.Errorf("errors.Is(joined, ErrGeoServerPublish) = false; want true (a or c carries it)")
-	}
-	if !errors.Is(joined, ErrPostGISConnect) {
-		t.Errorf("errors.Is(joined, ErrPostGISConnect) = false; want true (b carries it)")
-	}
-	if errors.Is(joined, ErrUnsupportedFormat) {
-		t.Errorf("errors.Is(joined, ErrUnsupportedFormat) = true; want false")
-	}
-
-	// errors.As surfaces the FIRST *GISError in the joined chain (Go's
-	// stdlib walks left-to-right). For PublishAll this is always
-	// useful: callers usually just want one example to log.
-	var first *GISError
-	if !errors.As(joined, &first) {
-		t.Fatal("errors.As did not extract a *GISError from the joined chain")
-	}
-	if first.Op != "PublishGeoserverLayer" || first.Source != "ws/ds/A" {
-		t.Errorf("errors.As surfaced the wrong leaf: Op=%q Source=%q", first.Op, first.Source)
-	}
-
-	// Enumerate via the unwrap-multiple interface — the documented
-	// path for "show me every failure" callers (e.g. CLI summaries
-	// or batch dashboards).
-	var multi interface{ Unwrap() []error }
-	if !errors.As(joined, &multi) {
-		t.Fatal("errors.As to the multi-Unwrap interface failed")
-	}
-	if got := len(multi.Unwrap()); got != 3 {
-		t.Errorf("Unwrap() returned %d errors; want 3", got)
-	}
-}
-
-func TestGISError_ErrorFormatsByCombination(t *testing.T) {
-	cases := []struct {
-		name string
-		e    *GISError
-		want string
-	}{
-		{
-			name: "sentinel-only",
-			e:    newGISError("OpenSource", "", ErrUnsupportedFormat, nil),
-			want: "gismanager: OpenSource: gismanager: unsupported format",
-		},
-		{
-			name: "sentinel-with-cause-no-source",
-			e:    newGISError("Ping", "", ErrPostGISConnect, errors.New("dial tcp: refused")),
-			want: "gismanager: Ping: gismanager: postgis connect: dial tcp: refused",
-		},
-		{
-			name: "source-no-cause",
-			e:    newGISError("OpenSource", "/tmp/foo.bin", ErrUnsupportedFormat, nil),
-			want: `gismanager: OpenSource "/tmp/foo.bin": gismanager: unsupported format`,
-		},
-		{
-			name: "all-fields",
-			e:    newGISError("Publish", "ws/ds/lyr", ErrGeoServerPublish, errors.New("500")),
-			want: `gismanager: Publish "ws/ds/lyr": gismanager: geoserver publish: 500`,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.e.Error(); got != tc.want {
-				t.Errorf("\n got: %q\nwant: %q", got, tc.want)
-			}
-		})
+	if rootShape != internalShape {
+		t.Errorf("alias spellings should resolve to the same pointer; got root=%p internal=%p",
+			rootShape, internalShape)
 	}
 }

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,139 @@
+// Package errs is gismanager's typed-error machinery — the *GISError
+// envelope and the package-level Err* sentinels. Moved here from the
+// root gismanager package as part of the v2 restructure groundwork
+// (Phase 1) so the future convert/ and publish/ subpackages can
+// reference these without a circular import through the root.
+//
+// External callers continue to use gismanager.GISError /
+// gismanager.ErrConvertFailed / etc. via the type aliases and var
+// aliases the root package re-exports. The package name `errs` is
+// not part of the public v1.x API surface; it is only directly
+// imported by other packages inside this module.
+//
+// In v2, the convert/ and publish/ subpackages import this package
+// directly (e.g. errs.NewGISError) rather than the root package's
+// alias.
+package errs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Match via [errors.Is] — never compare error strings.
+//
+// These wrap higher-level failure categories. The library wraps them around
+// the underlying cause (GDAL CGo error, *geoserver.APIError, lib/pq error,
+// etc.) so callers can branch on the category while still recovering the
+// original via [errors.As].
+var (
+	// ErrConfigInvalid signals that the YAML config is syntactically valid
+	// but semantically wrong (missing fields, malformed values, etc.).
+	ErrConfigInvalid = errors.New("gismanager: config invalid")
+
+	// ErrUnsupportedFormat signals that a path's extension does not map to
+	// any GDAL OGR driver gismanager knows about.
+	ErrUnsupportedFormat = errors.New("gismanager: unsupported format")
+
+	// ErrInvalidLayer signals that a *GdalLayer was nil or had a nil
+	// embedded *gdal.Layer pointer when an operation required a real layer.
+	ErrInvalidLayer = errors.New("gismanager: invalid layer")
+
+	// ErrInvalidDatasource signals that a *gdal.DataSource passed in was
+	// nil or unusable.
+	ErrInvalidDatasource = errors.New("gismanager: invalid datasource")
+
+	// ErrPostGISConnect signals that the PostGIS ping/handshake failed.
+	// The underlying *pq.Error (or driver-level error) is recoverable via
+	// [errors.As].
+	ErrPostGISConnect = errors.New("gismanager: postgis connect")
+
+	// ErrGeoServerPublish signals that the GeoServer publish flow failed
+	// at workspace, datastore, or feature-type creation. The underlying
+	// *geoserver.APIError is recoverable via [errors.As].
+	ErrGeoServerPublish = errors.New("gismanager: geoserver publish")
+
+	// ErrNoSourcesFound signals that the configured source directory
+	// contained no supported GIS files.
+	ErrNoSourcesFound = errors.New("gismanager: no sources found")
+
+	// ErrConvertFailed signals that a vector or raster conversion
+	// (ConvertVector / ConvertRaster / ToCOG / ReprojectRaster) failed.
+	// The underlying GDAL error is recoverable via [errors.As] into
+	// [*GISError]; the GISError.Op field disambiguates which entry
+	// point produced the error.
+	ErrConvertFailed = errors.New("gismanager: convert failed")
+)
+
+// GISError is the typed error gismanager returns for higher-level
+// operations. It carries the operation name, the source path (file, layer
+// name, or workspace as appropriate), the sentinel category, and the
+// underlying cause.
+//
+// Match by sentinel:
+//
+//	if errors.Is(err, gismanager.ErrUnsupportedFormat) { ... }
+//
+// Inspect for fields:
+//
+//	var gerr *gismanager.GISError
+//	if errors.As(err, &gerr) {
+//	    log.Println(gerr.Op, gerr.Source)
+//	}
+type GISError struct {
+	// Op is the operation name (e.g. "OpenSource", "PublishGeoserverLayer",
+	// "LoadToPostGIS"). Useful for logging and triage.
+	Op string
+
+	// Source identifies what the operation acted on — typically a file
+	// path, a layer name, or a workspace name. Empty if not applicable.
+	Source string
+
+	// Sentinel is one of the package-level Err* values. errors.Is(e,
+	// Sentinel) returns true.
+	Sentinel error
+
+	// Cause is the underlying error. May be nil if the failure is
+	// purely a sentinel (e.g. ErrInvalidLayer with no nested cause).
+	Cause error
+}
+
+// Error returns a stable, parseable message of the form
+//
+//	gismanager: <Op> <Source>: <sentinel>: <cause>
+//
+// Source is omitted if empty; Cause is omitted if nil.
+func (e *GISError) Error() string {
+	switch {
+	case e.Source == "" && e.Cause == nil:
+		return fmt.Sprintf("gismanager: %s: %v", e.Op, e.Sentinel)
+	case e.Source == "":
+		return fmt.Sprintf("gismanager: %s: %v: %v", e.Op, e.Sentinel, e.Cause)
+	case e.Cause == nil:
+		return fmt.Sprintf("gismanager: %s %q: %v", e.Op, e.Source, e.Sentinel)
+	default:
+		return fmt.Sprintf("gismanager: %s %q: %v: %v", e.Op, e.Source, e.Sentinel, e.Cause)
+	}
+}
+
+// Unwrap returns the underlying cause for [errors.Is] / [errors.As]
+// traversal. It walks past Sentinel — Sentinel is matched separately by
+// [GISError.Is].
+func (e *GISError) Unwrap() error { return e.Cause }
+
+// Is reports whether the error matches the given target. It returns true
+// for the GISError's Sentinel so callers can match by category:
+//
+//	errors.Is(err, gismanager.ErrUnsupportedFormat)
+func (e *GISError) Is(target error) bool {
+	return target != nil && e.Sentinel == target
+}
+
+// NewGISError constructs a *GISError. Callers wrap underlying failures
+// with a sentinel category so the public surface is consistent. The
+// root gismanager package keeps a `newGISError` package-private wrapper
+// around this for the duration of the v1.x line; convert/ and publish/
+// subpackages call this directly.
+func NewGISError(op, source string, sentinel, cause error) *GISError {
+	return &GISError{Op: op, Source: source, Sentinel: sentinel, Cause: cause}
+}

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -1,0 +1,173 @@
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// These tests exercise the typed-error machinery directly, against the
+// internal/errs package. The root gismanager package's errors_test.go
+// keeps a single alias-chain confirmation test that ensures the v1.x
+// public API surface (gismanager.GISError, gismanager.ErrConvertFailed,
+// etc.) continues to resolve to these same instances.
+
+func TestGISError_IsAndUnwrap(t *testing.T) {
+	cause := errors.New("underlying boom")
+	gerr := NewGISError("OpenSource", "/tmp/foo.shp", ErrUnsupportedFormat, cause)
+
+	if !errors.Is(gerr, ErrUnsupportedFormat) {
+		t.Errorf("errors.Is(gerr, ErrUnsupportedFormat) = false, want true")
+	}
+	if errors.Is(gerr, ErrInvalidLayer) {
+		t.Errorf("errors.Is(gerr, ErrInvalidLayer) = true, want false")
+	}
+	if !errors.Is(gerr, cause) {
+		t.Errorf("errors.Is(gerr, cause) = false, want true (Unwrap)")
+	}
+}
+
+func TestGISError_As(t *testing.T) {
+	cause := errors.New("underlying boom")
+	gerr := NewGISError("PublishGeoserverLayer", "ws/ds/lyr", ErrGeoServerPublish, cause)
+	wrapped := fmt.Errorf("outer: %w", gerr)
+
+	var got *GISError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As did not match")
+	}
+	if got.Op != "PublishGeoserverLayer" {
+		t.Errorf("Op = %q, want PublishGeoserverLayer", got.Op)
+	}
+	if got.Source != "ws/ds/lyr" {
+		t.Errorf("Source = %q, want ws/ds/lyr", got.Source)
+	}
+}
+
+// TestGISError_NestedChain locks in the contract for the nested-*GISError
+// chain produced by the publish pipeline when an ensureWorkspace /
+// ensureDatastore helper fails: each helper returns a *GISError, which
+// PublishGeoserverLayer re-wraps in its own *GISError. Callers must be
+// able to:
+//
+//   - match the publish-failure sentinel at any level;
+//   - reach the outer envelope via errors.As;
+//   - reach the inner helper-level envelope via Unwrap+errors.As;
+//   - reach the underlying upstream cause via errors.As walking the chain.
+func TestGISError_NestedChain(t *testing.T) {
+	upstream := errors.New("simulated *geoserver.APIError 500")
+	inner := NewGISError("ensureWorkspace", "demo-ws", ErrGeoServerPublish, upstream)
+	outer := NewGISError("PublishGeoserverLayer", "demo-ws", ErrGeoServerPublish, inner)
+
+	if !errors.Is(outer, ErrGeoServerPublish) {
+		t.Errorf("errors.Is(outer, ErrGeoServerPublish) = false; want true")
+	}
+	if !errors.Is(outer, upstream) {
+		t.Errorf("errors.Is(outer, upstream) = false; want true (chain walk)")
+	}
+
+	var top *GISError
+	if !errors.As(outer, &top) {
+		t.Fatalf("errors.As(outer, &top) did not match")
+	}
+	if top.Op != "PublishGeoserverLayer" {
+		t.Errorf("outer Op = %q; want PublishGeoserverLayer", top.Op)
+	}
+
+	var helper *GISError
+	if !errors.As(top.Unwrap(), &helper) {
+		t.Fatalf("errors.As(top.Unwrap(), &helper) did not match a nested *GISError")
+	}
+	if helper.Op != "ensureWorkspace" {
+		t.Errorf("inner Op = %q; want ensureWorkspace", helper.Op)
+	}
+	if helper.Source != "demo-ws" {
+		t.Errorf("inner Source = %q; want demo-ws", helper.Source)
+	}
+	if !errors.Is(helper.Cause, upstream) {
+		t.Errorf("inner Cause = %v; want errors.Is match against upstream", helper.Cause)
+	}
+}
+
+// TestGISError_JoinedAggregation locks in the v1.4 PublishAll error
+// contract: each per-layer failure is appended to a slice, and the
+// final return value is errors.Join(slice...). Empty join returns nil;
+// populated join supports errors.Is for every constituent sentinel,
+// errors.As surfaces the first *GISError, and the multi-Unwrap
+// interface enumerates every per-layer failure.
+func TestGISError_JoinedAggregation(t *testing.T) {
+	a := NewGISError("PublishGeoserverLayer", "ws/ds/A", ErrGeoServerPublish, errors.New("500 Internal Server Error"))
+	b := NewGISError("LayerToPostgis", "ds-B", ErrPostGISConnect, errors.New("dial tcp: refused"))
+	c := NewGISError("PublishGeoserverLayer", "ws/ds/C", ErrGeoServerPublish, errors.New("conflict"))
+
+	if errors.Join() != nil {
+		t.Errorf("errors.Join() with no args = non-nil; want nil")
+	}
+
+	joined := errors.Join(a, b, c)
+	if joined == nil {
+		t.Fatal("errors.Join(a,b,c) = nil; want non-nil")
+	}
+
+	if !errors.Is(joined, ErrGeoServerPublish) {
+		t.Errorf("errors.Is(joined, ErrGeoServerPublish) = false; want true")
+	}
+	if !errors.Is(joined, ErrPostGISConnect) {
+		t.Errorf("errors.Is(joined, ErrPostGISConnect) = false; want true")
+	}
+	if errors.Is(joined, ErrUnsupportedFormat) {
+		t.Errorf("errors.Is(joined, ErrUnsupportedFormat) = true; want false")
+	}
+
+	var first *GISError
+	if !errors.As(joined, &first) {
+		t.Fatal("errors.As did not extract a *GISError from the joined chain")
+	}
+	if first.Op != "PublishGeoserverLayer" || first.Source != "ws/ds/A" {
+		t.Errorf("errors.As surfaced the wrong leaf: Op=%q Source=%q", first.Op, first.Source)
+	}
+
+	var multi interface{ Unwrap() []error }
+	if !errors.As(joined, &multi) {
+		t.Fatal("errors.As to the multi-Unwrap interface failed")
+	}
+	if got := len(multi.Unwrap()); got != 3 {
+		t.Errorf("Unwrap() returned %d errors; want 3", got)
+	}
+}
+
+func TestGISError_ErrorFormatsByCombination(t *testing.T) {
+	cases := []struct {
+		name string
+		e    *GISError
+		want string
+	}{
+		{
+			name: "sentinel-only",
+			e:    NewGISError("OpenSource", "", ErrUnsupportedFormat, nil),
+			want: "gismanager: OpenSource: gismanager: unsupported format",
+		},
+		{
+			name: "sentinel-with-cause-no-source",
+			e:    NewGISError("Ping", "", ErrPostGISConnect, errors.New("dial tcp: refused")),
+			want: "gismanager: Ping: gismanager: postgis connect: dial tcp: refused",
+		},
+		{
+			name: "source-no-cause",
+			e:    NewGISError("OpenSource", "/tmp/foo.bin", ErrUnsupportedFormat, nil),
+			want: `gismanager: OpenSource "/tmp/foo.bin": gismanager: unsupported format`,
+		},
+		{
+			name: "all-fields",
+			e:    NewGISError("Publish", "ws/ds/lyr", ErrGeoServerPublish, errors.New("500")),
+			want: `gismanager: Publish "ws/ds/lyr": gismanager: geoserver publish: 500`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.e.Error(); got != tc.want {
+				t.Errorf("\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/slogx/default.go
+++ b/internal/slogx/default.go
@@ -1,0 +1,26 @@
+// Package slogx provides a single helper that returns the project's
+// default *slog.Logger. Moved here from the root gismanager package
+// as part of the v2 restructure groundwork (Phase 1) so the future
+// convert/ and publish/ subpackages can reference it without a
+// circular import through the root.
+//
+// External callers continue to call gismanager.GetLogger() via the
+// thin wrapper the root package keeps. In v2, the convert/ and
+// publish/ subpackages call slogx.Default() directly.
+package slogx
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Default returns a *slog.Logger writing text-formatted records to
+// stderr — the project's fallback logger when no caller-supplied
+// *slog.Logger is configured.
+//
+// Production users typically construct their own *slog.Logger (any
+// handler — JSON, file-rotated, OpenTelemetry-bridged) and pass it
+// to library entry points via the available functional options.
+func Default() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+}

--- a/internal/slogx/default_test.go
+++ b/internal/slogx/default_test.go
@@ -1,0 +1,29 @@
+package slogx
+
+import (
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	l := Default()
+	if l == nil {
+		t.Fatal("Default() returned nil")
+	}
+	// Default()'s signature returns *slog.Logger; the public API
+	// (gismanager.GetLogger) advertises that exact shape via the
+	// thin wrapper. No further type-assertion is needed at the
+	// test layer — a return-type drift would surface as a compile
+	// error in the wrapper.
+}
+
+// TestDefault_DistinctInstances guards against an accidental "return
+// the same global *slog.Logger" implementation. Each call constructs
+// a fresh handler — callers attach context (e.g. WithAttrs) without
+// affecting other call sites.
+func TestDefault_DistinctInstances(t *testing.T) {
+	a := Default()
+	b := Default()
+	if a == b {
+		t.Errorf("Default() should return distinct instances each call; got the same pointer")
+	}
+}

--- a/log.go
+++ b/log.go
@@ -2,17 +2,20 @@ package gismanager
 
 import (
 	"log/slog"
-	"os"
+
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // GetLogger returns the project's default structured logger: a stdlib
 // *slog.Logger writing text-formatted records to stderr.
 //
-// Callers building their own pipeline should construct an *slog.Logger
-// directly (any handler — JSON, lumberjack-rotated, otel, etc.) and pass
-// it on the [ManagerConfig].logger field via the constructor (PR 4 still
-// loads it from FromConfig + GetLogger; functional-options constructor
-// lands in a follow-up).
+// As of the v2 restructure groundwork (Phase 1), the implementation
+// lives in [internal/slogx.Default]; this is a thin wrapper for
+// v1.x compatibility. v2 callers should construct their own
+// *slog.Logger directly (any handler — JSON, lumberjack-rotated,
+// OpenTelemetry-bridged) and pass it on via the available
+// functional options. The internal package is not part of the
+// v2 public API.
 func GetLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+	return slogx.Default()
 }

--- a/log_test.go
+++ b/log_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestGetLogger confirms the v1.x public API (gismanager.GetLogger)
+// resolves to a non-nil *slog.Logger. The implementation lives in
+// [internal/slogx.Default]; the deeper test coverage of that path
+// is in internal/slogx/default_test.go.
 func TestGetLogger(t *testing.T) {
 	logger := GetLogger()
 	assert.NotNil(t, logger)


### PR DESCRIPTION
## Summary

**Phase 1** of the v2 restructure plan ([`~/.claude/plans/how-can-we-improve-steady-emerson.md`](#)). Pure internal refactor — public API is byte-for-byte unchanged.

## Why now

Phase 2 (move \`convert_*.go\` to \`convert/\` subpackage) and Phase 3 (move publish-pipeline files to \`publish/\`) both need to call \`newGISError\` and use the default \`*slog.Logger\`. If those symbols stay in the root \`gismanager\` package, the new subpackages have to import root — which then can't import them back without forming a **circular import**. Pulling errors + logger to \`internal/\` subpackages breaks that future cycle before it forms.

## What moved

| From | To | Note |
|------|----|------|
| \`errors.go\` content | \`internal/errs/errs.go\` | \`newGISError\` → \`NewGISError\` (export required for cross-package access) |
| \`log.go::GetLogger()\` | \`internal/slogx/Default()\` | Renamed; idiomatic for an `slogx` package |

## What stayed (v1.x compat layer)

- \`errors.go\` declares \`type GISError = errs.GISError\` and \`var ErrConfigInvalid = errs.ErrConfigInvalid\` (etc.) so external callers continue to use \`gismanager.GISError\` / \`gismanager.ErrConvertFailed\` unchanged. **Type aliases preserve full identity** — \`errors.As\` / \`errors.Is\` / pointer equality work transparently across the boundary.
- \`errors.go\` keeps a package-private \`newGISError\` wrapper delegating to \`errs.NewGISError\`. Every caller in \`manager.go\` / \`layer.go\` / \`walk.go\` / \`utils.go\` / \`convert_*.go\` is **byte-identical** — they keep calling \`newGISError(...)\` without knowing about the move. Phase 2+ moves those callers to a subpackage where they call \`errs.NewGISError\` directly; Phase 4 drops the wrapper.
- \`log.go::GetLogger()\` keeps the same signature as a thin wrapper around \`slogx.Default()\`.

## Tests

- **\`internal/errs/errs_test.go\`** gets the comprehensive \`*GISError\` mechanic tests — \`TestGISError_IsAndUnwrap\` / \`As\` / \`NestedChain\` / \`JoinedAggregation\` / \`ErrorFormatsByCombination\`. Now uses the exported \`NewGISError\` name. Provides direct package coverage.
- **\`internal/slogx/default_test.go\`** — \`TestDefault\` (returns non-nil) + \`TestDefault_DistinctInstances\` (each call returns a fresh \`*slog.Logger\` so callers can \`WithAttrs\` without cross-talk).
- **\`errors_test.go\` (root)** shrinks to a single \`TestErrAliasChain_v1Compat\` — guards against a future refactor accidentally breaking the alias boundary for external callers.
- **\`log_test.go\` (root)** keeps the existing \`TestGetLogger\`.

## Test plan

- [x] \`make lint\` — 0 issues (after fixing one staticcheck QF1011 in slogx test)
- [x] \`make test-unit\` — green; new \`internal/errs\` and \`internal/slogx\` packages have direct test coverage
- [x] \`make test-integration\` against GeoServer 2.28.0 — green (~15s publish-pipeline runtime; alias chain doesn't disturb publish flow)
- [ ] CI: full matrix runs on push