### PR TITLE
refactor(convert): move convert_*.go to convert/ subpackage with v1.x compat wrappers

### DIFF
--- a/cmd/gisconvert/gisconvert.go
+++ b/cmd/gisconvert/gisconvert.go
@@ -13,9 +13,9 @@
 //	gisconvert -mode raster -src in.tif -dst out.warp.tif \
 //	    -s-srs EPSG:32618 -t-srs EPSG:3857 -resample bilinear
 //
-// gisconvert is a thin shell over [gismanager.ConvertVector],
-// [gismanager.ConvertRaster], [gismanager.ToCOG], and
-// [gismanager.ReprojectRaster]. It uses the stdlib `flag` package — no
+// gisconvert is a thin shell over [convert.ConvertVector],
+// [convert.ConvertRaster], [convert.ToCOG], and
+// [convert.ReprojectRaster]. It uses the stdlib `flag` package — no
 // runtime dependency beyond the gismanager library itself.
 package main
 
@@ -29,8 +29,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hishamkaram/gismanager"
 	"github.com/hishamkaram/gismanager/cmd/internal/cli"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 func main() { os.Exit(realMain()) }
@@ -108,83 +108,83 @@ func run(ctx context.Context, args []string) error {
 func runVector(ctx context.Context, src, dst, format, sSRS, tSRS, bbox,
 	where string, simplify float64, selectFields, layer string, overwrite bool,
 ) error {
-	opts := []gismanager.VectorConvertOption{}
+	opts := []convert.VectorOption{}
 	if format != "" {
-		opts = append(opts, gismanager.WithVectorFormat(format))
+		opts = append(opts, convert.WithVectorFormat(format))
 	}
 	if sSRS != "" {
-		opts = append(opts, gismanager.WithVectorSourceSRS(sSRS))
+		opts = append(opts, convert.WithVectorSourceSRS(sSRS))
 	}
 	if tSRS != "" {
-		opts = append(opts, gismanager.WithVectorTargetSRS(tSRS))
+		opts = append(opts, convert.WithVectorTargetSRS(tSRS))
 	}
 	if bbox != "" {
 		minX, minY, maxX, maxY, err := parseBBox(bbox)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, gismanager.WithVectorBoundingBox(minX, minY, maxX, maxY))
+		opts = append(opts, convert.WithVectorBoundingBox(minX, minY, maxX, maxY))
 	}
 	if where != "" {
-		opts = append(opts, gismanager.WithVectorWhere(where))
+		opts = append(opts, convert.WithVectorWhere(where))
 	}
 	if simplify > 0 {
-		opts = append(opts, gismanager.WithVectorSimplify(simplify))
+		opts = append(opts, convert.WithVectorSimplify(simplify))
 	}
 	if selectFields != "" {
 		fields := strings.Split(selectFields, ",")
-		opts = append(opts, gismanager.WithVectorSelectFields(fields...))
+		opts = append(opts, convert.WithVectorSelectFields(fields...))
 	}
 	if layer != "" {
-		opts = append(opts, gismanager.WithVectorLayerName(layer))
+		opts = append(opts, convert.WithVectorLayerName(layer))
 	}
 	if overwrite {
-		opts = append(opts, gismanager.WithVectorOverwrite())
+		opts = append(opts, convert.WithVectorOverwrite())
 	}
-	return gismanager.ConvertVector(ctx, src, dst, opts...)
+	return convert.ConvertVector(ctx, src, dst, opts...)
 }
 
 func runRaster(ctx context.Context, src, dst, format, sSRS, tSRS, bbox,
 	bands, resample, tr string, cog bool,
 	cutlineDS, cutlineLayer string, creationOpts []string,
 ) error {
-	opts := []gismanager.RasterConvertOption{}
+	opts := []convert.RasterOption{}
 	if format != "" {
-		opts = append(opts, gismanager.WithRasterFormat(format))
+		opts = append(opts, convert.WithRasterFormat(format))
 	}
 	for _, co := range creationOpts {
 		k, v, ok := strings.Cut(co, "=")
 		if !ok {
 			return fmt.Errorf("gisconvert: -co value %q must be KEY=VAL", co)
 		}
-		opts = append(opts, gismanager.WithRasterCreationOption(k, v))
+		opts = append(opts, convert.WithRasterCreationOption(k, v))
 	}
 	if bbox != "" {
 		minX, minY, maxX, maxY, err := parseBBox(bbox)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, gismanager.WithRasterOutputBounds(minX, minY, maxX, maxY))
+		opts = append(opts, convert.WithRasterOutputBounds(minX, minY, maxX, maxY))
 	}
 	if bands != "" {
 		bs, err := parseBands(bands)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, gismanager.WithRasterBands(bs...))
+		opts = append(opts, convert.WithRasterBands(bs...))
 	}
 	if resample != "" {
-		opts = append(opts, gismanager.WithRasterResamplingAlg(resample))
+		opts = append(opts, convert.WithRasterResamplingAlg(resample))
 	}
 	if tr != "" {
 		xRes, yRes, err := parseRes(tr)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, gismanager.WithRasterTargetResolution(xRes, yRes))
+		opts = append(opts, convert.WithRasterTargetResolution(xRes, yRes))
 	}
 	if cutlineDS != "" {
-		opts = append(opts, gismanager.WithRasterCutline(cutlineDS, cutlineLayer))
+		opts = append(opts, convert.WithRasterCutline(cutlineDS, cutlineLayer))
 	}
 
 	// Reproject mode: both -s-srs and -t-srs supplied (or just -t-srs;
@@ -193,15 +193,15 @@ func runRaster(ctx context.Context, src, dst, format, sSRS, tSRS, bbox,
 		if sSRS == "" {
 			return errors.New("gisconvert: raster reprojection requires both -s-srs and -t-srs")
 		}
-		return gismanager.ReprojectRaster(ctx, src, dst, sSRS, tSRS, opts...)
+		return convert.ReprojectRaster(ctx, src, dst, sSRS, tSRS, opts...)
 	}
 
 	// COG shortcut.
 	if cog {
-		return gismanager.ToCOG(ctx, src, dst, opts...)
+		return convert.ToCOG(ctx, src, dst, opts...)
 	}
 
-	return gismanager.ConvertRaster(ctx, src, dst, opts...)
+	return convert.ConvertRaster(ctx, src, dst, opts...)
 }
 
 // parseBBox parses "minX,minY,maxX,maxY" into four float64s.

--- a/compat_convert.go
+++ b/compat_convert.go
@@ -1,0 +1,361 @@
+package gismanager
+
+// Compatibility shim for the v1.x conversion subsystem API.
+//
+// The conversion subsystem (ConvertVector / ConvertRaster / ToCOG /
+// ReprojectRaster / Rasterize / BuildVRT / DEMProcessing / ToPMTiles
+// plus all their With* options) moved to the [convert] subpackage as
+// part of the v2 restructure groundwork (see Phase 2 in
+// ~/.claude/plans/how-can-we-improve-steady-emerson.md).
+//
+// This file re-exports every public symbol from the convert subpackage
+// at its v1.x import path so existing v1.x callers compile unchanged.
+// Type aliases preserve full identity — errors.As, errors.Is, pointer
+// equality, slice element types all interoperate transparently across
+// the boundary. Function wrappers are pure pass-throughs with no
+// behavior change.
+//
+// All declarations are marked Deprecated; new code should import
+// "github.com/hishamkaram/gismanager/convert" directly. The v2 module
+// bump (Phase 4) deletes this file.
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/hishamkaram/gismanager/convert"
+)
+
+// =============================================================================
+// Type aliases
+// =============================================================================
+
+// VectorConvertOption is preserved as a v1.x alias of [convert.VectorOption].
+//
+// Deprecated: use [convert.VectorOption] directly via
+// `import "github.com/hishamkaram/gismanager/convert"`.
+type VectorConvertOption = convert.VectorOption
+
+// RasterConvertOption is preserved as a v1.x alias of [convert.RasterOption].
+//
+// Deprecated: use [convert.RasterOption] directly.
+type RasterConvertOption = convert.RasterOption
+
+// RasterizeOption is preserved as a v1.x alias of [convert.RasterizeOption].
+//
+// Deprecated: use [convert.RasterizeOption] directly.
+type RasterizeOption = convert.RasterizeOption
+
+// VRTOption is preserved as a v1.x alias of [convert.VRTOption].
+//
+// Deprecated: use [convert.VRTOption] directly.
+type VRTOption = convert.VRTOption
+
+// DEMOption is preserved as a v1.x alias of [convert.DEMOption].
+//
+// Deprecated: use [convert.DEMOption] directly.
+type DEMOption = convert.DEMOption
+
+// PMTilesOption is preserved as a v1.x alias of [convert.PMTilesOption].
+//
+// Deprecated: use [convert.PMTilesOption] directly.
+type PMTilesOption = convert.PMTilesOption
+
+// =============================================================================
+// Entry points
+// =============================================================================
+
+// ConvertVector forwards to [convert.ConvertVector].
+//
+// Deprecated: use [convert.ConvertVector] directly.
+func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOption) error {
+	return convert.ConvertVector(ctx, src, dst, opts...)
+}
+
+// ConvertRaster forwards to [convert.ConvertRaster].
+//
+// Deprecated: use [convert.ConvertRaster] directly.
+func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterConvertOption) error {
+	return convert.ConvertRaster(ctx, src, dst, opts...)
+}
+
+// ToCOG forwards to [convert.ToCOG].
+//
+// Deprecated: use [convert.ToCOG] directly.
+func ToCOG(ctx context.Context, src, dst string, opts ...RasterConvertOption) error {
+	return convert.ToCOG(ctx, src, dst, opts...)
+}
+
+// ReprojectRaster forwards to [convert.ReprojectRaster].
+//
+// Deprecated: use [convert.ReprojectRaster] directly.
+func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterConvertOption) error {
+	return convert.ReprojectRaster(ctx, src, dst, srcSRS, dstSRS, opts...)
+}
+
+// Rasterize forwards to [convert.Rasterize].
+//
+// Deprecated: use [convert.Rasterize] directly.
+func Rasterize(ctx context.Context, vectorSrc, rasterDst string, opts ...RasterizeOption) error {
+	return convert.Rasterize(ctx, vectorSrc, rasterDst, opts...)
+}
+
+// BuildVRT forwards to [convert.BuildVRT].
+//
+// Deprecated: use [convert.BuildVRT] directly.
+func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption) error {
+	return convert.BuildVRT(ctx, dst, srcs, opts...)
+}
+
+// DEMProcessing forwards to [convert.DEMProcessing].
+//
+// Deprecated: use [convert.DEMProcessing] directly.
+func DEMProcessing(ctx context.Context, src, dst, mode string, opts ...DEMOption) error {
+	return convert.DEMProcessing(ctx, src, dst, mode, opts...)
+}
+
+// ToPMTiles forwards to [convert.ToPMTiles].
+//
+// Deprecated: use [convert.ToPMTiles] directly.
+func ToPMTiles(ctx context.Context, src, dst string, opts ...PMTilesOption) error {
+	return convert.ToPMTiles(ctx, src, dst, opts...)
+}
+
+// =============================================================================
+// Vector options — all forward to convert.WithVector*; all Deprecated.
+// =============================================================================
+
+// WithVectorLogger forwards to [convert.WithVectorLogger]. Deprecated.
+func WithVectorLogger(l *slog.Logger) VectorConvertOption { return convert.WithVectorLogger(l) }
+
+// WithVectorFormat forwards to [convert.WithVectorFormat]. Deprecated.
+func WithVectorFormat(driverName string) VectorConvertOption {
+	return convert.WithVectorFormat(driverName)
+}
+
+// WithVectorSourceSRS forwards to [convert.WithVectorSourceSRS]. Deprecated.
+func WithVectorSourceSRS(srs string) VectorConvertOption { return convert.WithVectorSourceSRS(srs) }
+
+// WithVectorTargetSRS forwards to [convert.WithVectorTargetSRS]. Deprecated.
+func WithVectorTargetSRS(srs string) VectorConvertOption { return convert.WithVectorTargetSRS(srs) }
+
+// WithVectorBoundingBox forwards to [convert.WithVectorBoundingBox]. Deprecated.
+func WithVectorBoundingBox(minX, minY, maxX, maxY float64) VectorConvertOption {
+	return convert.WithVectorBoundingBox(minX, minY, maxX, maxY)
+}
+
+// WithVectorWhere forwards to [convert.WithVectorWhere]. Deprecated.
+func WithVectorWhere(sql string) VectorConvertOption { return convert.WithVectorWhere(sql) }
+
+// WithVectorSimplify forwards to [convert.WithVectorSimplify]. Deprecated.
+func WithVectorSimplify(tolerance float64) VectorConvertOption {
+	return convert.WithVectorSimplify(tolerance)
+}
+
+// WithVectorSelectFields forwards to [convert.WithVectorSelectFields]. Deprecated.
+func WithVectorSelectFields(fields ...string) VectorConvertOption {
+	return convert.WithVectorSelectFields(fields...)
+}
+
+// WithVectorLayerName forwards to [convert.WithVectorLayerName]. Deprecated.
+func WithVectorLayerName(name string) VectorConvertOption { return convert.WithVectorLayerName(name) }
+
+// WithVectorOverwrite forwards to [convert.WithVectorOverwrite]. Deprecated.
+func WithVectorOverwrite() VectorConvertOption { return convert.WithVectorOverwrite() }
+
+// WithVectorRawOptions forwards to [convert.WithVectorRawOptions]. Deprecated.
+func WithVectorRawOptions(args ...string) VectorConvertOption {
+	return convert.WithVectorRawOptions(args...)
+}
+
+// =============================================================================
+// Raster options — all forward to convert.WithRaster*; all Deprecated.
+// =============================================================================
+
+// WithRasterLogger forwards to [convert.WithRasterLogger]. Deprecated.
+func WithRasterLogger(l *slog.Logger) RasterConvertOption { return convert.WithRasterLogger(l) }
+
+// WithRasterFormat forwards to [convert.WithRasterFormat]. Deprecated.
+func WithRasterFormat(driver string) RasterConvertOption { return convert.WithRasterFormat(driver) }
+
+// WithRasterCreationOption forwards to [convert.WithRasterCreationOption]. Deprecated.
+func WithRasterCreationOption(key, val string) RasterConvertOption {
+	return convert.WithRasterCreationOption(key, val)
+}
+
+// WithRasterOutputBounds forwards to [convert.WithRasterOutputBounds]. Deprecated.
+func WithRasterOutputBounds(minX, minY, maxX, maxY float64) RasterConvertOption {
+	return convert.WithRasterOutputBounds(minX, minY, maxX, maxY)
+}
+
+// WithRasterBands forwards to [convert.WithRasterBands]. Deprecated.
+func WithRasterBands(bands ...int) RasterConvertOption { return convert.WithRasterBands(bands...) }
+
+// WithRasterResamplingAlg forwards to [convert.WithRasterResamplingAlg]. Deprecated.
+func WithRasterResamplingAlg(alg string) RasterConvertOption {
+	return convert.WithRasterResamplingAlg(alg)
+}
+
+// WithRasterTargetResolution forwards to [convert.WithRasterTargetResolution]. Deprecated.
+func WithRasterTargetResolution(xRes, yRes float64) RasterConvertOption {
+	return convert.WithRasterTargetResolution(xRes, yRes)
+}
+
+// WithRasterCutline forwards to [convert.WithRasterCutline]. Deprecated.
+func WithRasterCutline(ds, layer string) RasterConvertOption {
+	return convert.WithRasterCutline(ds, layer)
+}
+
+// WithRasterRawOptions forwards to [convert.WithRasterRawOptions]. Deprecated.
+func WithRasterRawOptions(args ...string) RasterConvertOption {
+	return convert.WithRasterRawOptions(args...)
+}
+
+// =============================================================================
+// Rasterize options — all forward to convert.WithRasterize*; all Deprecated.
+// =============================================================================
+
+// WithRasterizeLogger forwards to [convert.WithRasterizeLogger]. Deprecated.
+func WithRasterizeLogger(l *slog.Logger) RasterizeOption { return convert.WithRasterizeLogger(l) }
+
+// WithRasterizeFormat forwards to [convert.WithRasterizeFormat]. Deprecated.
+func WithRasterizeFormat(driver string) RasterizeOption { return convert.WithRasterizeFormat(driver) }
+
+// WithRasterizeBurnValues forwards to [convert.WithRasterizeBurnValues]. Deprecated.
+func WithRasterizeBurnValues(values ...float64) RasterizeOption {
+	return convert.WithRasterizeBurnValues(values...)
+}
+
+// WithRasterizeAttribute forwards to [convert.WithRasterizeAttribute]. Deprecated.
+func WithRasterizeAttribute(name string) RasterizeOption { return convert.WithRasterizeAttribute(name) }
+
+// WithRasterizeTargetResolution forwards to [convert.WithRasterizeTargetResolution]. Deprecated.
+func WithRasterizeTargetResolution(xRes, yRes float64) RasterizeOption {
+	return convert.WithRasterizeTargetResolution(xRes, yRes)
+}
+
+// WithRasterizeOutputSize forwards to [convert.WithRasterizeOutputSize]. Deprecated.
+func WithRasterizeOutputSize(xSize, ySize int) RasterizeOption {
+	return convert.WithRasterizeOutputSize(xSize, ySize)
+}
+
+// WithRasterizeOutputBounds forwards to [convert.WithRasterizeOutputBounds]. Deprecated.
+func WithRasterizeOutputBounds(minX, minY, maxX, maxY float64) RasterizeOption {
+	return convert.WithRasterizeOutputBounds(minX, minY, maxX, maxY)
+}
+
+// WithRasterizeLayer forwards to [convert.WithRasterizeLayer]. Deprecated.
+func WithRasterizeLayer(name string) RasterizeOption { return convert.WithRasterizeLayer(name) }
+
+// WithRasterizeWhere forwards to [convert.WithRasterizeWhere]. Deprecated.
+func WithRasterizeWhere(sql string) RasterizeOption { return convert.WithRasterizeWhere(sql) }
+
+// WithRasterizeCreationOption forwards to [convert.WithRasterizeCreationOption]. Deprecated.
+func WithRasterizeCreationOption(key, val string) RasterizeOption {
+	return convert.WithRasterizeCreationOption(key, val)
+}
+
+// WithRasterizeOutputType forwards to [convert.WithRasterizeOutputType]. Deprecated.
+func WithRasterizeOutputType(t string) RasterizeOption { return convert.WithRasterizeOutputType(t) }
+
+// WithRasterizeRawOptions forwards to [convert.WithRasterizeRawOptions]. Deprecated.
+func WithRasterizeRawOptions(args ...string) RasterizeOption {
+	return convert.WithRasterizeRawOptions(args...)
+}
+
+// =============================================================================
+// VRT options — all forward to convert.WithVRT*; all Deprecated.
+// =============================================================================
+
+// WithVRTLogger forwards to [convert.WithVRTLogger]. Deprecated.
+func WithVRTLogger(l *slog.Logger) VRTOption { return convert.WithVRTLogger(l) }
+
+// WithVRTResolution forwards to [convert.WithVRTResolution]. Deprecated.
+func WithVRTResolution(mode string) VRTOption { return convert.WithVRTResolution(mode) }
+
+// WithVRTUserResolution forwards to [convert.WithVRTUserResolution]. Deprecated.
+func WithVRTUserResolution(xRes, yRes float64) VRTOption {
+	return convert.WithVRTUserResolution(xRes, yRes)
+}
+
+// WithVRTSeparate forwards to [convert.WithVRTSeparate]. Deprecated.
+func WithVRTSeparate() VRTOption { return convert.WithVRTSeparate() }
+
+// WithVRTAddAlpha forwards to [convert.WithVRTAddAlpha]. Deprecated.
+func WithVRTAddAlpha() VRTOption { return convert.WithVRTAddAlpha() }
+
+// WithVRTResamplingAlg forwards to [convert.WithVRTResamplingAlg]. Deprecated.
+func WithVRTResamplingAlg(alg string) VRTOption { return convert.WithVRTResamplingAlg(alg) }
+
+// WithVRTSrcNoData forwards to [convert.WithVRTSrcNoData]. Deprecated.
+func WithVRTSrcNoData(values string) VRTOption { return convert.WithVRTSrcNoData(values) }
+
+// WithVRTNoData forwards to [convert.WithVRTNoData]. Deprecated.
+func WithVRTNoData(values string) VRTOption { return convert.WithVRTNoData(values) }
+
+// WithVRTHideNoData forwards to [convert.WithVRTHideNoData]. Deprecated.
+func WithVRTHideNoData() VRTOption { return convert.WithVRTHideNoData() }
+
+// WithVRTBands forwards to [convert.WithVRTBands]. Deprecated.
+func WithVRTBands(bands ...int) VRTOption { return convert.WithVRTBands(bands...) }
+
+// WithVRTAllowProjectionDifference forwards to [convert.WithVRTAllowProjectionDifference]. Deprecated.
+func WithVRTAllowProjectionDifference() VRTOption { return convert.WithVRTAllowProjectionDifference() }
+
+// WithVRTRawOptions forwards to [convert.WithVRTRawOptions]. Deprecated.
+func WithVRTRawOptions(args ...string) VRTOption { return convert.WithVRTRawOptions(args...) }
+
+// =============================================================================
+// DEM options — all forward to convert.WithDEM*; all Deprecated.
+// =============================================================================
+
+// WithDEMLogger forwards to [convert.WithDEMLogger]. Deprecated.
+func WithDEMLogger(l *slog.Logger) DEMOption { return convert.WithDEMLogger(l) }
+
+// WithDEMFormat forwards to [convert.WithDEMFormat]. Deprecated.
+func WithDEMFormat(driver string) DEMOption { return convert.WithDEMFormat(driver) }
+
+// WithDEMColorFile forwards to [convert.WithDEMColorFile]. Deprecated.
+func WithDEMColorFile(path string) DEMOption { return convert.WithDEMColorFile(path) }
+
+// WithDEMZFactor forwards to [convert.WithDEMZFactor]. Deprecated.
+func WithDEMZFactor(z float64) DEMOption { return convert.WithDEMZFactor(z) }
+
+// WithDEMScale forwards to [convert.WithDEMScale]. Deprecated.
+func WithDEMScale(s float64) DEMOption { return convert.WithDEMScale(s) }
+
+// WithDEMAzimuth forwards to [convert.WithDEMAzimuth]. Deprecated.
+func WithDEMAzimuth(degrees float64) DEMOption { return convert.WithDEMAzimuth(degrees) }
+
+// WithDEMAltitude forwards to [convert.WithDEMAltitude]. Deprecated.
+func WithDEMAltitude(degrees float64) DEMOption { return convert.WithDEMAltitude(degrees) }
+
+// WithDEMCombined forwards to [convert.WithDEMCombined]. Deprecated.
+func WithDEMCombined() DEMOption { return convert.WithDEMCombined() }
+
+// WithDEMMultidirectional forwards to [convert.WithDEMMultidirectional]. Deprecated.
+func WithDEMMultidirectional() DEMOption { return convert.WithDEMMultidirectional() }
+
+// WithDEMAlgorithm forwards to [convert.WithDEMAlgorithm]. Deprecated.
+func WithDEMAlgorithm(alg string) DEMOption { return convert.WithDEMAlgorithm(alg) }
+
+// WithDEMCreationOption forwards to [convert.WithDEMCreationOption]. Deprecated.
+func WithDEMCreationOption(key, val string) DEMOption {
+	return convert.WithDEMCreationOption(key, val)
+}
+
+// WithDEMOutputType forwards to [convert.WithDEMOutputType]. Deprecated.
+func WithDEMOutputType(t string) DEMOption { return convert.WithDEMOutputType(t) }
+
+// WithDEMRawOptions forwards to [convert.WithDEMRawOptions]. Deprecated.
+func WithDEMRawOptions(args ...string) DEMOption { return convert.WithDEMRawOptions(args...) }
+
+// =============================================================================
+// PMTiles options — all forward to convert.WithPMTiles*; all Deprecated.
+// =============================================================================
+
+// WithPMTilesLogger forwards to [convert.WithPMTilesLogger]. Deprecated.
+func WithPMTilesLogger(l *slog.Logger) PMTilesOption { return convert.WithPMTilesLogger(l) }
+
+// WithPMTilesDeduplicate forwards to [convert.WithPMTilesDeduplicate]. Deprecated.
+func WithPMTilesDeduplicate(dedupe bool) PMTilesOption { return convert.WithPMTilesDeduplicate(dedupe) }

--- a/convert/buildvrt.go
+++ b/convert/buildvrt.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // VRTOption configures a [BuildVRT] call. Construct via the
@@ -30,7 +33,7 @@ type vrtConfig struct {
 }
 
 func newVRTConfig(opts []VRTOption) *vrtConfig {
-	c := &vrtConfig{logger: GetLogger()}
+	c := &vrtConfig{logger: slogx.Default()}
 	for _, o := range opts {
 		if o != nil {
 			o(c)
@@ -40,11 +43,11 @@ func newVRTConfig(opts []VRTOption) *vrtConfig {
 }
 
 // WithVRTLogger sets the structured logger used during VRT build.
-// nil falls back to [GetLogger].
+// nil falls back to [slogx.Default].
 func WithVRTLogger(l *slog.Logger) VRTOption {
 	return func(c *vrtConfig) {
 		if l == nil {
-			c.logger = GetLogger()
+			c.logger = slogx.Default()
 			return
 		}
 		c.logger = l
@@ -140,14 +143,14 @@ func WithVRTRawOptions(args ...string) VRTOption {
 // `gdal.OpenEx(OFRaster|OFReadOnly)` and closed when [BuildVRT]
 // returns.
 //
-// Errors are wrapped with [ErrConvertFailed]; recover via
+// Errors are wrapped with [errs.ErrConvertFailed]; recover via
 // [errors.As] into [*GISError]. The Op field is "BuildVRT".
 func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if len(srcs) == 0 {
-		return newGISError("BuildVRT", dst, ErrConvertFailed,
+		return errs.NewGISError("BuildVRT", dst, errs.ErrConvertFailed,
 			fmt.Errorf("at least one source path is required"))
 	}
 
@@ -164,7 +167,7 @@ func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption)
 		ds, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
 		if err != nil {
 			cfg.logger.Error("BuildVRT: open source", "src", src, "err", err)
-			return newGISError("BuildVRT", src, ErrConvertFailed, err)
+			return errs.NewGISError("BuildVRT", src, errs.ErrConvertFailed, err)
 		}
 		ds.Close()
 	}
@@ -184,7 +187,7 @@ func BuildVRT(ctx context.Context, dst string, srcs []string, opts ...VRTOption)
 
 	out, vErr := gdal.BuildVRT(dst, zeroDS, srcs, args)
 	if vErr != nil {
-		return newGISError("BuildVRT", dst, ErrConvertFailed, vErr)
+		return errs.NewGISError("BuildVRT", dst, errs.ErrConvertFailed, vErr)
 	}
 	defer out.Close()
 	return nil

--- a/convert/buildvrt_integration_test.go
+++ b/convert/buildvrt_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestBuildVRT_TwoGeoTIFFs_Integration assembles two GeoTIFF inputs into
@@ -21,10 +21,10 @@ func TestBuildVRT_TwoGeoTIFFs_Integration(t *testing.T) {
 	src2 := mustFetched(t, "cog.tif")
 	dst := filepath.Join(t.TempDir(), "mosaic.vrt")
 
-	if err := gismanager.BuildVRT(context.Background(), dst,
+	if err := convert.BuildVRT(context.Background(), dst,
 		[]string{src1, src2},
-		gismanager.WithVRTResolution("highest"),
-		gismanager.WithVRTAllowProjectionDifference(),
+		convert.WithVRTResolution("highest"),
+		convert.WithVRTAllowProjectionDifference(),
 	); err != nil {
 		t.Fatalf("BuildVRT: %v", err)
 	}
@@ -52,10 +52,10 @@ func TestBuildVRT_SeparateMode_Integration(t *testing.T) {
 	src2 := mustFetched(t, "cog.tif")      // typically 1 band
 	dst := filepath.Join(t.TempDir(), "stack.vrt")
 
-	if err := gismanager.BuildVRT(context.Background(), dst,
+	if err := convert.BuildVRT(context.Background(), dst,
 		[]string{src1, src2},
-		gismanager.WithVRTSeparate(),
-		gismanager.WithVRTAllowProjectionDifference(),
+		convert.WithVRTSeparate(),
+		convert.WithVRTAllowProjectionDifference(),
 	); err != nil {
 		t.Fatalf("BuildVRT: %v", err)
 	}

--- a/convert/buildvrt_test.go
+++ b/convert/buildvrt_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestBuildVRTArgs(t *testing.T) {
@@ -111,9 +113,9 @@ func TestBuildVRT_CtxCancelledFailsFast(t *testing.T) {
 func TestBuildVRT_RejectsEmptySources(t *testing.T) {
 	err := BuildVRT(context.Background(), "/tmp/out.vrt", nil)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "BuildVRT", gerr.Op)
 }
@@ -121,11 +123,11 @@ func TestBuildVRT_RejectsEmptySources(t *testing.T) {
 func TestBuildVRT_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := BuildVRT(context.Background(),
 		"/tmp/should_not_be_created.vrt",
-		[]string{"./testdata/__definitely_does_not_exist__.tif"})
+		[]string{"../testdata/__definitely_does_not_exist__.tif"})
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "BuildVRT", gerr.Op)
 }

--- a/convert/dem.go
+++ b/convert/dem.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // DEMOption configures a [DEMProcessing] call.
@@ -32,7 +35,7 @@ type demConfig struct {
 }
 
 func newDEMConfig(opts []DEMOption) *demConfig {
-	c := &demConfig{logger: GetLogger()}
+	c := &demConfig{logger: slogx.Default()}
 	for _, o := range opts {
 		if o != nil {
 			o(c)
@@ -42,11 +45,11 @@ func newDEMConfig(opts []DEMOption) *demConfig {
 }
 
 // WithDEMLogger sets the structured logger used during DEM processing.
-// nil falls back to [GetLogger].
+// nil falls back to [slogx.Default].
 func WithDEMLogger(l *slog.Logger) DEMOption {
 	return func(c *demConfig) {
 		if l == nil {
-			c.logger = GetLogger()
+			c.logger = slogx.Default()
 			return
 		}
 		c.logger = l
@@ -158,34 +161,34 @@ func WithDEMRawOptions(args ...string) DEMOption {
 //   - "TPI" — Topographic Position Index
 //   - "roughness" — local elevation variability
 //
-// Errors are wrapped with [ErrConvertFailed]; recover via [errors.As]
+// Errors are wrapped with [errs.ErrConvertFailed]; recover via [errors.As]
 // into [*GISError]. The Op field is "DEMProcessing".
 func DEMProcessing(ctx context.Context, src, dst, mode string, opts ...DEMOption) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if mode == "" {
-		return newGISError("DEMProcessing", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed,
+		return errs.NewGISError("DEMProcessing", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed,
 			fmt.Errorf("mode must be one of hillshade, slope, aspect, color-relief, TRI, TPI, roughness"))
 	}
 
 	cfg := newDEMConfig(opts)
 
 	if mode == "color-relief" && cfg.colorFile == "" {
-		return newGISError("DEMProcessing", src, ErrConvertFailed,
+		return errs.NewGISError("DEMProcessing", src, errs.ErrConvertFailed,
 			fmt.Errorf("mode=color-relief requires WithDEMColorFile"))
 	}
 
 	if err := validateGDALDriver(cfg.format); err != nil {
 		cfg.logger.Error("DEMProcessing: invalid format", "format", cfg.format, "err", err)
-		return newGISError("DEMProcessing", src, ErrConvertFailed, err)
+		return errs.NewGISError("DEMProcessing", src, errs.ErrConvertFailed, err)
 	}
 
 	srcDS, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
 	if err != nil {
 		cfg.logger.Error("DEMProcessing: open source", "src", src, "err", err)
-		return newGISError("DEMProcessing", src, ErrConvertFailed, err)
+		return errs.NewGISError("DEMProcessing", src, errs.ErrConvertFailed, err)
 	}
 	defer srcDS.Close()
 
@@ -195,8 +198,8 @@ func DEMProcessing(ctx context.Context, src, dst, mode string, opts ...DEMOption
 
 	out, dErr := gdal.DEMProcessing(dst, srcDS, mode, cfg.colorFile, args)
 	if dErr != nil {
-		return newGISError("DEMProcessing", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed, dErr)
+		return errs.NewGISError("DEMProcessing", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed, dErr)
 	}
 	defer out.Close()
 	return nil

--- a/convert/dem_integration_test.go
+++ b/convert/dem_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestDEMProcessing_Hillshade_Integration runs hillshade against the
@@ -20,10 +20,10 @@ func TestDEMProcessing_Hillshade_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "hs.tif")
 
-	if err := gismanager.DEMProcessing(context.Background(), src, dst, "hillshade",
-		gismanager.WithDEMFormat("GTiff"),
-		gismanager.WithDEMAzimuth(315),
-		gismanager.WithDEMAltitude(45),
+	if err := convert.DEMProcessing(context.Background(), src, dst, "hillshade",
+		convert.WithDEMFormat("GTiff"),
+		convert.WithDEMAzimuth(315),
+		convert.WithDEMAltitude(45),
 	); err != nil {
 		t.Fatalf("DEMProcessing hillshade: %v", err)
 	}
@@ -46,8 +46,8 @@ func TestDEMProcessing_Slope_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "slope.tif")
 
-	if err := gismanager.DEMProcessing(context.Background(), src, dst, "slope",
-		gismanager.WithDEMFormat("GTiff"),
+	if err := convert.DEMProcessing(context.Background(), src, dst, "slope",
+		convert.WithDEMFormat("GTiff"),
 	); err != nil {
 		t.Fatalf("DEMProcessing slope: %v", err)
 	}
@@ -69,8 +69,8 @@ func TestDEMProcessing_TRI_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "tri.tif")
 
-	if err := gismanager.DEMProcessing(context.Background(), src, dst, "TRI",
-		gismanager.WithDEMFormat("GTiff"),
+	if err := convert.DEMProcessing(context.Background(), src, dst, "TRI",
+		convert.WithDEMFormat("GTiff"),
 	); err != nil {
 		t.Fatalf("DEMProcessing TRI: %v", err)
 	}

--- a/convert/dem_test.go
+++ b/convert/dem_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestBuildDEMArgs(t *testing.T) {
@@ -110,7 +112,7 @@ func TestDEMProcessing_RejectsEmptyMode(t *testing.T) {
 	err := DEMProcessing(context.Background(),
 		"/dev/null", "/tmp/out.tif", "")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 	assert.Contains(t, err.Error(), "mode")
 }
 
@@ -118,19 +120,19 @@ func TestDEMProcessing_ColorReliefRequiresColorFile(t *testing.T) {
 	err := DEMProcessing(context.Background(),
 		"/dev/null", "/tmp/out.tif", "color-relief")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 	assert.Contains(t, err.Error(), "WithDEMColorFile")
 }
 
 func TestDEMProcessing_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := DEMProcessing(context.Background(),
-		"./testdata/__definitely_does_not_exist__.tif",
+		"../testdata/__definitely_does_not_exist__.tif",
 		"/tmp/should_not_be_created.hs.tif",
 		"hillshade")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "DEMProcessing", gerr.Op)
 }

--- a/convert/doc.go
+++ b/convert/doc.go
@@ -1,0 +1,31 @@
+// Package convert is gismanager's stateless conversion subsystem —
+// thin Go wrappers over GDAL's `ogr2ogr` / `gdal_translate` / `gdalwarp`
+// / `gdal_rasterize` / `gdalbuildvrt` / `gdaldem` C entry points, plus
+// PMTiles archive conversion via [protomaps/go-pmtiles].
+//
+// Entry points:
+//
+//   - [ConvertVector] (the `ogr2ogr` equivalent)
+//   - [ConvertRaster] / [ToCOG] (the `gdal_translate` equivalent + COG helper)
+//   - [ReprojectRaster] (the `gdalwarp` equivalent)
+//   - [Rasterize] (the `gdal_rasterize` equivalent: vector → raster)
+//   - [BuildVRT] (the `gdalbuildvrt` equivalent: multi-raster mosaic)
+//   - [DEMProcessing] (the `gdaldem` equivalent: hillshade / slope / aspect / etc.)
+//   - [ToPMTiles] (MBTiles → PMTiles archive)
+//
+// Each entry point has a matching `*Option` type and `WithX*` functional
+// option helpers ([VectorOption] / [RasterOption] / [RasterizeOption] /
+// [VRTOption] / [DEMOption] / [PMTilesOption]). Pass any number of
+// options in any order; nil options are tolerated.
+//
+// Errors wrap [github.com/hishamkaram/gismanager/internal/errs.ErrConvertFailed];
+// recover the underlying GDAL or filesystem error via [errors.As] into
+// [*errs.GISError]. The Op field on the returned *GISError disambiguates
+// which entry point produced the failure.
+//
+// History: this package split out of the root gismanager package as part
+// of the v2 restructure (Phase 2). v1.x callers can continue to use the
+// v1 names (gismanager.ConvertVector etc.) — those are now thin
+// [Deprecated] wrappers that delegate here. v2 (Phase 4) drops the
+// wrappers; v2 callers import this package directly.
+package convert

--- a/convert/example_test.go
+++ b/convert/example_test.go
@@ -1,4 +1,4 @@
-package gismanager_test
+package convert_test
 
 // Runnable godoc examples for the conversion subsystem. Each example
 // runs hermetically via the dev container's GDAL build — the source
@@ -17,7 +17,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // ExampleConvertVector demonstrates a vector format conversion from
@@ -25,12 +25,12 @@ import (
 // filesystem write, no network. Same shape works for /vsis3/, /vsigs/,
 // /vsicurl/ destinations.
 func ExampleConvertVector() {
-	src := "./testdata/neighborhood_names_gis.geojson"
+	src := "../testdata/neighborhood_names_gis.geojson"
 	dst := "/vsimem/example_convert_vector.gpkg"
 
-	if err := gismanager.ConvertVector(context.Background(), src, dst,
-		gismanager.WithVectorFormat("GPKG"),
-		gismanager.WithVectorOverwrite(),
+	if err := convert.ConvertVector(context.Background(), src, dst,
+		convert.WithVectorFormat("GPKG"),
+		convert.WithVectorOverwrite(),
 	); err != nil {
 		fmt.Println("error:", err)
 		return
@@ -54,7 +54,7 @@ func ExampleToCOG() {
 	srcDS := driver.Create(src, 16, 16, 1, gdal.Byte, nil)
 	srcDS.Close()
 
-	if err := gismanager.ToCOG(context.Background(), src, dst); err != nil {
+	if err := convert.ToCOG(context.Background(), src, dst); err != nil {
 		fmt.Println("error:", err)
 		return
 	}
@@ -80,7 +80,7 @@ func ExampleReprojectRaster() {
 	srcDS.SetProjection(wkt)
 	srcDS.Close()
 
-	if err := gismanager.ReprojectRaster(context.Background(), src, dst,
+	if err := convert.ReprojectRaster(context.Background(), src, dst,
 		"EPSG:4326", "EPSG:3857",
 	); err != nil {
 		fmt.Println("error:", err)
@@ -93,13 +93,13 @@ func ExampleReprojectRaster() {
 // ExampleRasterize demonstrates burning vector features into a
 // raster grid (the gdal_rasterize equivalent).
 func ExampleRasterize() {
-	src := "./testdata/neighborhood_names_gis.geojson"
+	src := "../testdata/neighborhood_names_gis.geojson"
 	dst := "/vsimem/example_rasterize.tif"
 
-	if err := gismanager.Rasterize(context.Background(), src, dst,
-		gismanager.WithRasterizeFormat("GTiff"),
-		gismanager.WithRasterizeOutputSize(64, 64),
-		gismanager.WithRasterizeBurnValues(1),
+	if err := convert.Rasterize(context.Background(), src, dst,
+		convert.WithRasterizeFormat("GTiff"),
+		convert.WithRasterizeOutputSize(64, 64),
+		convert.WithRasterizeBurnValues(1),
 	); err != nil {
 		fmt.Println("error:", err)
 		return
@@ -123,7 +123,7 @@ func ExampleDEMProcessing() {
 	srcDS.SetGeoTransform([6]float64{0, 1, 0, 32, 0, -1})
 	srcDS.Close()
 
-	if err := gismanager.DEMProcessing(context.Background(), src, dst,
+	if err := convert.DEMProcessing(context.Background(), src, dst,
 		"hillshade",
 	); err != nil {
 		fmt.Println("error:", err)
@@ -149,7 +149,7 @@ func ExampleBuildVRT() {
 		ds.Close()
 	}
 
-	if err := gismanager.BuildVRT(context.Background(), dst,
+	if err := convert.BuildVRT(context.Background(), dst,
 		[]string{src1, src2},
 	); err != nil {
 		fmt.Println("error:", err)

--- a/convert/pmtiles.go
+++ b/convert/pmtiles.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/protomaps/go-pmtiles/pmtiles"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // PMTilesOption configures [ToPMTiles] at call time.
@@ -20,7 +23,7 @@ type pmtilesConfig struct {
 
 func newPMTilesConfig(opts []PMTilesOption) *pmtilesConfig {
 	cfg := &pmtilesConfig{
-		logger:      GetLogger(),
+		logger:      slogx.Default(),
 		deduplicate: true,
 	}
 	for _, opt := range opts {
@@ -61,9 +64,9 @@ func WithPMTilesDeduplicate(dedupe bool) PMTilesOption {
 //
 // Two-stage pipeline for callers who start from a raster:
 //
-//	if err := gismanager.ConvertRaster(ctx, "scene.tif", "scene.mbtiles",
-//	    gismanager.WithRasterFormat("MBTILES")); err != nil { ... }
-//	if err := gismanager.ToPMTiles(ctx, "scene.mbtiles", "scene.pmtiles"); err != nil { ... }
+//	if err := convert.ConvertRaster(ctx, "scene.tif", "scene.mbtiles",
+//	    convert.WithRasterFormat("MBTILES")); err != nil { ... }
+//	if err := convert.ToPMTiles(ctx, "scene.mbtiles", "scene.pmtiles"); err != nil { ... }
 //
 // PMTiles is the dominant 2026 single-file tile archive format,
 // suitable for serverless distribution from S3, HTTP, or any
@@ -73,7 +76,7 @@ func WithPMTilesDeduplicate(dedupe bool) PMTilesOption {
 // tracked as a v1.5 follow-up; for v1.4 the two-step path is
 // the supported route.
 //
-// Errors are wrapped with [ErrConvertFailed]; recover the underlying
+// Errors are wrapped with [errs.ErrConvertFailed]; recover the underlying
 // go-pmtiles or filesystem error via [errors.As] into [*GISError]. The
 // Op field is "ToPMTiles".
 func ToPMTiles(ctx context.Context, src, dst string, opts ...PMTilesOption) error {
@@ -87,7 +90,7 @@ func ToPMTiles(ctx context.Context, src, dst string, opts ...PMTilesOption) erro
 	// only the missing inode without naming the user-supplied path.
 	if _, err := os.Stat(src); err != nil {
 		cfg.logger.Error("ToPMTiles: stat source", "src", src, "err", err)
-		return newGISError("ToPMTiles", src, ErrConvertFailed, err)
+		return errs.NewGISError("ToPMTiles", src, errs.ErrConvertFailed, err)
 	}
 
 	// pmtiles.Convert wants a temp scratch *os.File for staging the
@@ -99,7 +102,7 @@ func ToPMTiles(ctx context.Context, src, dst string, opts ...PMTilesOption) erro
 	tmp, err := os.CreateTemp(tmpDir, ".gismanager-pmtiles-*.tmp")
 	if err != nil {
 		cfg.logger.Error("ToPMTiles: create temp file", "dir", tmpDir, "err", err)
-		return newGISError("ToPMTiles", dst, ErrConvertFailed, err)
+		return errs.NewGISError("ToPMTiles", dst, errs.ErrConvertFailed, err)
 	}
 	defer func() {
 		_ = tmp.Close()
@@ -116,9 +119,9 @@ func ToPMTiles(ctx context.Context, src, dst string, opts ...PMTilesOption) erro
 	stdLogger := slog.NewLogLogger(cfg.logger.Handler(), slog.LevelInfo)
 
 	if err := pmtiles.Convert(stdLogger, src, dst, cfg.deduplicate, tmp); err != nil {
-		return newGISError("ToPMTiles",
+		return errs.NewGISError("ToPMTiles",
 			fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed, err)
+			errs.ErrConvertFailed, err)
 	}
 	return nil
 }

--- a/convert/pmtiles_test.go
+++ b/convert/pmtiles_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestToPMTiles_CtxCanceledFastFail(t *testing.T) {
@@ -20,17 +22,17 @@ func TestToPMTiles_CtxCanceledFastFail(t *testing.T) {
 
 func TestToPMTiles_MissingSourceWrapsErr(t *testing.T) {
 	err := ToPMTiles(context.Background(),
-		"./testdata/this-file-definitely-does-not-exist.mbtiles",
+		"../testdata/this-file-definitely-does-not-exist.mbtiles",
 		"/tmp/should-never-be-written.pmtiles")
 	if err == nil {
 		t.Fatal("want error on missing source, got nil")
 	}
-	if !errors.Is(err, ErrConvertFailed) {
-		t.Errorf("errors.Is(err, ErrConvertFailed) = false; want true. err=%v", err)
+	if !errors.Is(err, errs.ErrConvertFailed) {
+		t.Errorf("errors.Is(err, errs.ErrConvertFailed) = false; want true. err=%v", err)
 	}
-	var gerr *GISError
+	var gerr *errs.GISError
 	if !errors.As(err, &gerr) {
-		t.Fatalf("errors.As to *GISError: no match")
+		t.Fatalf("errors.As to *errs.GISError: no match")
 	}
 	if gerr.Op != "ToPMTiles" {
 		t.Errorf("Op = %q; want ToPMTiles", gerr.Op)
@@ -40,7 +42,7 @@ func TestToPMTiles_MissingSourceWrapsErr(t *testing.T) {
 func TestNewPMTilesConfig_DefaultsAndOptions(t *testing.T) {
 	cfg := newPMTilesConfig(nil)
 	if cfg.logger == nil {
-		t.Error("default config: logger should fall back to GetLogger()")
+		t.Error("default config: logger should fall back to slogx.Default()")
 	}
 	if !cfg.deduplicate {
 		t.Error("default config: deduplicate should default to true")
@@ -75,7 +77,7 @@ func TestNewPMTilesConfig_DefaultsAndOptions(t *testing.T) {
 // user-supplied path — useful for triage in batch jobs converting
 // many tilesets in one run.
 func TestToPMTiles_ErrorMessagesIncludePath(t *testing.T) {
-	src := "./testdata/missing-tile-archive-zzz.mbtiles"
+	src := "../testdata/missing-tile-archive-zzz.mbtiles"
 	err := ToPMTiles(context.Background(), src, "/tmp/x.pmtiles")
 	if err == nil {
 		t.Fatal("want error on missing source")

--- a/convert/raster.go
+++ b/convert/raster.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -7,13 +7,16 @@ import (
 	"strconv"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
-// RasterConvertOption configures [ConvertRaster], [ToCOG], and
+// RasterOption configures [ConvertRaster], [ToCOG], and
 // [ReprojectRaster]. Construct via the [WithRaster*] helpers.
-type RasterConvertOption func(*rasterConvertConfig)
+type RasterOption func(*rasterConfig)
 
-type rasterConvertConfig struct {
+type rasterConfig struct {
 	logger          *slog.Logger
 	format          string
 	creationOptions []string // raw "KEY=VAL" pairs for -co
@@ -32,8 +35,8 @@ type rasterBounds struct {
 	MinX, MinY, MaxX, MaxY float64
 }
 
-func newRasterConvertConfig(opts []RasterConvertOption) *rasterConvertConfig {
-	c := &rasterConvertConfig{logger: GetLogger()}
+func newRasterConfig(opts []RasterOption) *rasterConfig {
+	c := &rasterConfig{logger: slogx.Default()}
 	for _, o := range opts {
 		if o != nil {
 			o(c)
@@ -43,11 +46,11 @@ func newRasterConvertConfig(opts []RasterConvertOption) *rasterConvertConfig {
 }
 
 // WithRasterLogger sets the structured logger used during conversion.
-// nil falls back to [GetLogger].
-func WithRasterLogger(l *slog.Logger) RasterConvertOption {
-	return func(c *rasterConvertConfig) {
+// nil falls back to [slogx.Default].
+func WithRasterLogger(l *slog.Logger) RasterOption {
+	return func(c *rasterConfig) {
 		if l == nil {
-			c.logger = GetLogger()
+			c.logger = slogx.Default()
 			return
 		}
 		c.logger = l
@@ -57,16 +60,16 @@ func WithRasterLogger(l *slog.Logger) RasterConvertOption {
 // WithRasterFormat selects the GDAL output driver by name (e.g.
 // "GTiff", "COG", "PNG", "JPEG"). Maps to gdal_translate's `-of` and
 // gdalwarp's `-of`. When empty, GDAL infers from the destination path.
-func WithRasterFormat(driver string) RasterConvertOption {
-	return func(c *rasterConvertConfig) { c.format = driver }
+func WithRasterFormat(driver string) RasterOption {
+	return func(c *rasterConfig) { c.format = driver }
 }
 
 // WithRasterCreationOption appends a single driver-specific creation
 // option (e.g. "COMPRESS=DEFLATE", "TILING_SCHEME=GoogleMapsCompatible",
 // "BLOCKSIZE=512"). May be called multiple times to set several options.
 // Maps to `-co KEY=VAL`.
-func WithRasterCreationOption(key, val string) RasterConvertOption {
-	return func(c *rasterConvertConfig) {
+func WithRasterCreationOption(key, val string) RasterOption {
+	return func(c *rasterConfig) {
 		c.creationOptions = append(c.creationOptions, fmt.Sprintf("%s=%s", key, val))
 	}
 }
@@ -75,30 +78,30 @@ func WithRasterCreationOption(key, val string) RasterConvertOption {
 // in the source CRS units (for [ConvertRaster]'s `-projwin`) or target
 // CRS units (for [ReprojectRaster]'s `-te`). The wrapper picks the right
 // flag based on which entry point invoked it.
-func WithRasterOutputBounds(minX, minY, maxX, maxY float64) RasterConvertOption {
-	return func(c *rasterConvertConfig) {
+func WithRasterOutputBounds(minX, minY, maxX, maxY float64) RasterOption {
+	return func(c *rasterConfig) {
 		c.outputBounds = &rasterBounds{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
 	}
 }
 
 // WithRasterBands selects a subset of source bands to copy, in the
 // given order. Maps to `-b 1 -b 2 ...`. Empty means all bands.
-func WithRasterBands(bands ...int) RasterConvertOption {
-	return func(c *rasterConvertConfig) { c.bands = append([]int(nil), bands...) }
+func WithRasterBands(bands ...int) RasterOption {
+	return func(c *rasterConfig) { c.bands = append([]int(nil), bands...) }
 }
 
 // WithRasterResamplingAlg sets the resampling algorithm for warp /
 // translate. Common values: "near", "bilinear", "cubic", "cubicspline",
 // "lanczos", "average", "mode", "max", "min". Maps to `-r`.
-func WithRasterResamplingAlg(alg string) RasterConvertOption {
-	return func(c *rasterConvertConfig) { c.resamplingAlg = alg }
+func WithRasterResamplingAlg(alg string) RasterOption {
+	return func(c *rasterConfig) { c.resamplingAlg = alg }
 }
 
 // WithRasterTargetResolution sets the output pixel size in target-CRS
 // units. Pass non-zero values for both axes; zero means "use source
 // resolution". Maps to `-tr xRes yRes`.
-func WithRasterTargetResolution(xRes, yRes float64) RasterConvertOption {
-	return func(c *rasterConvertConfig) {
+func WithRasterTargetResolution(xRes, yRes float64) RasterOption {
+	return func(c *rasterConfig) {
 		c.targetResX = xRes
 		c.targetResY = yRes
 		c.hasTargetRes = true
@@ -109,8 +112,8 @@ func WithRasterTargetResolution(xRes, yRes float64) RasterConvertOption {
 // within it) to mask the output by. Pixels outside the cutline polygon
 // are written as NoData. Maps to `-cutline <ds>` (and `-cl <layer>` if
 // non-empty). Useful for cookie-cutter clipping of imagery.
-func WithRasterCutline(ds, layer string) RasterConvertOption {
-	return func(c *rasterConvertConfig) {
+func WithRasterCutline(ds, layer string) RasterOption {
+	return func(c *rasterConfig) {
 		c.cutlineDS = ds
 		c.cutlineLayer = layer
 	}
@@ -119,8 +122,8 @@ func WithRasterCutline(ds, layer string) RasterConvertOption {
 // WithRasterRawOptions appends raw flag tokens to the generated
 // argument list. Use this to reach gdal_translate / gdalwarp flags the
 // typed helpers don't expose.
-func WithRasterRawOptions(args ...string) RasterConvertOption {
-	return func(c *rasterConvertConfig) { c.rawOptions = append(c.rawOptions, args...) }
+func WithRasterRawOptions(args ...string) RasterOption {
+	return func(c *rasterConfig) { c.rawOptions = append(c.rawOptions, args...) }
 }
 
 // ConvertRaster converts the raster source at src into dst, applying any
@@ -136,23 +139,23 @@ func WithRasterRawOptions(args ...string) RasterConvertOption {
 // For reprojection use [ReprojectRaster] instead — gdal_translate does
 // NOT reproject.
 //
-// Errors are wrapped with [ErrConvertFailed]; recover the underlying
+// Errors are wrapped with [errs.ErrConvertFailed]; recover the underlying
 // GDAL error via [errors.As] into [*GISError].
-func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterConvertOption) error {
+func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterOption) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	cfg := newRasterConvertConfig(opts)
+	cfg := newRasterConfig(opts)
 
 	if err := validateGDALDriver(cfg.format); err != nil {
 		cfg.logger.Error("ConvertRaster: invalid format", "format", cfg.format, "err", err)
-		return newGISError("ConvertRaster", src, ErrConvertFailed, err)
+		return errs.NewGISError("ConvertRaster", src, errs.ErrConvertFailed, err)
 	}
 
 	srcDS, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
 	if err != nil {
 		cfg.logger.Error("ConvertRaster: open source", "src", src, "err", err)
-		return newGISError("ConvertRaster", src, ErrConvertFailed, err)
+		return errs.NewGISError("ConvertRaster", src, errs.ErrConvertFailed, err)
 	}
 	defer srcDS.Close()
 
@@ -162,8 +165,8 @@ func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterConvertOp
 
 	out, tErr := gdal.Translate(dst, srcDS, args)
 	if tErr != nil {
-		return newGISError("ConvertRaster", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed, tErr)
+		return errs.NewGISError("ConvertRaster", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed, tErr)
 	}
 	defer out.Close()
 	return nil
@@ -181,14 +184,14 @@ func ConvertRaster(ctx context.Context, src, dst string, opts ...RasterConvertOp
 //
 // Caller-supplied opts override any of the defaults — pass
 // `WithRasterCreationOption("COMPRESS", "ZSTD")` to swap codecs, etc.
-func ToCOG(ctx context.Context, src, dst string, opts ...RasterConvertOption) error {
-	defaults := []RasterConvertOption{
+func ToCOG(ctx context.Context, src, dst string, opts ...RasterOption) error {
+	defaults := []RasterOption{
 		WithRasterFormat("COG"),
 		WithRasterCreationOption("COMPRESS", "DEFLATE"),
 		WithRasterCreationOption("BLOCKSIZE", "512"),
 		WithRasterCreationOption("OVERVIEW_RESAMPLING", "NEAREST"),
 	}
-	merged := make([]RasterConvertOption, 0, len(defaults)+len(opts))
+	merged := make([]RasterOption, 0, len(defaults)+len(opts))
 	merged = append(merged, defaults...)
 	merged = append(merged, opts...)
 	return ConvertRaster(ctx, src, dst, merged...)
@@ -196,7 +199,7 @@ func ToCOG(ctx context.Context, src, dst string, opts ...RasterConvertOption) er
 
 // buildTranslateArgs renders cfg into gdal_translate-style args.
 // Unit-tested separately so the mapping is locked in without CGo.
-func buildTranslateArgs(cfg *rasterConvertConfig) []string {
+func buildTranslateArgs(cfg *rasterConfig) []string {
 	var args []string
 	if cfg.format != "" {
 		args = append(args, "-of", cfg.format)

--- a/convert/raster_integration_test.go
+++ b/convert/raster_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestConvertRaster_GeoTIFFToCOG_Integration exercises the most common
@@ -20,7 +20,7 @@ func TestConvertRaster_GeoTIFFToCOG_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "RGB.cog.tif")
 
-	if err := gismanager.ToCOG(context.Background(), src, dst); err != nil {
+	if err := convert.ToCOG(context.Background(), src, dst); err != nil {
 		t.Fatalf("ToCOG: %v", err)
 	}
 
@@ -54,9 +54,9 @@ func TestConvertRaster_GeoTIFFToPNG_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "RGB.png")
 
-	if err := gismanager.ConvertRaster(context.Background(), src, dst,
-		gismanager.WithRasterFormat("PNG"),
-		gismanager.WithRasterBands(1, 2, 3),
+	if err := convert.ConvertRaster(context.Background(), src, dst,
+		convert.WithRasterFormat("PNG"),
+		convert.WithRasterBands(1, 2, 3),
 	); err != nil {
 		t.Fatalf("ConvertRaster: %v", err)
 	}
@@ -82,8 +82,8 @@ func TestToCOG_OverridesDefaults_Integration(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "RGB.zstd.cog.tif")
 
 	// User picks ZSTD compression instead of the default DEFLATE.
-	if err := gismanager.ToCOG(context.Background(), src, dst,
-		gismanager.WithRasterCreationOption("COMPRESS", "ZSTD"),
+	if err := convert.ToCOG(context.Background(), src, dst,
+		convert.WithRasterCreationOption("COMPRESS", "ZSTD"),
 	); err != nil {
 		t.Skipf("ToCOG with ZSTD failed (GDAL build may lack zstd): %v", err)
 	}

--- a/convert/raster_reproject.go
+++ b/convert/raster_reproject.go
@@ -1,10 +1,12 @@
-package gismanager
+package convert
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 // ReprojectRaster reprojects the raster source at src into dst, going
@@ -25,34 +27,34 @@ import (
 // interpreted in the *target* CRS (gdalwarp's `-te` semantics), not
 // the source CRS (gdal_translate's `-projwin`).
 //
-// Errors are wrapped with [ErrConvertFailed]; recover via
+// Errors are wrapped with [errs.ErrConvertFailed]; recover via
 // [errors.As] into [*GISError]. The Op field is "ReprojectRaster".
 //
 // Driver names supplied via [WithRasterFormat] are pre-validated; an
-// unknown driver surfaces as a clean ErrConvertFailed before the C
+// unknown driver surfaces as a clean errs.ErrConvertFailed before the C
 // call. Other silent-failure modes (invalid CRS strings, malformed
 // option values) still rely on GDAL surfacing a non-zero cerr.
-func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterConvertOption) error {
+func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts ...RasterOption) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if srcSRS == "" || dstSRS == "" {
-		return newGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed,
+		return errs.NewGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed,
 			fmt.Errorf("srcSRS and dstSRS must both be non-empty"))
 	}
 
-	cfg := newRasterConvertConfig(opts)
+	cfg := newRasterConfig(opts)
 
 	if err := validateGDALDriver(cfg.format); err != nil {
 		cfg.logger.Error("ReprojectRaster: invalid format", "format", cfg.format, "err", err)
-		return newGISError("ReprojectRaster", src, ErrConvertFailed, err)
+		return errs.NewGISError("ReprojectRaster", src, errs.ErrConvertFailed, err)
 	}
 
 	srcDS, err := gdal.OpenEx(src, gdal.OFRaster|gdal.OFReadOnly, nil, nil, nil)
 	if err != nil {
 		cfg.logger.Error("ReprojectRaster: open source", "src", src, "err", err)
-		return newGISError("ReprojectRaster", src, ErrConvertFailed, err)
+		return errs.NewGISError("ReprojectRaster", src, errs.ErrConvertFailed, err)
 	}
 	defer srcDS.Close()
 
@@ -62,8 +64,8 @@ func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts 
 
 	out, wErr := gdal.Warp(dst, nil, []gdal.Dataset{srcDS}, args)
 	if wErr != nil {
-		return newGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed, wErr)
+		return errs.NewGISError("ReprojectRaster", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed, wErr)
 	}
 	defer out.Close()
 	return nil
@@ -78,7 +80,7 @@ func ReprojectRaster(ctx context.Context, src, dst, srcSRS, dstSRS string, opts 
 //     a warp-only flag; gdal_translate does not support it).
 //
 // Unit-tested separately so the mapping is locked in without CGo.
-func buildWarpArgs(cfg *rasterConvertConfig, srcSRS, dstSRS string) []string {
+func buildWarpArgs(cfg *rasterConfig, srcSRS, dstSRS string) []string {
 	var args []string
 	if cfg.format != "" {
 		args = append(args, "-of", cfg.format)

--- a/convert/raster_reproject_integration_test.go
+++ b/convert/raster_reproject_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestReprojectRaster_GeoTIFFToWebMercator_Integration exercises the
@@ -20,10 +20,10 @@ func TestReprojectRaster_GeoTIFFToWebMercator_Integration(t *testing.T) {
 	src := mustFetched(t, "RGB.byte.tif")
 	dst := filepath.Join(t.TempDir(), "RGB.3857.tif")
 
-	if err := gismanager.ReprojectRaster(context.Background(),
+	if err := convert.ReprojectRaster(context.Background(),
 		src, dst, "EPSG:32618", "EPSG:3857",
-		gismanager.WithRasterFormat("GTiff"),
-		gismanager.WithRasterResamplingAlg("bilinear"),
+		convert.WithRasterFormat("GTiff"),
+		convert.WithRasterResamplingAlg("bilinear"),
 	); err != nil {
 		t.Fatalf("ReprojectRaster: %v", err)
 	}

--- a/convert/raster_reproject_test.go
+++ b/convert/raster_reproject_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestBuildWarpArgs(t *testing.T) {
 	cases := []struct {
 		name   string
-		opts   []RasterConvertOption
+		opts   []RasterOption
 		srcSRS string
 		dstSRS string
 		want   []string
@@ -24,7 +26,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "with format and creation option",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterFormat("GTiff"),
 				WithRasterCreationOption("COMPRESS", "DEFLATE"),
 			},
@@ -38,7 +40,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "output bounds use -te (target CRS) not -projwin",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterOutputBounds(-180, -90, 180, 90),
 			},
 			srcSRS: "EPSG:4326",
@@ -50,7 +52,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "resampling + target resolution",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterResamplingAlg("bilinear"),
 				WithRasterTargetResolution(30, 30),
 			},
@@ -64,7 +66,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "cutline emits -cutline + -cl + -crop_to_cutline",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterCutline("clip.geojson", "outline"),
 			},
 			srcSRS: "EPSG:4326",
@@ -78,7 +80,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "cutline without explicit layer omits -cl",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterCutline("clip.geojson", ""),
 			},
 			srcSRS: "EPSG:4326",
@@ -91,7 +93,7 @@ func TestBuildWarpArgs(t *testing.T) {
 		},
 		{
 			name: "raw options append at end",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterRawOptions("-overwrite", "-multi"),
 			},
 			srcSRS: "EPSG:4326",
@@ -105,7 +107,7 @@ func TestBuildWarpArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := newRasterConvertConfig(tc.opts)
+			cfg := newRasterConfig(tc.opts)
 			got := buildWarpArgs(cfg, tc.srcSRS, tc.dstSRS)
 			assert.Equal(t, tc.want, got)
 		})
@@ -126,25 +128,25 @@ func TestReprojectRaster_RejectsEmptySRS(t *testing.T) {
 		err := ReprojectRaster(context.Background(),
 			"/dev/null", "/tmp/out.tif", "", "EPSG:3857")
 		assert.Error(t, err)
-		assert.True(t, errors.Is(err, ErrConvertFailed))
+		assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 	})
 	t.Run("empty dstSRS", func(t *testing.T) {
 		err := ReprojectRaster(context.Background(),
 			"/dev/null", "/tmp/out.tif", "EPSG:4326", "")
 		assert.Error(t, err)
-		assert.True(t, errors.Is(err, ErrConvertFailed))
+		assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 	})
 }
 
 func TestReprojectRaster_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := ReprojectRaster(context.Background(),
-		"./testdata/__definitely_does_not_exist__.tif",
+		"../testdata/__definitely_does_not_exist__.tif",
 		"/tmp/should_not_be_created.warped.tif",
 		"EPSG:32618", "EPSG:3857")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "ReprojectRaster", gerr.Op)
 }

--- a/convert/raster_test.go
+++ b/convert/raster_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestBuildTranslateArgs(t *testing.T) {
 	cases := []struct {
 		name string
-		opts []RasterConvertOption
+		opts []RasterOption
 		want []string
 	}{
 		{
@@ -21,19 +23,19 @@ func TestBuildTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "format only",
-			opts: []RasterConvertOption{WithRasterFormat("COG")},
+			opts: []RasterOption{WithRasterFormat("COG")},
 			want: []string{"-of", "COG"},
 		},
 		{
 			name: "single creation option",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterCreationOption("COMPRESS", "DEFLATE"),
 			},
 			want: []string{"-co", "COMPRESS=DEFLATE"},
 		},
 		{
 			name: "multiple creation options preserve order",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterCreationOption("COMPRESS", "DEFLATE"),
 				WithRasterCreationOption("BLOCKSIZE", "512"),
 				WithRasterCreationOption("OVERVIEW_RESAMPLING", "NEAREST"),
@@ -46,31 +48,31 @@ func TestBuildTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "band selection emits one -b per band",
-			opts: []RasterConvertOption{WithRasterBands(1, 2, 3)},
+			opts: []RasterOption{WithRasterBands(1, 2, 3)},
 			want: []string{"-b", "1", "-b", "2", "-b", "3"},
 		},
 		{
 			name: "resampling alg",
-			opts: []RasterConvertOption{WithRasterResamplingAlg("bilinear")},
+			opts: []RasterOption{WithRasterResamplingAlg("bilinear")},
 			want: []string{"-r", "bilinear"},
 		},
 		{
 			name: "output bounds use -projwin (ulx uly lrx lry — y-flip)",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterOutputBounds(-180, -90, 180, 90),
 			},
 			want: []string{"-projwin", "-180", "90", "180", "-90"},
 		},
 		{
 			name: "target resolution",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterTargetResolution(0.0001, 0.0001),
 			},
 			want: []string{"-tr", "0.0001", "0.0001"},
 		},
 		{
 			name: "raw options append at end",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterFormat("GTiff"),
 				WithRasterRawOptions("-a_srs", "EPSG:4326"),
 			},
@@ -78,7 +80,7 @@ func TestBuildTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "ToCOG defaults expand correctly when applied",
-			opts: []RasterConvertOption{
+			opts: []RasterOption{
 				WithRasterFormat("COG"),
 				WithRasterCreationOption("COMPRESS", "DEFLATE"),
 				WithRasterCreationOption("BLOCKSIZE", "512"),
@@ -93,14 +95,14 @@ func TestBuildTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "nil options tolerated",
-			opts: []RasterConvertOption{nil, WithRasterFormat("PNG"), nil},
+			opts: []RasterOption{nil, WithRasterFormat("PNG"), nil},
 			want: []string{"-of", "PNG"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := newRasterConvertConfig(tc.opts)
+			cfg := newRasterConfig(tc.opts)
 			got := buildTranslateArgs(cfg)
 			assert.Equal(t, tc.want, got)
 		})
@@ -108,7 +110,7 @@ func TestBuildTranslateArgs(t *testing.T) {
 }
 
 func TestWithRasterLogger_NilFallsBackToDefault(t *testing.T) {
-	cfg := newRasterConvertConfig([]RasterConvertOption{WithRasterLogger(nil)})
+	cfg := newRasterConfig([]RasterOption{WithRasterLogger(nil)})
 	assert.NotNil(t, cfg.logger)
 }
 
@@ -130,13 +132,13 @@ func TestToCOG_CtxCancelledFailsFast(t *testing.T) {
 
 func TestConvertRaster_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := ConvertRaster(context.Background(),
-		"./testdata/__definitely_does_not_exist__.tif",
+		"../testdata/__definitely_does_not_exist__.tif",
 		"/tmp/should_not_be_created.cog")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed),
-		"expected ErrConvertFailed, got %v", err)
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed),
+		"expected errs.ErrConvertFailed, got %v", err)
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "ConvertRaster", gerr.Op)
 }

--- a/convert/rasterize.go
+++ b/convert/rasterize.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -7,6 +7,9 @@ import (
 	"strconv"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // RasterizeOption configures a [Rasterize] call. Construct via the
@@ -35,7 +38,7 @@ type rasterizeConfig struct {
 }
 
 func newRasterizeConfig(opts []RasterizeOption) *rasterizeConfig {
-	c := &rasterizeConfig{logger: GetLogger()}
+	c := &rasterizeConfig{logger: slogx.Default()}
 	for _, o := range opts {
 		if o != nil {
 			o(c)
@@ -45,11 +48,11 @@ func newRasterizeConfig(opts []RasterizeOption) *rasterizeConfig {
 }
 
 // WithRasterizeLogger sets the structured logger used during rasterization.
-// nil falls back to [GetLogger].
+// nil falls back to [slogx.Default].
 func WithRasterizeLogger(l *slog.Logger) RasterizeOption {
 	return func(c *rasterizeConfig) {
 		if l == nil {
-			c.logger = GetLogger()
+			c.logger = slogx.Default()
 			return
 		}
 		c.logger = l
@@ -158,7 +161,7 @@ func WithRasterizeRawOptions(args ...string) RasterizeOption {
 // units) or [WithRasterizeOutputSize] (pixel dimensions). Without
 // either, GDAL chooses an arbitrary 256x256 default.
 //
-// Errors are wrapped with [ErrConvertFailed]; recover via
+// Errors are wrapped with [errs.ErrConvertFailed]; recover via
 // [errors.As] into [*GISError]. The Op field is "Rasterize".
 //
 // Same binding gaps documented on [ConvertVector] apply: ctx is
@@ -172,13 +175,13 @@ func Rasterize(ctx context.Context, vectorSrc, rasterDst string, opts ...Rasteri
 
 	if err := validateGDALDriver(cfg.format); err != nil {
 		cfg.logger.Error("Rasterize: invalid format", "format", cfg.format, "err", err)
-		return newGISError("Rasterize", vectorSrc, ErrConvertFailed, err)
+		return errs.NewGISError("Rasterize", vectorSrc, errs.ErrConvertFailed, err)
 	}
 
 	srcDS, err := gdal.OpenEx(vectorSrc, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
 	if err != nil {
 		cfg.logger.Error("Rasterize: open source", "src", vectorSrc, "err", err)
-		return newGISError("Rasterize", vectorSrc, ErrConvertFailed, err)
+		return errs.NewGISError("Rasterize", vectorSrc, errs.ErrConvertFailed, err)
 	}
 	defer srcDS.Close()
 
@@ -188,8 +191,8 @@ func Rasterize(ctx context.Context, vectorSrc, rasterDst string, opts ...Rasteri
 
 	out, rErr := gdal.Rasterize(rasterDst, srcDS, args)
 	if rErr != nil {
-		return newGISError("Rasterize", fmt.Sprintf("%s -> %s", vectorSrc, rasterDst),
-			ErrConvertFailed, rErr)
+		return errs.NewGISError("Rasterize", fmt.Sprintf("%s -> %s", vectorSrc, rasterDst),
+			errs.ErrConvertFailed, rErr)
 	}
 	defer out.Close()
 	return nil

--- a/convert/rasterize_integration_test.go
+++ b/convert/rasterize_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestRasterize_PolygonsToGeoTIFF_Integration burns the Africa subset
@@ -20,15 +20,15 @@ func TestRasterize_PolygonsToGeoTIFF_Integration(t *testing.T) {
 	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
 	dst := filepath.Join(t.TempDir(), "africa_mask.tif")
 
-	if err := gismanager.Rasterize(context.Background(), src, dst,
-		gismanager.WithRasterizeFormat("GTiff"),
-		gismanager.WithRasterizeOutputType("Byte"),
-		gismanager.WithRasterizeBurnValues(1.0),
-		gismanager.WithRasterizeWhere("CONTINENT = 'Africa'"),
+	if err := convert.Rasterize(context.Background(), src, dst,
+		convert.WithRasterizeFormat("GTiff"),
+		convert.WithRasterizeOutputType("Byte"),
+		convert.WithRasterizeBurnValues(1.0),
+		convert.WithRasterizeWhere("CONTINENT = 'Africa'"),
 		// Africa-ish bbox in 4326.
-		gismanager.WithRasterizeOutputBounds(-25, -40, 60, 40),
-		gismanager.WithRasterizeOutputSize(256, 256),
-		gismanager.WithRasterizeCreationOption("COMPRESS", "DEFLATE"),
+		convert.WithRasterizeOutputBounds(-25, -40, 60, 40),
+		convert.WithRasterizeOutputSize(256, 256),
+		convert.WithRasterizeCreationOption("COMPRESS", "DEFLATE"),
 	); err != nil {
 		t.Fatalf("Rasterize: %v", err)
 	}
@@ -58,11 +58,11 @@ func TestRasterize_AttributeBurn_Integration(t *testing.T) {
 	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
 	dst := filepath.Join(t.TempDir(), "pop_attr.tif")
 
-	if err := gismanager.Rasterize(context.Background(), src, dst,
-		gismanager.WithRasterizeFormat("GTiff"),
-		gismanager.WithRasterizeOutputType("Float32"),
-		gismanager.WithRasterizeAttribute("POP_EST"),
-		gismanager.WithRasterizeOutputSize(360, 180),
+	if err := convert.Rasterize(context.Background(), src, dst,
+		convert.WithRasterizeFormat("GTiff"),
+		convert.WithRasterizeOutputType("Float32"),
+		convert.WithRasterizeAttribute("POP_EST"),
+		convert.WithRasterizeOutputSize(360, 180),
 	); err != nil {
 		t.Fatalf("Rasterize: %v", err)
 	}

--- a/convert/rasterize_test.go
+++ b/convert/rasterize_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestBuildRasterizeArgs(t *testing.T) {
@@ -134,12 +136,12 @@ func TestRasterize_CtxCancelledFailsFast(t *testing.T) {
 
 func TestRasterize_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := Rasterize(context.Background(),
-		"./testdata/__definitely_does_not_exist__.geojson",
+		"../testdata/__definitely_does_not_exist__.geojson",
 		"/tmp/should_not_be_created.tif")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "Rasterize", gerr.Op)
 }

--- a/convert/validate.go
+++ b/convert/validate.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"fmt"
@@ -21,9 +21,9 @@ import (
 // (cerr=0, NULL dataset) when the user hands them an unknown driver
 // name — they fail at C-level option parsing, log to stderr, and
 // return without setting cerr. Pre-validating on the Go side surfaces
-// the bad-driver case as a clean ErrConvertFailed before the C call.
+// the bad-driver case as a clean errs.ErrConvertFailed before the C call.
 //
-// Caller wraps the returned error with newGISError(...).
+// Caller wraps the returned error with errs.NewGISError(...).
 func validateGDALDriver(name string) error {
 	if name == "" {
 		return nil

--- a/convert/validate_test.go
+++ b/convert/validate_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestValidateGDALDriver(t *testing.T) {
@@ -33,17 +35,17 @@ func TestValidateGDALDriver(t *testing.T) {
 
 // TestConvertVector_PreValidatesFormat closes the v1.2 silent-failure
 // gap on the vector side: an unknown WithVectorFormat is rejected before
-// the C call, with the standard *GISError envelope.
+// the C call, with the standard *errs.GISError envelope.
 func TestConvertVector_PreValidatesFormat(t *testing.T) {
 	err := ConvertVector(context.Background(),
-		"./testdata/neighborhood_names_gis.geojson",
+		"../testdata/neighborhood_names_gis.geojson",
 		"/tmp/should_not_be_created.bogus",
 		WithVectorFormat("BOGUS_FORMAT_NEVER_EXISTS"),
 	)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "ConvertVector", gerr.Op)
 }
@@ -54,23 +56,23 @@ func TestConvertRaster_PreValidatesFormat(t *testing.T) {
 		WithRasterFormat("BOGUS_FORMAT_NEVER_EXISTS"),
 	)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "ConvertRaster", gerr.Op)
 }
 
 func TestRasterize_PreValidatesFormat(t *testing.T) {
 	err := Rasterize(context.Background(),
-		"./testdata/neighborhood_names_gis.geojson",
+		"../testdata/neighborhood_names_gis.geojson",
 		"/tmp/out.tif",
 		WithRasterizeFormat("BOGUS_FORMAT_NEVER_EXISTS"),
 	)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "Rasterize", gerr.Op)
 }
@@ -81,9 +83,9 @@ func TestDEMProcessing_PreValidatesFormat(t *testing.T) {
 		WithDEMFormat("BOGUS_FORMAT_NEVER_EXISTS"),
 	)
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed))
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed))
 
-	var gerr *GISError
+	var gerr *errs.GISError
 	assert.True(t, errors.As(err, &gerr))
 	assert.Equal(t, "DEMProcessing", gerr.Op)
 }

--- a/convert/vector.go
+++ b/convert/vector.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"context"
@@ -8,18 +8,21 @@ import (
 	"strings"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
-// VectorConvertOption configures a [ConvertVector] call. Construct via
+// VectorOption configures a [ConvertVector] call. Construct via
 // the [WithVector*] helpers below; pass any number of options in any
 // order. Each helper mutates a private config struct; nil options are
 // tolerated.
 //
 // The pattern matches v1.1's manager [Option] precedent — functional
 // options for additive growth without breaking the public surface.
-type VectorConvertOption func(*vectorConvertConfig)
+type VectorOption func(*vectorConfig)
 
-type vectorConvertConfig struct {
+type vectorConfig struct {
 	logger       *slog.Logger
 	format       string
 	sourceSRS    string
@@ -37,8 +40,8 @@ type vectorBBox struct {
 	MinX, MinY, MaxX, MaxY float64
 }
 
-func newVectorConvertConfig(opts []VectorConvertOption) *vectorConvertConfig {
-	c := &vectorConvertConfig{logger: GetLogger()}
+func newVectorConfig(opts []VectorOption) *vectorConfig {
+	c := &vectorConfig{logger: slogx.Default()}
 	for _, o := range opts {
 		if o != nil {
 			o(c)
@@ -49,11 +52,11 @@ func newVectorConvertConfig(opts []VectorConvertOption) *vectorConvertConfig {
 
 // WithVectorLogger sets the structured logger used for diagnostic output
 // during conversion. Passing nil falls back to the default logger from
-// [GetLogger]. Mirrors v1.1's [WithLogger] semantics for the manager.
-func WithVectorLogger(l *slog.Logger) VectorConvertOption {
-	return func(c *vectorConvertConfig) {
+// [slogx.Default]. Mirrors v1.1's [WithLogger] semantics for the manager.
+func WithVectorLogger(l *slog.Logger) VectorOption {
+	return func(c *vectorConfig) {
 		if l == nil {
-			c.logger = GetLogger()
+			c.logger = slogx.Default()
 			return
 		}
 		c.logger = l
@@ -64,31 +67,31 @@ func WithVectorLogger(l *slog.Logger) VectorConvertOption {
 // "GeoJSON", "FlatGeobuf", "ESRI Shapefile", "KML"). Maps to ogr2ogr's
 // `-f` flag. When empty, GDAL infers the driver from the destination
 // path's extension.
-func WithVectorFormat(driverName string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.format = driverName }
+func WithVectorFormat(driverName string) VectorOption {
+	return func(c *vectorConfig) { c.format = driverName }
 }
 
 // WithVectorSourceSRS overrides the input CRS. Accepts any GDAL
 // SetFromUserInput-friendly form ("EPSG:4326", "+proj=longlat ...",
 // well-known WKT). Use only when the source has a missing or wrong CRS.
 // Maps to ogr2ogr's `-s_srs`.
-func WithVectorSourceSRS(srs string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.sourceSRS = srs }
+func WithVectorSourceSRS(srs string) VectorOption {
+	return func(c *vectorConfig) { c.sourceSRS = srs }
 }
 
 // WithVectorTargetSRS reprojects features to the given CRS during the
 // conversion. The most common use is `WithVectorTargetSRS("EPSG:3857")`
 // for web tile pipelines. Maps to ogr2ogr's `-t_srs`.
-func WithVectorTargetSRS(srs string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.targetSRS = srs }
+func WithVectorTargetSRS(srs string) VectorOption {
+	return func(c *vectorConfig) { c.targetSRS = srs }
 }
 
 // WithVectorBoundingBox restricts output to features intersecting the
 // given bounding box. Coordinates are in the *source* CRS unless
 // [WithVectorSourceSRS] also reinterprets them. Maps to ogr2ogr's
 // `-spat`.
-func WithVectorBoundingBox(minX, minY, maxX, maxY float64) VectorConvertOption {
-	return func(c *vectorConvertConfig) {
+func WithVectorBoundingBox(minX, minY, maxX, maxY float64) VectorOption {
+	return func(c *vectorConfig) {
 		c.bbox = &vectorBBox{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
 	}
 }
@@ -96,44 +99,44 @@ func WithVectorBoundingBox(minX, minY, maxX, maxY float64) VectorConvertOption {
 // WithVectorWhere restricts output to features matching the given OGR
 // SQL WHERE expression (without the `WHERE` keyword), e.g.
 // `"CONTINENT = 'Africa'"`. Maps to ogr2ogr's `-where`.
-func WithVectorWhere(sql string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.where = sql }
+func WithVectorWhere(sql string) VectorOption {
+	return func(c *vectorConfig) { c.where = sql }
 }
 
 // WithVectorSimplify applies Douglas-Peucker simplification with the
 // given tolerance (in target-CRS units). Useful for thinning vector
 // data before web delivery. Maps to ogr2ogr's `-simplify`.
-func WithVectorSimplify(tolerance float64) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.simplifyTol = tolerance }
+func WithVectorSimplify(tolerance float64) VectorOption {
+	return func(c *vectorConfig) { c.simplifyTol = tolerance }
 }
 
 // WithVectorSelectFields restricts the output to the named attribute
 // fields. The geometry column is always preserved. Maps to ogr2ogr's
 // `-select`.
-func WithVectorSelectFields(fields ...string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.selectFields = append([]string(nil), fields...) }
+func WithVectorSelectFields(fields ...string) VectorOption {
+	return func(c *vectorConfig) { c.selectFields = append([]string(nil), fields...) }
 }
 
 // WithVectorLayerName renames the destination layer (e.g. forces a
 // different table name when copying to PostGIS or a different layer
 // name in GPKG). Maps to ogr2ogr's `-nln`.
-func WithVectorLayerName(name string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.layerName = name }
+func WithVectorLayerName(name string) VectorOption {
+	return func(c *vectorConfig) { c.layerName = name }
 }
 
 // WithVectorOverwrite replaces an existing destination layer instead of
 // failing with a "layer already exists" error. Maps to ogr2ogr's
 // `-overwrite`.
-func WithVectorOverwrite() VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.overwrite = true }
+func WithVectorOverwrite() VectorOption {
+	return func(c *vectorConfig) { c.overwrite = true }
 }
 
 // WithVectorRawOptions appends raw `ogr2ogr`-style flags to the
 // generated argument list, after every other option. Use this to reach
 // flags the typed helpers do not yet expose (e.g. `-lco`, `-skipfailures`,
 // `-nlt`). Each entry is one CLI token.
-func WithVectorRawOptions(args ...string) VectorConvertOption {
-	return func(c *vectorConvertConfig) { c.rawOptions = append(c.rawOptions, args...) }
+func WithVectorRawOptions(args ...string) VectorOption {
+	return func(c *vectorConfig) { c.rawOptions = append(c.rawOptions, args...) }
 }
 
 // ConvertVector converts the vector source at src into dst, applying any
@@ -156,28 +159,28 @@ func WithVectorRawOptions(args ...string) VectorConvertOption {
 //     the source); the underlying CGo call is synchronous and
 //     uninterruptible — long conversions cannot be cancelled mid-way.
 //
-// Errors are wrapped with [ErrConvertFailed]; recover the underlying
+// Errors are wrapped with [errs.ErrConvertFailed]; recover the underlying
 // GDAL error via [errors.As] into [*GISError].
 //
 // Driver names supplied via [WithVectorFormat] are validated against
 // the running GDAL build before the C call, so an unknown driver
-// surfaces as a clean ErrConvertFailed rather than the upstream
+// surfaces as a clean errs.ErrConvertFailed rather than the upstream
 // silent-fail-with-stderr-warning behavior.
-func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOption) error {
+func ConvertVector(ctx context.Context, src, dst string, opts ...VectorOption) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	cfg := newVectorConvertConfig(opts)
+	cfg := newVectorConfig(opts)
 
 	if err := validateGDALDriver(cfg.format); err != nil {
 		cfg.logger.Error("ConvertVector: invalid format", "format", cfg.format, "err", err)
-		return newGISError("ConvertVector", src, ErrConvertFailed, err)
+		return errs.NewGISError("ConvertVector", src, errs.ErrConvertFailed, err)
 	}
 
 	srcDS, err := gdal.OpenEx(src, gdal.OFVector|gdal.OFReadOnly, nil, nil, nil)
 	if err != nil {
 		cfg.logger.Error("ConvertVector: open source", "src", src, "err", err)
-		return newGISError("ConvertVector", src, ErrConvertFailed, err)
+		return errs.NewGISError("ConvertVector", src, errs.ErrConvertFailed, err)
 	}
 	defer srcDS.Close()
 
@@ -187,8 +190,8 @@ func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOp
 
 	out, vErr := gdal.VectorTranslate(dst, []gdal.Dataset{srcDS}, args)
 	if vErr != nil {
-		return newGISError("ConvertVector", fmt.Sprintf("%s -> %s", src, dst),
-			ErrConvertFailed, vErr)
+		return errs.NewGISError("ConvertVector", fmt.Sprintf("%s -> %s", src, dst),
+			errs.ErrConvertFailed, vErr)
 	}
 	defer out.Close()
 	return nil
@@ -197,7 +200,7 @@ func ConvertVector(ctx context.Context, src, dst string, opts ...VectorConvertOp
 // buildVectorTranslateArgs renders cfg into the []string ogr2ogr-style
 // arg list GDALVectorTranslate expects. Unit-tested separately so the
 // option->arg mapping is locked in without needing CGo.
-func buildVectorTranslateArgs(cfg *vectorConvertConfig) []string {
+func buildVectorTranslateArgs(cfg *vectorConfig) []string {
 	var args []string
 	if cfg.format != "" {
 		args = append(args, "-f", cfg.format)

--- a/convert/vector_geoparquet_integration_test.go
+++ b/convert/vector_geoparquet_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 // Integration test for the v1.4 GeoParquet support. Exercises the
 // full read/write contract: writes a GeoParquet from the tracked
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestConvertVector_GeoParquetRoundTrip_Integration round-trips a
@@ -27,7 +28,7 @@ import (
 // "Parquet" format, and (c) OpenSource dispatches the .parquet
 // extension to the right driver.
 func TestConvertVector_GeoParquetRoundTrip_Integration(t *testing.T) {
-	src := "./testdata/neighborhood_names_gis.geojson"
+	src := "../testdata/neighborhood_names_gis.geojson"
 	parquetPath := "/vsimem/test_geoparquet_roundtrip.parquet"
 
 	// 1. Source-side baseline: count features in the GeoJSON.
@@ -50,9 +51,9 @@ func TestConvertVector_GeoParquetRoundTrip_Integration(t *testing.T) {
 	}
 
 	// 2. Convert GeoJSON -> GeoParquet via the new format support.
-	if err := gismanager.ConvertVector(context.Background(), src, parquetPath,
-		gismanager.WithVectorFormat(parquetDriverName),
-		gismanager.WithVectorOverwrite(),
+	if err := convert.ConvertVector(context.Background(), src, parquetPath,
+		convert.WithVectorFormat(parquetDriverName),
+		convert.WithVectorOverwrite(),
 	); err != nil {
 		t.Fatalf("ConvertVector to GeoParquet: %v", err)
 	}
@@ -80,9 +81,9 @@ func TestConvertVector_GeoParquetRoundTrip_Integration(t *testing.T) {
 	t.Logf("GeoParquet round-trip ok: %d features", dstCount)
 }
 
-// parquetDriverName mirrors the unexported [parquetDriver] constant
-// without exposing it. We can't reach the unexported name from this
-// `gismanager_test` package, so we duplicate the string here. If a
-// future PR exports the driver-name constants (a v2 change), this
-// duplication goes away.
+// parquetDriverName mirrors the unexported [gismanager.parquetDriver]
+// constant without exposing it. We can't reach the unexported name from
+// this external `convert_test` package, so we duplicate the string
+// here. If a future PR exports the driver-name constants (a v2 change),
+// this duplication goes away.
 const parquetDriverName = "Parquet"

--- a/convert/vector_integration_test.go
+++ b/convert/vector_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package convert_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestConvertVector_ShapefileToGeoPackage_Integration exercises the most
@@ -25,9 +25,9 @@ func TestConvertVector_ShapefileToGeoPackage_Integration(t *testing.T) {
 	src := "/vsizip/" + mustFetched(t, "ne_110m_admin_0_countries.zip")
 	dst := filepath.Join(t.TempDir(), "countries.gpkg")
 
-	if err := gismanager.ConvertVector(context.Background(), src, dst,
-		gismanager.WithVectorFormat("GPKG"),
-		gismanager.WithVectorOverwrite(),
+	if err := convert.ConvertVector(context.Background(), src, dst,
+		convert.WithVectorFormat("GPKG"),
+		convert.WithVectorOverwrite(),
 	); err != nil {
 		t.Fatalf("ConvertVector: %v", err)
 	}
@@ -73,14 +73,14 @@ func TestConvertVector_GeoJSONReprojectAndFilter_Integration(t *testing.T) {
 	src := mustFetched(t, "ne_110m_admin_0_countries.geojson")
 	dst := filepath.Join(t.TempDir(), "africa_3857.gpkg")
 
-	if err := gismanager.ConvertVector(context.Background(), src, dst,
-		gismanager.WithVectorFormat("GPKG"),
-		gismanager.WithVectorOverwrite(),
-		gismanager.WithVectorTargetSRS("EPSG:3857"),
+	if err := convert.ConvertVector(context.Background(), src, dst,
+		convert.WithVectorFormat("GPKG"),
+		convert.WithVectorOverwrite(),
+		convert.WithVectorTargetSRS("EPSG:3857"),
 		// Africa-ish bbox in 4326 (-spat applies to source CRS by default).
-		gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
-		gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
-		gismanager.WithVectorLayerName("africa_3857"),
+		convert.WithVectorBoundingBox(-25, -40, 60, 40),
+		convert.WithVectorWhere("CONTINENT = 'Africa'"),
+		convert.WithVectorLayerName("africa_3857"),
 	); err != nil {
 		t.Fatalf("ConvertVector: %v", err)
 	}
@@ -119,9 +119,9 @@ func TestConvertVector_Idempotent_Integration(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "countries.gpkg")
 
 	for i := 0; i < 2; i++ {
-		if err := gismanager.ConvertVector(context.Background(), src, dst,
-			gismanager.WithVectorFormat("GPKG"),
-			gismanager.WithVectorOverwrite(),
+		if err := convert.ConvertVector(context.Background(), src, dst,
+			convert.WithVectorFormat("GPKG"),
+			convert.WithVectorOverwrite(),
 		); err != nil {
 			t.Fatalf("iteration %d: %v", i+1, err)
 		}
@@ -139,9 +139,13 @@ func TestConvertVector_Idempotent_Integration(t *testing.T) {
 // mustFetched returns the absolute path to a fixture inside
 // `testdata-fetched/`. It t.Skips the test if the fixture is missing
 // (the user forgot to run `make fetch-testdata`); CI always pre-fetches.
+//
+// The fetched fixtures live at the module root; tests in this convert/
+// subpackage are one level down so the relative join is
+// "../testdata-fetched". Same fixture set as the v1.x layout.
 func mustFetched(t *testing.T, name string) string {
 	t.Helper()
-	abs, err := filepath.Abs(filepath.Join("testdata-fetched", name))
+	abs, err := filepath.Abs(filepath.Join("..", "testdata-fetched", name))
 	if err != nil {
 		t.Fatalf("filepath.Abs: %v", err)
 	}

--- a/convert/vector_test.go
+++ b/convert/vector_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package convert
 
 import (
 	"bytes"
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 // TestBuildVectorTranslateArgs is a table-driven unit test that locks in
@@ -18,7 +20,7 @@ import (
 func TestBuildVectorTranslateArgs(t *testing.T) {
 	cases := []struct {
 		name string
-		opts []VectorConvertOption
+		opts []VectorOption
 		want []string
 	}{
 		{
@@ -28,17 +30,17 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "format only",
-			opts: []VectorConvertOption{WithVectorFormat("GPKG")},
+			opts: []VectorOption{WithVectorFormat("GPKG")},
 			want: []string{"-f", "GPKG"},
 		},
 		{
 			name: "overwrite",
-			opts: []VectorConvertOption{WithVectorOverwrite()},
+			opts: []VectorOption{WithVectorOverwrite()},
 			want: []string{"-overwrite"},
 		},
 		{
 			name: "source + target SRS",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorSourceSRS("EPSG:4326"),
 				WithVectorTargetSRS("EPSG:3857"),
 			},
@@ -46,43 +48,43 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "bbox emits four float args after -spat",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorBoundingBox(-10.5, -20, 30.25, 45.75),
 			},
 			want: []string{"-spat", "-10.5", "-20", "30.25", "45.75"},
 		},
 		{
 			name: "where clause",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorWhere("CONTINENT = 'Africa'"),
 			},
 			want: []string{"-where", "CONTINENT = 'Africa'"},
 		},
 		{
 			name: "simplify with non-zero tolerance",
-			opts: []VectorConvertOption{WithVectorSimplify(0.001)},
+			opts: []VectorOption{WithVectorSimplify(0.001)},
 			want: []string{"-simplify", "0.001"},
 		},
 		{
 			name: "simplify with zero tolerance is dropped",
-			opts: []VectorConvertOption{WithVectorSimplify(0)},
+			opts: []VectorOption{WithVectorSimplify(0)},
 			want: nil,
 		},
 		{
 			name: "select fields",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorSelectFields("NAME", "POP_EST", "CONTINENT"),
 			},
 			want: []string{"-select", "NAME,POP_EST,CONTINENT"},
 		},
 		{
 			name: "layer name",
-			opts: []VectorConvertOption{WithVectorLayerName("countries_3857")},
+			opts: []VectorOption{WithVectorLayerName("countries_3857")},
 			want: []string{"-nln", "countries_3857"},
 		},
 		{
 			name: "raw options append at end",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorFormat("GPKG"),
 				WithVectorRawOptions("-lco", "FID=fid", "-skipfailures"),
 			},
@@ -90,7 +92,7 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "full pipeline: reproject + bbox + where + simplify + select + rename",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				WithVectorFormat("GPKG"),
 				WithVectorOverwrite(),
 				WithVectorTargetSRS("EPSG:3857"),
@@ -113,7 +115,7 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 		},
 		{
 			name: "nil options are tolerated",
-			opts: []VectorConvertOption{
+			opts: []VectorOption{
 				nil,
 				WithVectorFormat("GPKG"),
 				nil,
@@ -124,7 +126,7 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := newVectorConvertConfig(tc.opts)
+			cfg := newVectorConfig(tc.opts)
 			got := buildVectorTranslateArgs(cfg)
 			assert.Equal(t, tc.want, got)
 		})
@@ -133,9 +135,9 @@ func TestBuildVectorTranslateArgs(t *testing.T) {
 
 // TestWithVectorLogger_NilFallsBackToDefault confirms passing nil through
 // WithVectorLogger doesn't leave cfg.logger nil — the helper falls back
-// to GetLogger() so downstream callers can always emit structured logs.
+// to slogx.Default() so downstream callers can always emit structured logs.
 func TestWithVectorLogger_NilFallsBackToDefault(t *testing.T) {
-	cfg := newVectorConvertConfig([]VectorConvertOption{WithVectorLogger(nil)})
+	cfg := newVectorConfig([]VectorOption{WithVectorLogger(nil)})
 	assert.NotNil(t, cfg.logger, "logger must never be nil after option apply")
 }
 
@@ -145,7 +147,7 @@ func TestWithVectorLogger_NilFallsBackToDefault(t *testing.T) {
 func TestWithVectorLogger_CustomHandlerCaptured(t *testing.T) {
 	var buf bytes.Buffer
 	custom := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	cfg := newVectorConvertConfig([]VectorConvertOption{WithVectorLogger(custom)})
+	cfg := newVectorConfig([]VectorOption{WithVectorLogger(custom)})
 	cfg.logger.Debug("test", "key", "value")
 	assert.Contains(t, buf.String(), `"key":"value"`)
 }
@@ -164,18 +166,18 @@ func TestConvertVector_CtxCancelledFailsFast(t *testing.T) {
 }
 
 // TestConvertVector_OpenError_WrapsErrConvertFailed locks in the error
-// envelope: a missing source surfaces as *GISError wrapping
-// ErrConvertFailed, so callers can branch on the sentinel without
+// envelope: a missing source surfaces as *errs.GISError wrapping
+// errs.ErrConvertFailed, so callers can branch on the sentinel without
 // scraping strings.
 func TestConvertVector_OpenError_WrapsErrConvertFailed(t *testing.T) {
 	err := ConvertVector(context.Background(),
-		"./testdata/__definitely_does_not_exist__.geojson",
+		"../testdata/__definitely_does_not_exist__.geojson",
 		"/tmp/gismanager_should_not_be_created.gpkg")
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrConvertFailed),
-		"expected ErrConvertFailed, got %v", err)
+	assert.True(t, errors.Is(err, errs.ErrConvertFailed),
+		"expected errs.ErrConvertFailed, got %v", err)
 
-	var gerr *GISError
-	assert.True(t, errors.As(err, &gerr), "expected *GISError envelope")
+	var gerr *errs.GISError
+	assert.True(t, errors.As(err, &gerr), "expected *errs.GISError envelope")
 	assert.Equal(t, "ConvertVector", gerr.Op)
 }

--- a/convert/vector_vsimem_test.go
+++ b/convert/vector_vsimem_test.go
@@ -1,4 +1,4 @@
-package gismanager_test
+package convert_test
 
 // Note: this file lives under the _test.go non-integration build tag so it
 // runs in the unit suite. It exercises GDAL's /vsimem/ in-process VFS
@@ -12,7 +12,7 @@ import (
 
 	"github.com/lukeroth/gdal"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 // TestConvertVector_VsiMemDestination_Unit confirms ConvertVector accepts
@@ -20,16 +20,16 @@ import (
 // readable. The source is the tracked legacy fixture so this test stays
 // in the unit suite (no `make fetch-testdata` prerequisite).
 func TestConvertVector_VsiMemDestination_Unit(t *testing.T) {
-	src := "./testdata/neighborhood_names_gis.geojson"
+	src := "../testdata/neighborhood_names_gis.geojson"
 	dst := "/vsimem/test_convert_vector.gpkg"
 	// /vsimem/ entries are freed when the test process exits; the
 	// lukeroth/gdal binding doesn't wrap VSIUnlink so we let GC + EOL
 	// cleanup handle it. WithVectorOverwrite() above makes the test
 	// re-runnable in -count=N mode.
 
-	if err := gismanager.ConvertVector(context.Background(), src, dst,
-		gismanager.WithVectorFormat("GPKG"),
-		gismanager.WithVectorOverwrite(),
+	if err := convert.ConvertVector(context.Background(), src, dst,
+		convert.WithVectorFormat("GPKG"),
+		convert.WithVectorOverwrite(),
 	); err != nil {
 		t.Fatalf("ConvertVector to /vsimem/: %v", err)
 	}

--- a/examples/convert_pipeline/main.go
+++ b/examples/convert_pipeline/main.go
@@ -17,7 +17,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/convert"
 )
 
 func main() {
@@ -29,14 +29,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := gismanager.ConvertVector(context.Background(), *in, *out,
-		gismanager.WithVectorFormat("GPKG"),
-		gismanager.WithVectorOverwrite(),
-		gismanager.WithVectorTargetSRS("EPSG:3857"),
-		gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
-		gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
-		gismanager.WithVectorLayerName("africa"),
-		gismanager.WithVectorSimplify(100),
+	if err := convert.ConvertVector(context.Background(), *in, *out,
+		convert.WithVectorFormat("GPKG"),
+		convert.WithVectorOverwrite(),
+		convert.WithVectorTargetSRS("EPSG:3857"),
+		convert.WithVectorBoundingBox(-25, -40, 60, 40),
+		convert.WithVectorWhere("CONTINENT = 'Africa'"),
+		convert.WithVectorLayerName("africa"),
+		convert.WithVectorSimplify(100),
 	); err != nil {
 		slog.Error("convert", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

**Phase 2** of the v2 restructure plan. The conversion subsystem (\`ConvertVector\` / \`ConvertRaster\` / \`ToCOG\` / \`ReprojectRaster\` / \`Rasterize\` / \`BuildVRT\` / \`DEMProcessing\` / \`ToPMTiles\` + ~60 \`With*\` helpers) splits cleanly into \`github.com/hishamkaram/gismanager/convert\`. Public v1.x API preserved via type aliases + function wrappers in \`compat_convert.go\`; new code should import the convert subpackage directly.

## What moved

25 files via \`git mv\` (history preserved):
- \`convert_*.go\` (8 source files) → \`convert/<basename>.go\`
- \`convert_*_test.go\` (16 test files) → \`convert/<basename>_test.go\`
- \`example_convert_test.go\` → \`convert/example_test.go\`

## Inside the convert package

- \`package gismanager\` → \`package convert\`
- Internal symbol references rewritten: \`newGISError\` → \`errs.NewGISError\`, \`GetLogger\` → \`slogx.Default\`, \`ErrConvertFailed\` → \`errs.ErrConvertFailed\`
- Type renames (drop redundant \`Convert\` prefix in subpackage scope):
  - \`VectorConvertOption\` → \`VectorOption\`
  - \`RasterConvertOption\` → \`RasterOption\`
  - Internal: \`vectorConvertConfig\` → \`vectorConfig\`, etc.
- Relative testdata paths updated: \`./testdata/\` → \`../testdata/\`, \`./testdata-fetched/\` → \`../testdata-fetched/\`, plus the \`mustFetched()\` helper rebased on \`filepath.Join("..", ...)\`
- New \`convert/doc.go\`

## Compat layer (root)

\`compat_convert.go\` (~370 lines) re-exports all **73 public symbols** from \`convert/\` at the v1.x import path:
- 6 type aliases (\`type X = convert.Y\`) — preserve full identity for \`errors.As\` / \`errors.Is\` / slice element types
- 8 entry-point function wrappers
- 59 \`With*\` helper wrappers

All declarations marked \`Deprecated:\`. v2 module bump (Phase 4) drops this file entirely.

## Internal callers updated

- \`cmd/gisconvert/gisconvert.go\` now imports \`gismanager/convert\` and calls \`convert.ConvertVector\` / \`convert.WithVectorFormat\` / etc. No deprecated-wrapper usage inside the project.
- \`examples/convert_pipeline/main.go\` — same migration.

## Test plan

- [x] \`make lint\` — 0 issues (after adding godocs to all 73 wrappers and a \`convert/doc.go\` package comment)
- [x] \`make test-unit\` — green; \`convert/\` package has full coverage from the moved tests
- [x] \`make test-integration\` against GeoServer 2.28.0 — green (3.3s convert + 7s gismanager). Two relative-path bugs caught + fixed during the run: \`./testdata/\` → \`../testdata/\` (fixture sub-trees) and the \`mustFetched()\` helper rebased to \`../testdata-fetched/\`.
- [ ] CI: full matrix runs on push

After this lands, the master branch is poised for Phase 3 (publish-pipeline split). v1.5.0 cuts the soft-launch with deprecation notices for external users; v2.0.0 (after Phases 4-8) drops the wrappers.