### PR TITLE
refactor(publish): move publish-pipeline files to publish/ subpackage with v1.x compat wrappers

### DIFF
--- a/cmd/gismanager/gismanager.go
+++ b/cmd/gismanager/gismanager.go
@@ -11,8 +11,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/hishamkaram/gismanager"
 	"github.com/hishamkaram/gismanager/cmd/internal/cli"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
 func main() { os.Exit(realMain()) }
@@ -52,7 +52,7 @@ func run(ctx context.Context, args []string) error {
 	if _, err := os.Stat(*configFile); os.IsNotExist(err) {
 		return errors.New("config: file does not exist")
 	}
-	manager, err := gismanager.FromConfig(*configFile)
+	manager, err := publish.FromConfig(*configFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/layerSchema/layerSchema.go
+++ b/cmd/layerSchema/layerSchema.go
@@ -19,23 +19,23 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/hishamkaram/gismanager"
 	"github.com/hishamkaram/gismanager/cmd/internal/cli"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
 // layerEntry is the JSON shape for one yielded layer when -json is set.
 // Field tags are explicit so the JSON keys stay stable even if the
 // underlying struct fields are renamed in a future refactor.
 type layerEntry struct {
-	Path   string                   `json:"path"`
-	Name   string                   `json:"name"`
-	Fields []*gismanager.LayerField `json:"fields"`
+	Path   string                `json:"path"`
+	Name   string                `json:"name"`
+	Fields []*publish.LayerField `json:"fields"`
 }
 
 func main() { os.Exit(realMain()) }
 
 // realMain is the testable entry point; see the matching helper in
-// cmd/gismanager/gismanager.go for rationale.
+// cmd/gismanager/publish.go for rationale.
 func realMain() int {
 	ctx, cancel := cli.SignalContext(context.Background())
 	defer cancel()
@@ -67,7 +67,7 @@ func run(ctx context.Context, args []string) error {
 	if _, err := os.Stat(*configFile); os.IsNotExist(err) {
 		return errors.New("config: file does not exist")
 	}
-	manager, err := gismanager.FromConfig(*configFile)
+	manager, err := publish.FromConfig(*configFile)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func run(ctx context.Context, args []string) error {
 // runText emits the human-readable per-layer block format. Walk errors
 // are logged to stderr via slog (the configured logger) but don't abort
 // the loop — same behavior as pre-1.4.
-func runText(ctx context.Context, manager *gismanager.ManagerConfig, out *os.File) error {
+func runText(ctx context.Context, manager *publish.Manager, out *os.File) error {
 	for item, walkErr := range manager.Walk(ctx) {
 		if walkErr != nil {
 			slog.Error("walk", "err", walkErr)
@@ -109,7 +109,7 @@ func runText(ctx context.Context, manager *gismanager.ManagerConfig, out *os.Fil
 // `python -m json.tool` if a human is reading it. Compact output is
 // the right shell-pipeline default: smaller, faster to parse, and a
 // drop-in for tooling that reads stdout.
-func runJSON(ctx context.Context, manager *gismanager.ManagerConfig, out *os.File) error {
+func runJSON(ctx context.Context, manager *publish.Manager, out *os.File) error {
 	entries := []layerEntry{}
 	for item, walkErr := range manager.Walk(ctx) {
 		if walkErr != nil {

--- a/cmd/layerSchema/main_test.go
+++ b/cmd/layerSchema/main_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
 // TestLayerEntryJSON_Shape locks in the on-the-wire shape of the
@@ -16,7 +16,7 @@ func TestLayerEntryJSON_Shape(t *testing.T) {
 	entry := layerEntry{
 		Path: "./testdata/sample.gpkg",
 		Name: "neighborhoods",
-		Fields: []*gismanager.LayerField{
+		Fields: []*publish.LayerField{
 			{Name: "geom", Type: "POLYGON"},
 			{Name: "id", Type: "Integer"},
 			{Name: "name", Type: "String"},

--- a/compat_publish.go
+++ b/compat_publish.go
@@ -1,0 +1,146 @@
+package gismanager
+
+// Compatibility shim for the v1.x publish-pipeline API.
+//
+// The publish pipeline (Manager constructor, Walk + PublishAll
+// orchestration, GdalLayer wrapper, the connection helpers, the
+// configuration types) moved to the [publish] subpackage as part of
+// the v2 restructure groundwork (see Phase 3 in
+// ~/.claude/plans/how-can-we-improve-steady-emerson.md).
+//
+// This file re-exports every public symbol from the publish subpackage
+// at its v1.x import path. Type aliases preserve full identity —
+// errors.As, errors.Is, method sets, slice element types all
+// interoperate transparently across the boundary. Function wrappers
+// are pure pass-throughs with no behavior change.
+//
+// Notable v1 → v2 type renames preserved here as aliases:
+//
+//   - gismanager.ManagerConfig → publish.Manager
+//   - gismanager.GdalLayer → publish.Layer
+//
+// The "Config" suffix on Manager was a misnomer — the type IS the
+// manager, not its config. Same for the redundant "Gdal" prefix on
+// Layer (it's clear from package context). v2 (Phase 4) drops this
+// file entirely; new code should import the publish subpackage
+// directly.
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/hishamkaram/gismanager/publish"
+)
+
+// =============================================================================
+// Type aliases
+// =============================================================================
+
+// ManagerConfig is preserved as a v1.x alias of [publish.Manager].
+//
+// Deprecated: use [publish.Manager] directly via
+// `import "github.com/hishamkaram/gismanager/publish"`.
+type ManagerConfig = publish.Manager
+
+// GdalLayer is preserved as a v1.x alias of [publish.Layer].
+//
+// Deprecated: use [publish.Layer] directly.
+type GdalLayer = publish.Layer
+
+// GeoserverConfig is preserved as a v1.x alias of [publish.GeoserverConfig].
+//
+// Deprecated: use [publish.GeoserverConfig] directly.
+type GeoserverConfig = publish.GeoserverConfig
+
+// SourceConfig is preserved as a v1.x alias of [publish.SourceConfig].
+//
+// Deprecated: use [publish.SourceConfig] directly.
+type SourceConfig = publish.SourceConfig
+
+// DatastoreConfig is preserved as a v1.x alias of [publish.DatastoreConfig].
+//
+// Deprecated: use [publish.DatastoreConfig] directly.
+type DatastoreConfig = publish.DatastoreConfig
+
+// Option is preserved as a v1.x alias of [publish.Option].
+//
+// Deprecated: use [publish.Option] directly.
+type Option = publish.Option
+
+// WalkItem is preserved as a v1.x alias of [publish.WalkItem].
+//
+// Deprecated: use [publish.WalkItem] directly.
+type WalkItem = publish.WalkItem
+
+// LayerField is preserved as a v1.x alias of [publish.LayerField].
+//
+// Deprecated: use [publish.LayerField] directly.
+type LayerField = publish.LayerField
+
+// =============================================================================
+// Top-level function wrappers — all forward to the publish subpackage.
+// All Deprecated.
+// =============================================================================
+
+// New forwards to [publish.New].
+//
+// Deprecated: use [publish.New] directly.
+func New(opts ...Option) (*ManagerConfig, error) {
+	return publish.New(opts...)
+}
+
+// FromConfig forwards to [publish.FromConfig].
+//
+// Deprecated: use [publish.FromConfig] directly.
+func FromConfig(configFile string) (*ManagerConfig, error) {
+	return publish.FromConfig(configFile)
+}
+
+// WithLogger forwards to [publish.WithLogger].
+//
+// Deprecated: use [publish.WithLogger] directly.
+func WithLogger(l *slog.Logger) Option {
+	return publish.WithLogger(l)
+}
+
+// WithGeoserver forwards to [publish.WithGeoserver].
+//
+// Deprecated: use [publish.WithGeoserver] directly.
+func WithGeoserver(cfg GeoserverConfig) Option {
+	return publish.WithGeoserver(cfg)
+}
+
+// WithDatastore forwards to [publish.WithDatastore].
+//
+// Deprecated: use [publish.WithDatastore] directly.
+func WithDatastore(cfg DatastoreConfig) Option {
+	return publish.WithDatastore(cfg)
+}
+
+// WithSource forwards to [publish.WithSource].
+//
+// Deprecated: use [publish.WithSource] directly.
+func WithSource(cfg SourceConfig) Option {
+	return publish.WithSource(cfg)
+}
+
+// GetGISFiles forwards to [publish.GetGISFiles].
+//
+// Deprecated: use [publish.GetGISFiles] directly.
+func GetGISFiles(root string) ([]string, error) {
+	return publish.GetGISFiles(root)
+}
+
+// DBIsAlive forwards to [publish.DBIsAlive].
+//
+// Deprecated: use [publish.DBIsAlive] directly.
+func DBIsAlive(dbType, connectionStr string) error {
+	return publish.DBIsAlive(dbType, connectionStr)
+}
+
+// DBIsAliveContext forwards to [publish.DBIsAliveContext].
+//
+// Deprecated: use [publish.DBIsAliveContext] directly.
+func DBIsAliveContext(ctx context.Context, dbType, connectionStr string) error {
+	return publish.DBIsAliveContext(ctx, dbType, connectionStr)
+}

--- a/convert/vector_geoparquet_integration_test.go
+++ b/convert/vector_geoparquet_integration_test.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hishamkaram/gismanager"
 	"github.com/hishamkaram/gismanager/convert"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
 // TestConvertVector_GeoParquetRoundTrip_Integration round-trips a
@@ -32,7 +32,7 @@ func TestConvertVector_GeoParquetRoundTrip_Integration(t *testing.T) {
 	parquetPath := "/vsimem/test_geoparquet_roundtrip.parquet"
 
 	// 1. Source-side baseline: count features in the GeoJSON.
-	mgr, err := gismanager.New()
+	mgr, err := publish.New()
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestConvertVector_GeoParquetRoundTrip_Integration(t *testing.T) {
 	t.Logf("GeoParquet round-trip ok: %d features", dstCount)
 }
 
-// parquetDriverName mirrors the unexported [gismanager.parquetDriver]
+// parquetDriverName mirrors the unexported [publish.parquetDriver]
 // constant without exposing it. We can't reach the unexported name from
 // this external `convert_test` package, so we duplicate the string
 // here. If a future PR exports the driver-name constants (a v2 change),

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,24 @@
+// Package gismanager is a v1.x compatibility shim above the v2-style
+// subpackage layout. Public symbols are re-exported as type aliases
+// and function wrappers from the [convert] (conversion subsystem)
+// and [publish] (publish pipeline) subpackages.
+//
+// Type aliases preserve full identity — errors.As, errors.Is, method
+// sets, slice element types all interoperate transparently across the
+// boundary. Function wrappers are pure pass-throughs with no behavior
+// change.
+//
+// All re-exported declarations are marked Deprecated; new code should
+// import the relevant subpackage directly:
+//
+//	import "github.com/hishamkaram/gismanager/convert"
+//	import "github.com/hishamkaram/gismanager/publish"
+//
+// v2 (the next major release) drops this root-level compatibility
+// shim. The v2 module path is github.com/hishamkaram/gismanager/v2;
+// v1.x users staying on the v1 line track the release/v1.x branch.
+//
+// See ~/.claude/plans/how-can-we-improve-steady-emerson.md for the
+// restructure plan and CHANGELOG.md for the per-release migration
+// notes.
+package gismanager

--- a/publish/datastore.go
+++ b/publish/datastore.go
@@ -1,7 +1,4 @@
-// Package gismanager publishes GIS data files (shapefile, GeoJSON,
-// GeoPackage, KML) to PostGIS, then exposes the resulting tables as
-// GeoServer feature types via the geoserver/v2 REST client.
-package gismanager
+package publish
 
 import "fmt"
 

--- a/publish/datastore_test.go
+++ b/publish/datastore_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"testing"

--- a/publish/doc.go
+++ b/publish/doc.go
@@ -1,0 +1,38 @@
+// Package publish is gismanager's publish-pipeline subpackage —
+// directory walk, OGR-based PostGIS load, and GeoServer feature-type
+// registration via the [hishamkaram/geoserver/v2] REST client.
+//
+// Entry points:
+//
+//   - [New] / [FromConfig] construct a *Manager.
+//   - [(*Manager).Walk] yields layers from the configured source.
+//   - [(*Manager).PublishAll] runs the full pipeline (walk → load →
+//     publish) with bounded GeoServer-publish concurrency.
+//   - [(*Manager).OpenSource] / [(*Manager).GetDriver] are read-only
+//     inspection helpers for use in CLIs / scripts.
+//   - [(*Manager).Validate] checks required fields against the
+//     publish-pipeline contract (ErrConfigInvalid envelope).
+//
+// Configuration:
+//
+//   - [Manager] holds the merged configuration; constructed once via
+//     [New] (functional options) or [FromConfig] (YAML, with ${VAR}
+//     env-var interpolation).
+//   - [GeoserverConfig], [DatastoreConfig], [SourceConfig] are the
+//     three sub-config struct types YAML decodes into.
+//
+// Errors wrap the sentinels in [github.com/hishamkaram/gismanager/internal/errs]:
+// ErrConfigInvalid (Validate failures), ErrUnsupportedFormat (GetDriver),
+// ErrInvalidLayer / ErrInvalidDatasource (LayerToPostgis), ErrPostGISConnect
+// (DBIsAlive), ErrGeoServerPublish (the publish flow). Recover the
+// underlying *geoserver.APIError or *pq.Error via [errors.As] into
+// [*errs.GISError].
+//
+// History: this package split out of the root gismanager package as
+// part of the v2 restructure (Phase 3). v1.x callers can continue to
+// use the v1 names (gismanager.ManagerConfig → publish.Manager,
+// gismanager.GdalLayer → publish.Layer, gismanager.New / FromConfig
+// / WithLogger / etc.) — those are now thin Deprecated wrappers in
+// the root package that delegate here. v2 (Phase 4) drops the
+// wrappers; v2 callers import this package directly.
+package publish

--- a/publish/driver_table_test.go
+++ b/publish/driver_table_test.go
@@ -1,10 +1,12 @@
-package gismanager
+package publish
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 // TestGetDriver_Table is the table-driven canonical test for the
@@ -21,7 +23,7 @@ func TestGetDriver_Table(t *testing.T) {
 	cases := []struct {
 		name       string
 		path       string
-		wantDriver string // empty → expect ErrUnsupportedFormat
+		wantDriver string // empty → expect errs.ErrUnsupportedFormat
 	}{
 		// --- supported extensions, lowercase ---
 		{name: "geopackage", path: "data/sample.gpkg", wantDriver: geopackageDriver},
@@ -66,8 +68,8 @@ func TestGetDriver_Table(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			drv, err := mgr.GetDriver(tc.path)
 			if tc.wantDriver == "" {
-				if !errors.Is(err, ErrUnsupportedFormat) {
-					t.Fatalf("expected ErrUnsupportedFormat, got %v", err)
+				if !errors.Is(err, errs.ErrUnsupportedFormat) {
+					t.Fatalf("expected errs.ErrUnsupportedFormat, got %v", err)
 				}
 				if drv != (gdal.OGRDriver{}) {
 					t.Errorf("expected zero-value OGRDriver on error, got %#v", drv)

--- a/publish/example_manager_test.go
+++ b/publish/example_manager_test.go
@@ -1,4 +1,4 @@
-package gismanager_test
+package publish_test
 
 // Runnable godoc examples for the publish-pipeline surface. The
 // PublishAll example demonstrates wiring without making real network
@@ -11,10 +11,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
-// ExampleManagerConfig_PublishAll demonstrates the high-level publish
+// ExampleManager_PublishAll demonstrates the high-level publish
 // flow: walk a source directory, load every supported GIS file into
 // the configured PostGIS datastore, then publish each as a GeoServer
 // feature type.
@@ -30,15 +30,15 @@ import (
 // — godoc tests would otherwise try to make a real GeoServer / PostGIS
 // connection. The integration suite (//go:build integration) covers
 // the runtime contract end-to-end.
-func ExampleManagerConfig_PublishAll() {
-	mgr, err := gismanager.New(
-		gismanager.WithGeoserver(gismanager.GeoserverConfig{
+func ExampleManager_PublishAll() {
+	mgr, err := publish.New(
+		publish.WithGeoserver(publish.GeoserverConfig{
 			ServerURL:     "http://localhost:8080/geoserver",
 			Username:      "admin",
 			Password:      "geoserver",
 			WorkspaceName: "demo",
 		}),
-		gismanager.WithDatastore(gismanager.DatastoreConfig{
+		publish.WithDatastore(publish.DatastoreConfig{
 			Host:   "localhost",
 			Port:   5432,
 			DBName: "gis",
@@ -46,7 +46,7 @@ func ExampleManagerConfig_PublishAll() {
 			DBPass: "postgres",
 			Name:   "gismanager_demo",
 		}),
-		gismanager.WithSource(gismanager.SourceConfig{Path: "./gis-data"}),
+		publish.WithSource(publish.SourceConfig{Path: "./gis-data"}),
 	)
 	if err != nil {
 		fmt.Println("construct manager:", err)
@@ -60,12 +60,12 @@ func ExampleManagerConfig_PublishAll() {
 	fmt.Println("published")
 }
 
-// ExampleManagerConfig_OpenSource shows the read-only inspection
+// ExampleManager_OpenSource shows the read-only inspection
 // surface: open a GIS file via the configured GDAL OGR driver and
 // list layer count. No PostGIS or GeoServer is touched.
-func ExampleManagerConfig_OpenSource() {
-	mgr, err := gismanager.New(
-		gismanager.WithSource(gismanager.SourceConfig{Path: "./testdata"}),
+func ExampleManager_OpenSource() {
+	mgr, err := publish.New(
+		publish.WithSource(publish.SourceConfig{Path: "../testdata"}),
 	)
 	if err != nil {
 		fmt.Println("construct manager:", err)
@@ -73,7 +73,7 @@ func ExampleManagerConfig_OpenSource() {
 	}
 
 	ds, err := mgr.OpenSource(context.Background(),
-		"./testdata/sample.gpkg", 0)
+		"../testdata/sample.gpkg", 0)
 	if err != nil {
 		fmt.Println("open:", err)
 		return

--- a/publish/layer.go
+++ b/publish/layer.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -12,17 +12,20 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
-// GdalLayer wraps a *gdal.Layer with the helper methods gismanager uses
+// Layer wraps a *gdal.Layer with the helper methods gismanager uses
 // (publish, copy-to-PostGIS, schema introspection).
 //
 // The logger field is intentionally lowercase: callers should construct
-// GdalLayers via [(*ManagerConfig).NewLayer] so the manager's configured
+// GdalLayers via [(*Manager).NewLayer] so the manager's configured
 // logger is stamped on automatically. The zero-value form
-// (`GdalLayer{Layer: l}`) is still supported for back-compat — methods
-// that need a logger fall back to [GetLogger] when the field is nil.
-type GdalLayer struct {
+// (`Layer{Layer: l}`) is still supported for back-compat — methods
+// that need a logger fall back to [slogx.Default] when the field is nil.
+type Layer struct {
 	*gdal.Layer
 	logger *slog.Logger
 }
@@ -32,17 +35,17 @@ type GdalLayer struct {
 // over the zero-value form so per-manager logger configuration
 // (custom handler, attached attrs, etc.) reaches the layer's helper
 // methods.
-func (manager *ManagerConfig) NewLayer(l *gdal.Layer) *GdalLayer {
-	return &GdalLayer{Layer: l, logger: manager.logger}
+func (manager *Manager) NewLayer(l *gdal.Layer) *Layer {
+	return &Layer{Layer: l, logger: manager.logger}
 }
 
 // loggerOrDefault returns the layer's stamped logger or, if nil, the
 // project default. Used by methods that emit structured logs but
 // must keep working on zero-value GdalLayers from pre-NewLayer
 // callers.
-func (layer *GdalLayer) loggerOrDefault() *slog.Logger {
+func (layer *Layer) loggerOrDefault() *slog.Logger {
 	if layer == nil || layer.logger == nil {
-		return GetLogger()
+		return slogx.Default()
 	}
 	return layer.logger
 }
@@ -63,26 +66,26 @@ type LayerField struct {
 // feature type, ensuring the configured workspace and PostGIS datastore
 // exist first.
 //
-// Errors are wrapped with [ErrGeoServerPublish]; the underlying
+// Errors are wrapped with [errs.ErrGeoServerPublish]; the underlying
 // *geoserver.APIError is recoverable via [errors.As] for fields and
 // [errors.Is] against the v2 sentinels (e.g. ErrConflict, ErrServerError).
-func (manager *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *GdalLayer) error {
+func (manager *Manager) PublishGeoserverLayer(ctx context.Context, layer *Layer) error {
 	catalog, err := manager.GetGeoserverCatalog()
 	if err != nil {
 		manager.logger.Error("build geoserver client", "err", err)
-		return newGISError("PublishGeoserverLayer", "", ErrGeoServerPublish, err)
+		return errs.NewGISError("PublishGeoserverLayer", "", errs.ErrGeoServerPublish, err)
 	}
 
 	ws := manager.Geoserver.WorkspaceName
 	if err := ensureWorkspace(ctx, catalog, ws); err != nil {
 		manager.logger.Error("ensure workspace", "workspace", ws, "err", err)
-		return newGISError("PublishGeoserverLayer", ws, ErrGeoServerPublish, err)
+		return errs.NewGISError("PublishGeoserverLayer", ws, errs.ErrGeoServerPublish, err)
 	}
 
 	dsName := manager.Datastore.Name
 	if err := ensureDatastore(ctx, catalog, ws, manager.Datastore); err != nil {
 		manager.logger.Error("ensure datastore", "workspace", ws, "datastore", dsName, "err", err)
-		return newGISError("PublishGeoserverLayer", ws+"/"+dsName, ErrGeoServerPublish, err)
+		return errs.NewGISError("PublishGeoserverLayer", ws+"/"+dsName, errs.ErrGeoServerPublish, err)
 	}
 
 	layerName := layer.Name()
@@ -94,7 +97,7 @@ func (manager *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *
 		return nil
 	} else if !errors.Is(err, geoserver.ErrNotFound) {
 		manager.logger.Error("get feature type", "workspace", ws, "datastore", dsName, "layer", layerName, "err", err)
-		return newGISError("PublishGeoserverLayer", ws+"/"+dsName+"/"+layerName, ErrGeoServerPublish, err)
+		return errs.NewGISError("PublishGeoserverLayer", ws+"/"+dsName+"/"+layerName, errs.ErrGeoServerPublish, err)
 	}
 	ft := &featuretypes.FeatureType{
 		Name:       layerName,
@@ -103,19 +106,19 @@ func (manager *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *
 	}
 	if err := scoped.Create(ctx, ft); err != nil {
 		manager.logger.Error("publish feature type", "workspace", ws, "datastore", dsName, "layer", layerName, "err", err)
-		return newGISError("PublishGeoserverLayer", ws+"/"+dsName+"/"+layerName, ErrGeoServerPublish, err)
+		return errs.NewGISError("PublishGeoserverLayer", ws+"/"+dsName+"/"+layerName, errs.ErrGeoServerPublish, err)
 	}
 	return nil
 }
 
 // ensureWorkspace looks up the GeoServer workspace by name and creates it
-// if missing. Errors are wrapped as *GISError with Op="ensureWorkspace"
-// and Sentinel=ErrGeoServerPublish so that errors.Is(...,
-// ErrGeoServerPublish) succeeds at every layer of the chain and the
+// if missing. Errors are wrapped as *errs.GISError with Op="ensureWorkspace"
+// and Sentinel=errs.ErrGeoServerPublish so that errors.Is(...,
+// errs.ErrGeoServerPublish) succeeds at every layer of the chain and the
 // underlying *geoserver.APIError remains recoverable via errors.As.
 // Callers (notably PublishGeoserverLayer) typically re-wrap the returned
-// *GISError with their own Op for the public-facing error envelope; the
-// inner GISError remains reachable via Unwrap for finer-grained triage.
+// *errs.GISError with their own Op for the public-facing error envelope; the
+// inner errs.GISError remains reachable via Unwrap for finer-grained triage.
 //
 // Concurrent-call safety: when N goroutines all hit the Get-not-found
 // branch simultaneously, only the first Create wins; the rest receive
@@ -128,13 +131,13 @@ func ensureWorkspace(ctx context.Context, c *geoserver.Client, name string) erro
 	if _, err := c.Workspaces.Get(ctx, name); err == nil {
 		return nil
 	} else if !errors.Is(err, geoserver.ErrNotFound) {
-		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
+		return errs.NewGISError("ensureWorkspace", name, errs.ErrGeoServerPublish, err)
 	}
 	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: name}); err != nil {
 		if errors.Is(err, geoserver.ErrConflict) {
 			return nil
 		}
-		return newGISError("ensureWorkspace", name, ErrGeoServerPublish, err)
+		return errs.NewGISError("ensureWorkspace", name, errs.ErrGeoServerPublish, err)
 	}
 	return nil
 }
@@ -142,14 +145,14 @@ func ensureWorkspace(ctx context.Context, c *geoserver.Client, name string) erro
 // ensureDatastore looks up the PostGIS-backed datastore in the given
 // workspace and creates it if missing. Same error-wrapping contract and
 // same concurrent-create idempotency (ErrConflict treated as success)
-// as [ensureWorkspace] — errors are *GISError with Op="ensureDatastore"
-// and Sentinel=ErrGeoServerPublish.
+// as [ensureWorkspace] — errors are *errs.GISError with Op="ensureDatastore"
+// and Sentinel=errs.ErrGeoServerPublish.
 func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds DatastoreConfig) error {
 	scoped := c.Datastores.InWorkspace(ws)
 	if _, err := scoped.Get(ctx, ds.Name); err == nil {
 		return nil
 	} else if !errors.Is(err, geoserver.ErrNotFound) {
-		return newGISError("ensureDatastore", ds.Name, ErrGeoServerPublish, err)
+		return errs.NewGISError("ensureDatastore", ds.Name, errs.ErrGeoServerPublish, err)
 	}
 	conn := datastores.PostGIS{
 		Name:     ds.Name,
@@ -163,7 +166,7 @@ func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds Dat
 		if errors.Is(err, geoserver.ErrConflict) {
 			return nil
 		}
-		return newGISError("ensureDatastore", ds.Name, ErrGeoServerPublish, err)
+		return errs.NewGISError("ensureDatastore", ds.Name, errs.ErrGeoServerPublish, err)
 	}
 	return nil
 }
@@ -173,21 +176,21 @@ func ensureDatastore(ctx context.Context, c *geoserver.Client, ws string, ds Dat
 // preserving the geometry column name and optionally overwriting an existing
 // table of the same name.
 //
-// Returns errors wrapping [ErrPostGISConnect] (PostGIS unreachable),
-// [ErrInvalidDatasource] (nil targetSource), or [ErrInvalidLayer] (nil
+// Returns errors wrapping [errs.ErrPostGISConnect] (PostGIS unreachable),
+// [errs.ErrInvalidDatasource] (nil targetSource), or [errs.ErrInvalidLayer] (nil
 // embedded *gdal.Layer). Match via [errors.Is].
-func (layer *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, manager *ManagerConfig, overwrite bool) (newLayer *GdalLayer, err error) {
+func (layer *Layer) LayerToPostgis(targetSource *gdal.DataSource, manager *Manager, overwrite bool) (newLayer *Layer, err error) {
 	connStr := manager.Datastore.PostgresConnectionString()
 	if dbErr := DBIsAlive("postgres", connStr); dbErr != nil {
-		err = newGISError("LayerToPostgis", manager.Datastore.Name, ErrPostGISConnect, dbErr)
+		err = errs.NewGISError("LayerToPostgis", manager.Datastore.Name, errs.ErrPostGISConnect, dbErr)
 		return
 	}
 	if targetSource == nil {
-		err = newGISError("LayerToPostgis", "", ErrInvalidDatasource, nil)
+		err = errs.NewGISError("LayerToPostgis", "", errs.ErrInvalidDatasource, nil)
 		return
 	}
 	if layer.Layer == nil {
-		err = newGISError("LayerToPostgis", "", ErrInvalidLayer, nil)
+		err = errs.NewGISError("LayerToPostgis", "", errs.ErrInvalidLayer, nil)
 		return
 	}
 	datasource := *targetSource
@@ -200,7 +203,7 @@ func (layer *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, manager *M
 		options = append(options, "OVERWRITE=YES")
 	}
 	innerLayer := datasource.CopyLayer(*layer.Layer, layer.Name(), options)
-	newLayer = &GdalLayer{
+	newLayer = &Layer{
 		Layer: &innerLayer,
 	}
 	return
@@ -209,7 +212,7 @@ func (layer *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, manager *M
 // GeometryName returns the OGR geometry-type name for this layer
 // ("POINT", "LINESTRING", etc.), defaulting to "geom" if the layer has
 // no geometry column.
-func (layer *GdalLayer) GeometryName() string {
+func (layer *Layer) GeometryName() string {
 	geom := gdal.Create(layer.Type())
 	name := geom.Name()
 	if name == "" {
@@ -223,11 +226,11 @@ func (layer *GdalLayer) GeometryName() string {
 // Deprecated: typo (missing 'e' in "Geometry"). Use [GeometryName],
 // which is byte-for-byte identical in behaviour. The typo'd form is
 // kept for v1.x back-compat and will be removed at v2.
-func (layer *GdalLayer) GetGeomtryName() string { return layer.GeometryName() }
+func (layer *Layer) GetGeomtryName() string { return layer.GeometryName() }
 
 // GetLayerSchema returns the layer's geometry column followed by every
 // attribute field, each as a LayerField with name + OGR type.
-func (layer *GdalLayer) GetLayerSchema() (fields []*LayerField) {
+func (layer *Layer) GetLayerSchema() (fields []*LayerField) {
 	if layer.Layer != nil {
 		layerDef := layer.Definition()
 		geomName := layer.GeometryColumn()
@@ -254,9 +257,9 @@ func (layer *GdalLayer) GetLayerSchema() (fields []*LayerField) {
 //
 // Deprecated: leaks gdal.Feature handles — each feature in the returned
 // slice owns a C-level handle that must be released via [gdal.Feature.Destroy],
-// which the slice form makes easy to forget. Use [(*GdalLayer).Features]
+// which the slice form makes easy to forget. Use [(*Layer).Features]
 // which destroys each feature as iteration advances and on early break.
-func (layer *GdalLayer) GetFeatures() (features []*gdal.Feature) {
+func (layer *Layer) GetFeatures() (features []*gdal.Feature) {
 	logger := layer.loggerOrDefault()
 	if layer.Layer != nil {
 		count, ok := layer.FeatureCount(true)
@@ -286,7 +289,7 @@ func (layer *GdalLayer) GetFeatures() (features []*gdal.Feature) {
 // Returns an empty iteration if the embedded *gdal.Layer is nil or
 // FeatureCount fails (the manager's logger gets an Error record in the
 // FeatureCount-failure case).
-func (layer *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature] {
+func (layer *Layer) Features(ctx context.Context) iter.Seq[gdal.Feature] {
 	logger := layer.loggerOrDefault()
 	return func(yield func(gdal.Feature) bool) {
 		if layer == nil || layer.Layer == nil {

--- a/publish/layer_logger_test.go
+++ b/publish/layer_logger_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"bytes"
@@ -10,7 +10,7 @@ import (
 )
 
 // TestNewLayer_StampsManagerLogger verifies that NewLayer attaches the
-// manager's logger to the returned GdalLayer so per-manager logger
+// manager's logger to the returned Layer so per-manager logger
 // configuration (custom handler, default attrs) reaches helper methods
 // without callers having to plumb a logger themselves.
 func TestNewLayer_StampsManagerLogger(t *testing.T) {
@@ -26,11 +26,11 @@ func TestNewLayer_StampsManagerLogger(t *testing.T) {
 }
 
 // TestGdalLayer_loggerOrDefault_FallsBackWhenNil locks in the back-compat
-// path: zero-value GdalLayer{Layer: ...} (used by both CLIs pre-Walk)
-// keeps working because loggerOrDefault returns GetLogger() when the
+// path: zero-value Layer{Layer: ...} (used by both CLIs pre-Walk)
+// keeps working because loggerOrDefault returns slogx.Default() when the
 // stamped field is nil.
 func TestGdalLayer_loggerOrDefault_FallsBackWhenNil(t *testing.T) {
-	zeroValue := &GdalLayer{}
+	zeroValue := &Layer{}
 	got := zeroValue.loggerOrDefault()
 	assert.NotNil(t, got, "fallback must return a non-nil logger")
 }
@@ -40,7 +40,7 @@ func TestGdalLayer_loggerOrDefault_FallsBackWhenNil(t *testing.T) {
 func TestGdalLayer_loggerOrDefault_UsesStamped(t *testing.T) {
 	var buf bytes.Buffer
 	custom := slog.New(slog.NewJSONHandler(&buf, nil))
-	stamped := &GdalLayer{logger: custom}
+	stamped := &Layer{logger: custom}
 
 	got := stamped.loggerOrDefault()
 	assert.Same(t, custom, got)
@@ -57,7 +57,7 @@ func TestGdalLayer_loggerOrDefault_UsesStamped(t *testing.T) {
 // without passing a logger; per-manager loggers are an internal-only
 // addition wired through getGISFiles.
 func TestGetGISFiles_StillUsesDefaultLogger(t *testing.T) {
-	files, err := GetGISFiles("./testdata")
+	files, err := GetGISFiles("../testdata")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, files, "testdata must contain some GIS files")
 }
@@ -70,7 +70,7 @@ func TestGetGISFiles_ManagerLoggerWired(t *testing.T) {
 	var buf bytes.Buffer
 	custom := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	files, err := getGISFiles("./testdata/faults.zip", custom)
+	files, err := getGISFiles("../testdata/faults.zip", custom)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, files)
 
@@ -82,7 +82,7 @@ func TestGetGISFiles_ManagerLoggerWired(t *testing.T) {
 		t.Skip("preprocessFile did not emit at default level — handler config may filter Debug; the wiring is exercised regardless")
 	}
 	// Either Debug or any level — what matters is *some* record landed
-	// in our buffer rather than the default GetLogger().
+	// in our buffer rather than the default slogx.Default().
 	assert.True(t, strings.Contains(out, "preprocess") ||
 		strings.Contains(out, "temp"),
 		"expected preprocess-related record in buffer; got %q", out)

--- a/publish/layer_test.go
+++ b/publish/layer_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -8,11 +8,11 @@ import (
 )
 
 func TestGetFeatures(t *testing.T) {
-	manager, _ := FromConfig("./testdata/test_config.yml")
+	manager, _ := FromConfig("../testdata/test_config.yml")
 	files, _ := GetGISFiles(manager.Source.Path)
 	source, _ := manager.OpenSource(context.Background(), files[0], 1)
 	layer := source.LayerByIndex(0)
-	gLayer := GdalLayer{
+	gLayer := Layer{
 		Layer: &layer,
 	}
 	count, _ := layer.FeatureCount(true)
@@ -22,11 +22,11 @@ func TestGetFeatures(t *testing.T) {
 }
 
 func TestGetLayerSchema(t *testing.T) {
-	manager, _ := FromConfig("./testdata/test_config.yml")
+	manager, _ := FromConfig("../testdata/test_config.yml")
 	files, _ := GetGISFiles(manager.Source.Path)
 	source, _ := manager.OpenSource(context.Background(), files[0], 1)
 	layer := source.LayerByIndex(0)
-	gLayer := GdalLayer{
+	gLayer := Layer{
 		Layer: &layer,
 	}
 	fields := gLayer.GetLayerSchema()

--- a/publish/lifecycle_test.go
+++ b/publish/lifecycle_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -10,15 +10,15 @@ import (
 )
 
 // TestFeatures_NilLayer_YieldsNothing locks in the zero-value safety:
-// iterating Features on a GdalLayer whose embedded *gdal.Layer is nil
+// iterating Features on a Layer whose embedded *gdal.Layer is nil
 // must produce zero items and not panic.
 func TestFeatures_NilLayer_YieldsNothing(t *testing.T) {
-	zero := &GdalLayer{}
+	zero := &Layer{}
 	count := 0
 	for range zero.Features(context.Background()) {
 		count++
 	}
-	assert.Equal(t, 0, count, "Features on nil-Layer GdalLayer must yield zero items")
+	assert.Equal(t, 0, count, "Features on nil-Layer Layer must yield zero items")
 }
 
 // TestFeatures_HonorsCanceledContext locks in cancellation: a ctx that
@@ -27,7 +27,7 @@ func TestFeatures_NilLayer_YieldsNothing(t *testing.T) {
 func TestFeatures_HonorsCanceledContext(t *testing.T) {
 	// Use a real layer fixture from testdata — Features needs a non-nil
 	// *gdal.Layer to reach the ctx.Err() check inside the loop.
-	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	mgr, err := New(WithSource(SourceConfig{Path: "../testdata"}))
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/publish/manager.go
+++ b/publish/manager.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -10,6 +10,8 @@ import (
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 // GeoserverConfig holds the GeoServer endpoint and credentials. WorkspaceName
@@ -28,18 +30,18 @@ type SourceConfig struct {
 	Path string `yaml:"path"`
 }
 
-// ManagerConfig is the top-level configuration loaded from YAML.
-type ManagerConfig struct {
+// Manager is the top-level configuration loaded from YAML.
+type Manager struct {
 	Geoserver GeoserverConfig `yaml:"geoserver"`
 	Datastore DatastoreConfig `yaml:"datastore"`
 	Source    SourceConfig    `yaml:"source"`
 	logger    *slog.Logger
 }
 
-// Validate checks that every required field on a ManagerConfig is set
+// Validate checks that every required field on a Manager is set
 // to a non-zero value and reports the missing fields in a single error.
-// The error wraps [ErrConfigInvalid]; recover the field list via
-// [errors.As] into [*GISError] and inspect Cause.Error().
+// The error wraps [errs.ErrConfigInvalid]; recover the field list via
+// [errors.As] into [*errs.GISError] and inspect Cause.Error().
 //
 // Validate covers the publish-pipeline contract — every field needed
 // for the walk → PostGIS-load → GeoServer-publish flow. Programmatic
@@ -48,7 +50,7 @@ type ManagerConfig struct {
 // [FromConfig] calls it automatically, since YAML callers signal
 // "I intend a full publish setup" by writing the YAML in the first
 // place.
-func (c *ManagerConfig) Validate() error {
+func (c *Manager) Validate() error {
 	var problems []string
 	if c.Geoserver.ServerURL == "" {
 		problems = append(problems, "geoserver.url is required")
@@ -84,7 +86,7 @@ func (c *ManagerConfig) Validate() error {
 		problems = append(problems, "source.path is required")
 	}
 	if len(problems) > 0 {
-		return newGISError("Validate", "", ErrConfigInvalid,
+		return errs.NewGISError("Validate", "", errs.ErrConfigInvalid,
 			errors.New(strings.Join(problems, "; ")))
 	}
 	return nil
@@ -107,7 +109,7 @@ func (c *ManagerConfig) Validate() error {
 // Datastore.Port (uint) is not expanded — port numbers should come from
 // config, not env vars; if a user truly needs a parameterized port they
 // should set it via the [WithDatastore] option in code.
-func (c *ManagerConfig) expandEnv() {
+func (c *Manager) expandEnv() {
 	c.Geoserver.ServerURL = os.ExpandEnv(c.Geoserver.ServerURL)
 	c.Geoserver.WorkspaceName = os.ExpandEnv(c.Geoserver.WorkspaceName)
 	c.Geoserver.Username = os.ExpandEnv(c.Geoserver.Username)
@@ -124,7 +126,7 @@ func (c *ManagerConfig) expandEnv() {
 // manager's GeoServer endpoint. Each call constructs a fresh client; the
 // underlying HTTP transport is the stdlib default. Returns an error if the
 // server URL is malformed.
-func (manager *ManagerConfig) GetGeoserverCatalog() (*geoserver.Client, error) {
+func (manager *Manager) GetGeoserverCatalog() (*geoserver.Client, error) {
 	return geoserver.New(
 		manager.Geoserver.ServerURL,
 		geoserver.WithBasicAuth(manager.Geoserver.Username, manager.Geoserver.Password),
@@ -137,10 +139,10 @@ func (manager *ManagerConfig) GetGeoserverCatalog() (*geoserver.Client, error) {
 // callers should still pass a real context so a downstream-aware version
 // is a non-breaking swap.
 //
-// Errors wrap [ErrUnsupportedFormat] (driver lookup failed) or
-// [ErrInvalidDatasource] (driver matched but Open returned !ok). Match via
-// [errors.Is]; recover details via [errors.As] into *GISError.
-func (manager *ManagerConfig) OpenSource(_ context.Context, path string, access int) (*gdal.DataSource, error) {
+// Errors wrap [errs.ErrUnsupportedFormat] (driver lookup failed) or
+// [errs.ErrInvalidDatasource] (driver matched but Open returned !ok). Match via
+// [errors.Is]; recover details via [errors.As] into *errs.GISError.
+func (manager *Manager) OpenSource(_ context.Context, path string, access int) (*gdal.DataSource, error) {
 	driver, err := manager.GetDriver(path)
 	if err != nil {
 		// GetDriver already logged + wrapped; just return.
@@ -149,7 +151,7 @@ func (manager *ManagerConfig) OpenSource(_ context.Context, path string, access 
 	targetSource, ok := driver.Open(path, access)
 	if !ok {
 		manager.logger.Error("open source", "path", path, "access", access)
-		return nil, newGISError("OpenSource", path, ErrInvalidDatasource, nil)
+		return nil, errs.NewGISError("OpenSource", path, errs.ErrInvalidDatasource, nil)
 	}
 	return &targetSource, nil
 }
@@ -159,8 +161,8 @@ func (manager *ManagerConfig) OpenSource(_ context.Context, path string, access 
 // the PostgreSQL driver; everything else dispatches on file extension.
 //
 // On unsupported extensions, returns an error wrapping
-// [ErrUnsupportedFormat] (match via [errors.Is]).
-func (manager *ManagerConfig) GetDriver(path string) (driver gdal.OGRDriver, err error) {
+// [errs.ErrUnsupportedFormat] (match via [errors.Is]).
+func (manager *Manager) GetDriver(path string) (driver gdal.OGRDriver, err error) {
 	if pgRegex.MatchString(path) {
 		driver = gdal.OGRDriverByName(postgreSQLDriver)
 	} else {
@@ -176,7 +178,7 @@ func (manager *ManagerConfig) GetDriver(path string) (driver gdal.OGRDriver, err
 		case ".parquet":
 			driver = gdal.OGRDriverByName(parquetDriver)
 		default:
-			err = newGISError("GetDriver", path, ErrUnsupportedFormat, nil)
+			err = errs.NewGISError("GetDriver", path, errs.ErrUnsupportedFormat, nil)
 			manager.logger.Error("get driver", "path", path, "err", err)
 		}
 	}

--- a/publish/manager_test.go
+++ b/publish/manager_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -7,62 +7,64 @@ import (
 
 	"github.com/lukeroth/gdal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
 func TestFromConfig(t *testing.T) {
-	manager, confErr := FromConfig("./testdata/test_config.yml")
+	manager, confErr := FromConfig("../testdata/test_config.yml")
 	assert.Nil(t, confErr)
 	assert.NotNil(t, manager)
-	expected := ManagerConfig{
+	expected := Manager{
 		Geoserver: GeoserverConfig{WorkspaceName: "golang", Username: "admin", Password: "geoserver", ServerURL: "http://localhost:8080/geoserver"},
 		Datastore: DatastoreConfig{Host: "localhost", Port: 5432, DBName: "gis", DBUser: "golang", DBPass: "golang", Name: "gismanager_data"},
-		Source:    SourceConfig{Path: "./testdata"},
+		Source:    SourceConfig{Path: "../testdata"},
 		logger:    manager.logger,
 	}
 	assert.Equal(t, expected.Geoserver, manager.Geoserver)
 	assert.Equal(t, expected.Source, manager.Source)
 	assert.Equal(t, expected.logger, manager.logger)
-	nilManager, nilConfErr := FromConfig("./testdata/test_configs.yml")
+	nilManager, nilConfErr := FromConfig("../testdata/test_configs.yml")
 	assert.NotNil(t, nilConfErr)
 	assert.Nil(t, nilManager)
-	errManager, errConfErr := FromConfig("./testdata/test_config_err.yml")
+	errManager, errConfErr := FromConfig("../testdata/test_config_err.yml")
 	assert.NotNil(t, errConfErr)
 	assert.Nil(t, errManager)
 }
 func TestOpenSource(t *testing.T) {
-	manager, _ := FromConfig("./testdata/test_config.yml")
+	manager, _ := FromConfig("../testdata/test_config.yml")
 	ctx := context.Background()
 
-	datasource, err := manager.OpenSource(ctx, "./testdata/sample.gpkg", 0)
+	datasource, err := manager.OpenSource(ctx, "../testdata/sample.gpkg", 0)
 	assert.Nil(t, err)
 	assert.NotNil(t, datasource)
 
-	nilDatasource, formatErr := manager.OpenSource(ctx, "./testdata/sample_dummy.xml", 0)
+	nilDatasource, formatErr := manager.OpenSource(ctx, "../testdata/sample_dummy.xml", 0)
 	assert.Nil(t, nilDatasource)
-	assert.True(t, errors.Is(formatErr, ErrUnsupportedFormat),
-		"expected ErrUnsupportedFormat, got %v", formatErr)
+	assert.True(t, errors.Is(formatErr, errs.ErrUnsupportedFormat),
+		"expected errs.ErrUnsupportedFormat, got %v", formatErr)
 }
 func TestGetGeoserverCatalog(t *testing.T) {
-	manager, _ := FromConfig("./testdata/test_config.yml")
+	manager, _ := FromConfig("../testdata/test_config.yml")
 	catalog, err := manager.GetGeoserverCatalog()
 	assert.Nil(t, err)
 	assert.NotNil(t, catalog)
 }
 func TestGetDriver(t *testing.T) {
-	manager, _ := FromConfig("./testdata/test_config.yml")
-	gpkgDriver, gpkgErr := manager.GetDriver("./testdata/sample.gpkg")
+	manager, _ := FromConfig("../testdata/test_config.yml")
+	gpkgDriver, gpkgErr := manager.GetDriver("../testdata/sample.gpkg")
 	assert.Nil(t, gpkgErr)
 	assert.NotNil(t, gpkgDriver)
 	assert.Equal(t, gdal.OGRDriverByName(geopackageDriver), gpkgDriver)
-	jsonDriver, jsonErr := manager.GetDriver("./testdata/neighborhood_names_gis.geojson")
+	jsonDriver, jsonErr := manager.GetDriver("../testdata/neighborhood_names_gis.geojson")
 	assert.Nil(t, jsonErr)
 	assert.NotNil(t, jsonDriver)
 	assert.Equal(t, gdal.OGRDriverByName(geoJSONDriver), jsonDriver)
-	zipDriver, zipErr := manager.GetDriver("./testdata/shapeFile.zip")
+	zipDriver, zipErr := manager.GetDriver("../testdata/shapeFile.zip")
 	assert.Nil(t, zipErr)
 	assert.NotNil(t, zipDriver)
 	assert.Equal(t, gdal.OGRDriverByName(shapeFileDriver), zipDriver)
-	KMLDriver, KMLErr := manager.GetDriver("./testdata/layer.kml")
+	KMLDriver, KMLErr := manager.GetDriver("../testdata/layer.kml")
 	assert.Nil(t, KMLErr)
 	assert.NotNil(t, KMLDriver)
 	assert.Equal(t, gdal.OGRDriverByName(kmlDriver), KMLDriver)
@@ -70,7 +72,7 @@ func TestGetDriver(t *testing.T) {
 	assert.Nil(t, pgErr)
 	assert.NotNil(t, pgDriver)
 	assert.Equal(t, gdal.OGRDriverByName(postgreSQLDriver), pgDriver)
-	tiffDriver, tiffErr := manager.GetDriver("./testdata/layer.tiff")
+	tiffDriver, tiffErr := manager.GetDriver("../testdata/layer.tiff")
 	assert.NotNil(t, tiffErr)
 	assert.Equal(t, gdal.OGRDriver{}, tiffDriver)
 

--- a/publish/options.go
+++ b/publish/options.go
@@ -1,8 +1,12 @@
-package gismanager
+package publish
 
-import "log/slog"
+import (
+	"log/slog"
 
-// Option configures a [ManagerConfig] at construction time. Pass options to
+	"github.com/hishamkaram/gismanager/internal/slogx"
+)
+
+// Option configures a [Manager] at construction time. Pass options to
 // [New] in any order.
 //
 // Each option is a small function that mutates the partially-constructed
@@ -11,15 +15,15 @@ import "log/slog"
 // surface small while leaving room for additive growth — new
 // configuration knobs can ship as new With* helpers without breaking
 // existing callers.
-type Option func(*ManagerConfig)
+type Option func(*Manager)
 
 // WithLogger sets the structured logger the manager and its sub-operations
 // use for diagnostic output. Passing nil falls back to the default logger
-// returned by [GetLogger] so callers can opt into the default explicitly.
+// returned by [slogx.Default] so callers can opt into the default explicitly.
 func WithLogger(l *slog.Logger) Option {
-	return func(m *ManagerConfig) {
+	return func(m *Manager) {
 		if l == nil {
-			m.logger = GetLogger()
+			m.logger = slogx.Default()
 			return
 		}
 		m.logger = l
@@ -29,32 +33,32 @@ func WithLogger(l *slog.Logger) Option {
 // WithGeoserver sets the GeoServer endpoint, credentials, and workspace
 // name the manager publishes feature types into.
 func WithGeoserver(cfg GeoserverConfig) Option {
-	return func(m *ManagerConfig) { m.Geoserver = cfg }
+	return func(m *Manager) { m.Geoserver = cfg }
 }
 
 // WithDatastore sets the PostGIS connection parameters and GeoServer
 // datastore name the manager loads layers into.
 func WithDatastore(cfg DatastoreConfig) Option {
-	return func(m *ManagerConfig) { m.Datastore = cfg }
+	return func(m *Manager) { m.Datastore = cfg }
 }
 
 // WithSource sets the source-directory configuration the manager scans for
 // supported GIS files.
 func WithSource(cfg SourceConfig) Option {
-	return func(m *ManagerConfig) { m.Source = cfg }
+	return func(m *Manager) { m.Source = cfg }
 }
 
-// New constructs a [ManagerConfig] from the given options. With no options,
+// New constructs a [Manager] from the given options. With no options,
 // the returned manager has zero-value GeoServer / Datastore / Source
-// configs and the default logger from [GetLogger]. The error return is
+// configs and the default logger from [slogx.Default]. The error return is
 // reserved — today [New] always returns nil — so future validation
 // (e.g. checking required fields) is a non-breaking addition.
 //
 // Programmatic callers should prefer [New] over [FromConfig]; YAML-driven
 // callers can still use [FromConfig], which now delegates here.
-func New(opts ...Option) (*ManagerConfig, error) {
-	m := &ManagerConfig{
-		logger: GetLogger(),
+func New(opts ...Option) (*Manager, error) {
+	m := &Manager{
+		logger: slogx.Default(),
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/publish/options_test.go
+++ b/publish/options_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"bytes"
@@ -57,7 +57,7 @@ func TestNew_WithLogger_AcceptsCustomLogger(t *testing.T) {
 func TestNew_WithLoggerNil_FallsBackToDefault(t *testing.T) {
 	mgr, err := New(WithLogger(nil))
 	assert.NoError(t, err)
-	assert.NotNil(t, mgr.logger, "WithLogger(nil) must fall back to GetLogger()")
+	assert.NotNil(t, mgr.logger, "WithLogger(nil) must fall back to slogx.Default()")
 }
 
 func TestNew_NilOptionIgnored(t *testing.T) {
@@ -73,9 +73,9 @@ func TestNew_NilOptionIgnored(t *testing.T) {
 func TestFromConfig_ParityWithNew(t *testing.T) {
 	// Loading the same YAML through FromConfig and through New + manual
 	// options should yield deep-equal Geoserver / Datastore / Source
-	// values. Logger pointers will differ — both are GetLogger() instances
+	// values. Logger pointers will differ — both are slogx.Default() instances
 	// which are not deduped — so compare the configurable fields only.
-	viaFromConfig, err := FromConfig("./testdata/test_config.yml")
+	viaFromConfig, err := FromConfig("../testdata/test_config.yml")
 	assert.NoError(t, err)
 
 	viaNew, err := New(
@@ -89,7 +89,7 @@ func TestFromConfig_ParityWithNew(t *testing.T) {
 			Host: "postgis", Port: 5432,
 			DBName: "gis", DBUser: "golang", DBPass: "golang", Name: "gismanager_data",
 		}),
-		WithSource(SourceConfig{Path: "./testdata"}),
+		WithSource(SourceConfig{Path: "../testdata"}),
 	)
 	assert.NoError(t, err)
 

--- a/publish/publish_integration_test.go
+++ b/publish/publish_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package gismanager_test
+package publish_test
 
 import (
 	"context"
@@ -15,14 +15,15 @@ import (
 	geoserver "github.com/hishamkaram/geoserver/v2"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 
-	"github.com/hishamkaram/gismanager"
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/publish"
 )
 
-// integrationConfig builds a *gismanager.ManagerConfig from the environment.
+// integrationConfig builds a *publish.Manager from the environment.
 // Defaults match docker-compose.test.yml's test-runner service so the test
 // works in-cluster (compose internal hostnames) and is overridable for
 // out-of-cluster use (export the env vars before running go test).
-func integrationConfig(t *testing.T, workspaceName string) *gismanager.ManagerConfig {
+func integrationConfig(t *testing.T, workspaceName string) *publish.Manager {
 	t.Helper()
 
 	cfgPath := filepath.Join(t.TempDir(), "integration_config.yml")
@@ -44,7 +45,7 @@ datastore:
   password: %s
   name: gismanager_test_ds
 source:
-  path: ./testdata
+  path: ../testdata
 `,
 		envOr("GISMANAGER_TEST_GEOSERVER_URL", "http://localhost:8080/geoserver"),
 		envOr("GISMANAGER_TEST_GEOSERVER_USER", "admin"),
@@ -60,7 +61,7 @@ source:
 		t.Fatalf("write tmp config: %v", err)
 	}
 
-	mgr, err := gismanager.FromConfig(cfgPath)
+	mgr, err := publish.FromConfig(cfgPath)
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -84,7 +85,7 @@ func uniqueWorkspaceName(t *testing.T) string {
 
 // cleanup deletes the workspace recursively. Called via t.Cleanup so tests
 // leave a clean GeoServer behind even on failure.
-func cleanup(t *testing.T, mgr *gismanager.ManagerConfig, ws string) {
+func cleanup(t *testing.T, mgr *publish.Manager, ws string) {
 	t.Helper()
 	c, err := mgr.GetGeoserverCatalog()
 	if err != nil {
@@ -100,7 +101,7 @@ func cleanup(t *testing.T, mgr *gismanager.ManagerConfig, ws string) {
 }
 
 // TestPublishAll_EndToEnd_Integration exercises the high-level
-// (*ManagerConfig).PublishAll convenience added in PR 3 of the v1.1
+// (*Manager).PublishAll convenience added in PR 3 of the v1.1
 // series. It walks testdata/ end-to-end through the same pipeline the
 // gismanager CLI uses (Walk → LayerToPostgis → PublishGeoserverLayer)
 // and verifies via the v2 client that the workspace + datastore + at
@@ -143,7 +144,7 @@ func TestPublishGeoJSON_EndToEnd_Integration(t *testing.T) {
 	t.Cleanup(func() { cleanup(t, mgr, ws) })
 
 	// Pick a small GeoJSON fixture so the test stays fast.
-	srcPath := "./testdata/neighborhood_names_gis.geojson"
+	srcPath := "../testdata/neighborhood_names_gis.geojson"
 	src, err := mgr.OpenSource(ctx, srcPath, 0)
 	if err != nil {
 		t.Fatalf("OpenSource %s: %v", srcPath, err)
@@ -157,7 +158,7 @@ func TestPublishGeoJSON_EndToEnd_Integration(t *testing.T) {
 		t.Fatalf("source %s has no layers", srcPath)
 	}
 	layer := src.LayerByIndex(0)
-	gLayer := gismanager.GdalLayer{Layer: &layer}
+	gLayer := publish.Layer{Layer: &layer}
 
 	newLayer, err := gLayer.LayerToPostgis(target, mgr, true)
 	if err != nil {
@@ -198,7 +199,7 @@ func TestPublishGeoJSON_Idempotent_Integration(t *testing.T) {
 	mgr := integrationConfig(t, ws)
 	t.Cleanup(func() { cleanup(t, mgr, ws) })
 
-	src, err := mgr.OpenSource(ctx, "./testdata/neighborhood_names_gis.geojson", 0)
+	src, err := mgr.OpenSource(ctx, "../testdata/neighborhood_names_gis.geojson", 0)
 	if err != nil {
 		t.Fatalf("OpenSource: %v", err)
 	}
@@ -207,7 +208,7 @@ func TestPublishGeoJSON_Idempotent_Integration(t *testing.T) {
 		t.Fatalf("OpenSource postgis: %v", err)
 	}
 	layer := src.LayerByIndex(0)
-	gLayer := gismanager.GdalLayer{Layer: &layer}
+	gLayer := publish.Layer{Layer: &layer}
 
 	newLayer, err := gLayer.LayerToPostgis(target, mgr, true)
 	if err != nil {
@@ -230,38 +231,38 @@ func TestUnsupportedFormat_Integration(t *testing.T) {
 	mgr := integrationConfig(t, ws)
 	// No t.Cleanup — no workspace was ever created.
 
-	_, err := mgr.OpenSource(ctx, "./testdata/sample_dummy.xml", 0)
-	if !errors.Is(err, gismanager.ErrUnsupportedFormat) {
-		t.Fatalf("expected ErrUnsupportedFormat, got %v", err)
+	_, err := mgr.OpenSource(ctx, "../testdata/sample_dummy.xml", 0)
+	if !errors.Is(err, errs.ErrUnsupportedFormat) {
+		t.Fatalf("expected errs.ErrUnsupportedFormat, got %v", err)
 	}
 }
 
 // TestLayerToPostgis_NilDatasource_Integration locks in the
-// ErrInvalidDatasource branch of LayerToPostgis. It needs the integration
+// errs.ErrInvalidDatasource branch of LayerToPostgis. It needs the integration
 // build tag because DBIsAlive runs first and would fail with
-// ErrPostGISConnect when no PostGIS is reachable, masking the
+// errs.ErrPostGISConnect when no PostGIS is reachable, masking the
 // nil-datasource check this test is asserting. Direct port of the same
 // case from the pre-revival ManagerLayerSuite.TestLayerOperations.
 func TestLayerToPostgis_NilDatasource_Integration(t *testing.T) {
 	ctx := context.Background()
 	mgr := integrationConfig(t, uniqueWorkspaceName(t))
-	src, err := mgr.OpenSource(ctx, "./testdata/neighborhood_names_gis.geojson", 0)
+	src, err := mgr.OpenSource(ctx, "../testdata/neighborhood_names_gis.geojson", 0)
 	if err != nil {
 		t.Fatalf("OpenSource: %v", err)
 	}
 	layer := src.LayerByIndex(0)
-	gLayer := gismanager.GdalLayer{Layer: &layer}
+	gLayer := publish.Layer{Layer: &layer}
 
 	got, postgisErr := gLayer.LayerToPostgis(nil, mgr, true)
 	if got != nil {
 		t.Errorf("got non-nil layer with nil targetSource: %#v", got)
 	}
-	if !errors.Is(postgisErr, gismanager.ErrInvalidDatasource) {
-		t.Fatalf("expected ErrInvalidDatasource, got %v", postgisErr)
+	if !errors.Is(postgisErr, errs.ErrInvalidDatasource) {
+		t.Fatalf("expected errs.ErrInvalidDatasource, got %v", postgisErr)
 	}
 }
 
-// TestLayerToPostgis_NilLayer_Integration locks in the ErrInvalidLayer
+// TestLayerToPostgis_NilLayer_Integration locks in the errs.ErrInvalidLayer
 // branch of LayerToPostgis. Direct port of the same case from the
 // pre-revival ManagerLayerSuite.TestLayerOperations.
 func TestLayerToPostgis_NilLayer_Integration(t *testing.T) {
@@ -272,13 +273,13 @@ func TestLayerToPostgis_NilLayer_Integration(t *testing.T) {
 		t.Fatalf("OpenSource postgis: %v", err)
 	}
 
-	gLayer := gismanager.GdalLayer{} // nil embedded *gdal.Layer
+	gLayer := publish.Layer{} // nil embedded *gdal.Layer
 
 	got, postgisErr := gLayer.LayerToPostgis(target, mgr, true)
 	if got != nil {
-		t.Errorf("got non-nil layer with nil GdalLayer.Layer: %#v", got)
+		t.Errorf("got non-nil layer with nil Layer.Layer: %#v", got)
 	}
-	if !errors.Is(postgisErr, gismanager.ErrInvalidLayer) {
-		t.Fatalf("expected ErrInvalidLayer, got %v", postgisErr)
+	if !errors.Is(postgisErr, errs.ErrInvalidLayer) {
+		t.Fatalf("expected errs.ErrInvalidLayer, got %v", postgisErr)
 	}
 }

--- a/publish/utils.go
+++ b/publish/utils.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 	"github.com/hishamkaram/gismanager/internal/zipx"
 
 	// PostgreSQL driver registered via blank import for database/sql.
@@ -17,26 +19,26 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// FromConfig loads a ManagerConfig from a YAML file at the given path.
+// FromConfig loads a Manager from a YAML file at the given path.
 //
-// Returns errors wrapping [ErrConfigInvalid]; recover the underlying
+// Returns errors wrapping [errs.ErrConfigInvalid]; recover the underlying
 // os/yaml error via [errors.As].
 //
 // Programmatic callers (no YAML file) should prefer [New] with [Option]
 // helpers like [WithGeoserver] / [WithDatastore] / [WithSource] /
 // [WithLogger]. FromConfig now delegates to New after the YAML decode.
-func FromConfig(configFile string) (*ManagerConfig, error) {
-	logger := GetLogger()
+func FromConfig(configFile string) (*Manager, error) {
+	logger := slogx.Default()
 	absPath, _ := filepath.Abs(configFile)
 	yamlFile, readErr := os.ReadFile(absPath) //nolint:gosec // G304: configFile is the operator-supplied --config path; reading it is the documented entry point.
 	if readErr != nil {
 		logger.Error("read yaml", "path", absPath, "err", readErr)
-		return nil, newGISError("FromConfig", absPath, ErrConfigInvalid, readErr)
+		return nil, errs.NewGISError("FromConfig", absPath, errs.ErrConfigInvalid, readErr)
 	}
-	var decoded ManagerConfig
+	var decoded Manager
 	if unmarshalErr := yaml.Unmarshal(yamlFile, &decoded); unmarshalErr != nil {
 		logger.Error("unmarshal yaml", "path", absPath, "err", unmarshalErr)
-		return nil, newGISError("FromConfig", absPath, ErrConfigInvalid, unmarshalErr)
+		return nil, errs.NewGISError("FromConfig", absPath, errs.ErrConfigInvalid, unmarshalErr)
 	}
 	// Apply ${VAR} substitution to operator-supplied string fields
 	// before validation so a YAML referencing $PG_PASSWORD doesn't
@@ -71,12 +73,12 @@ func isSupported(ext string) bool {
 // path it finds (shapefile, GeoJSON, GeoPackage, KML, plus zipped shapefile
 // bundles which are auto-extracted to a temp directory).
 //
-// Diagnostic logs use the project default logger from [GetLogger]. Callers
+// Diagnostic logs use the project default logger from [slogx.Default]. Callers
 // that want to thread a custom logger should construct a manager via [New]
 // + [WithLogger] and use the manager-driven walk path (added by a
 // follow-up PR); the default logger here is preserved for back-compat.
 func GetGISFiles(root string) ([]string, error) {
-	return getGISFiles(root, GetLogger())
+	return getGISFiles(root, slogx.Default())
 }
 
 // getGISFiles is the logger-aware implementation. Internal callers
@@ -158,7 +160,7 @@ func zippedShapeFile(zippedPath string, destPath string) (err error) {
 
 func preprocessFile(filePath string, tempPath string, logger *slog.Logger) (finalPath string, err error) {
 	if logger == nil {
-		logger = GetLogger()
+		logger = slogx.Default()
 	}
 	ext := strings.ToLower(filepath.Ext(filePath))
 	switch ext {

--- a/publish/utils_test.go
+++ b/publish/utils_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"os"
@@ -18,33 +18,33 @@ func TestIsSupported(t *testing.T) {
 }
 func TestZippedShapeFile(t *testing.T) {
 	newDir, _ := os.MkdirTemp("", "zipped_shapeFile")
-	unzipErr := zippedShapeFile("./testdata/faults.zip", newDir)
+	unzipErr := zippedShapeFile("../testdata/faults.zip", newDir)
 	assert.Nil(t, unzipErr)
-	dummyErr := zippedShapeFile("./testdata/faults_ss.zip", newDir)
+	dummyErr := zippedShapeFile("../testdata/faults_ss.zip", newDir)
 	assert.NotNil(t, dummyErr)
-	dirErr := zippedShapeFile("./testdata/", newDir)
+	dirErr := zippedShapeFile("../testdata/", newDir)
 	assert.NotNil(t, dirErr)
 }
 func TestPreprocessFile(t *testing.T) {
-	finalPath, preProcessErr := preprocessFile("./testdata/faults.zip", "", nil)
+	finalPath, preProcessErr := preprocessFile("../testdata/faults.zip", "", nil)
 	assert.NotNil(t, finalPath)
 	assert.NotEqual(t, "", finalPath)
 	assert.Nil(t, preProcessErr)
-	errFinalPath, err := preprocessFile("./testdata/dummy.zip", "", nil)
+	errFinalPath, err := preprocessFile("../testdata/dummy.zip", "", nil)
 	assert.Equal(t, "", errFinalPath)
 	assert.NotNil(t, err)
-	emptyFinalPath, emptyErr := preprocessFile("./testdata/faults_empty.zip", "", nil)
+	emptyFinalPath, emptyErr := preprocessFile("../testdata/faults_empty.zip", "", nil)
 	assert.Equal(t, "", emptyFinalPath)
 	assert.NotNil(t, emptyErr)
 }
 func TestGetGISFiles(t *testing.T) {
-	files, err := GetGISFiles("./testdata")
+	files, err := GetGISFiles("../testdata")
 	// 5 supported files post-PR 5 of v1.1: faults.zip, neighborhood_names_gis.geojson,
 	// nested/nyc_wi-fi_hotspot_locations.geojson, sample.gpkg, sample.kml.
 	// faults_empty.zip yields no GIS files so doesn't count.
 	assert.Equal(t, 5, len(files))
 	assert.Nil(t, err)
-	noDir, NoDirerr := GetGISFiles("./testdata/sample.gpkg")
+	noDir, NoDirerr := GetGISFiles("../testdata/sample.gpkg")
 	assert.Equal(t, 1, len(noDir))
 	assert.Nil(t, NoDirerr)
 	dummyFiles, dummyFileserr := GetGISFiles("./testdata_dummy/sample.gpkg")

--- a/publish/validate_test.go
+++ b/publish/validate_test.go
@@ -1,16 +1,18 @@
-package gismanager
+package publish
 
 import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
 )
 
-// fullConfig returns a ManagerConfig with every required field
+// fullConfig returns a Manager with every required field
 // populated to a sane non-zero value. Tests start from this and
 // blank out one field at a time to exercise Validate's error paths.
-func fullConfig() *ManagerConfig {
-	return &ManagerConfig{
+func fullConfig() *Manager {
+	return &Manager{
 		Geoserver: GeoserverConfig{
 			ServerURL:     "http://localhost:8080/geoserver",
 			Username:      "admin",
@@ -25,7 +27,7 @@ func fullConfig() *ManagerConfig {
 			DBPass: "golang",
 			Name:   "gismanager_data",
 		},
-		Source: SourceConfig{Path: "./testdata"},
+		Source: SourceConfig{Path: "../testdata"},
 	}
 }
 
@@ -38,20 +40,20 @@ func TestManagerConfig_Validate_HappyPath(t *testing.T) {
 func TestManagerConfig_Validate_RejectsEachMissingField(t *testing.T) {
 	cases := []struct {
 		name      string
-		mutate    func(*ManagerConfig)
+		mutate    func(*Manager)
 		wantInMsg string
 	}{
-		{"missing geoserver.url", func(c *ManagerConfig) { c.Geoserver.ServerURL = "" }, "geoserver.url is required"},
-		{"missing geoserver.workspace", func(c *ManagerConfig) { c.Geoserver.WorkspaceName = "" }, "geoserver.workspace is required"},
-		{"missing geoserver.username", func(c *ManagerConfig) { c.Geoserver.Username = "" }, "geoserver.username is required"},
-		{"missing geoserver.password", func(c *ManagerConfig) { c.Geoserver.Password = "" }, "geoserver.password is required"},
-		{"missing datastore.host", func(c *ManagerConfig) { c.Datastore.Host = "" }, "datastore.host is required"},
-		{"zero datastore.port", func(c *ManagerConfig) { c.Datastore.Port = 0 }, "datastore.port is required"},
-		{"missing datastore.database", func(c *ManagerConfig) { c.Datastore.DBName = "" }, "datastore.database is required"},
-		{"missing datastore.username", func(c *ManagerConfig) { c.Datastore.DBUser = "" }, "datastore.username is required"},
-		{"missing datastore.password", func(c *ManagerConfig) { c.Datastore.DBPass = "" }, "datastore.password is required"},
-		{"missing datastore.name", func(c *ManagerConfig) { c.Datastore.Name = "" }, "datastore.name is required"},
-		{"missing source.path", func(c *ManagerConfig) { c.Source.Path = "" }, "source.path is required"},
+		{"missing geoserver.url", func(c *Manager) { c.Geoserver.ServerURL = "" }, "geoserver.url is required"},
+		{"missing geoserver.workspace", func(c *Manager) { c.Geoserver.WorkspaceName = "" }, "geoserver.workspace is required"},
+		{"missing geoserver.username", func(c *Manager) { c.Geoserver.Username = "" }, "geoserver.username is required"},
+		{"missing geoserver.password", func(c *Manager) { c.Geoserver.Password = "" }, "geoserver.password is required"},
+		{"missing datastore.host", func(c *Manager) { c.Datastore.Host = "" }, "datastore.host is required"},
+		{"zero datastore.port", func(c *Manager) { c.Datastore.Port = 0 }, "datastore.port is required"},
+		{"missing datastore.database", func(c *Manager) { c.Datastore.DBName = "" }, "datastore.database is required"},
+		{"missing datastore.username", func(c *Manager) { c.Datastore.DBUser = "" }, "datastore.username is required"},
+		{"missing datastore.password", func(c *Manager) { c.Datastore.DBPass = "" }, "datastore.password is required"},
+		{"missing datastore.name", func(c *Manager) { c.Datastore.Name = "" }, "datastore.name is required"},
+		{"missing source.path", func(c *Manager) { c.Source.Path = "" }, "source.path is required"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -61,15 +63,15 @@ func TestManagerConfig_Validate_RejectsEachMissingField(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Validate(): want error, got nil")
 			}
-			if !errors.Is(err, ErrConfigInvalid) {
-				t.Errorf("errors.Is(err, ErrConfigInvalid) = false; want true. err=%v", err)
+			if !errors.Is(err, errs.ErrConfigInvalid) {
+				t.Errorf("errors.Is(err, errs.ErrConfigInvalid) = false; want true. err=%v", err)
 			}
 			if !strings.Contains(err.Error(), tc.wantInMsg) {
 				t.Errorf("error message missing %q\n got: %v", tc.wantInMsg, err)
 			}
-			var gerr *GISError
+			var gerr *errs.GISError
 			if !errors.As(err, &gerr) {
-				t.Fatalf("errors.As to *GISError: no match")
+				t.Fatalf("errors.As to *errs.GISError: no match")
 			}
 			if gerr.Op != "Validate" {
 				t.Errorf("Op = %q; want Validate", gerr.Op)
@@ -110,7 +112,7 @@ func TestManagerConfig_ExpandEnv(t *testing.T) {
 	t.Setenv("GISMGR_TEST_PG_PASS", "demo-pg-pass")
 	t.Setenv("GISMGR_TEST_SRC_PATH", "/srv/data")
 
-	c := &ManagerConfig{
+	c := &Manager{
 		Geoserver: GeoserverConfig{
 			ServerURL: "${GISMGR_TEST_GS_URL}",
 			Username:  "${GISMGR_TEST_GS_USER}",
@@ -145,7 +147,7 @@ func TestManagerConfig_ExpandEnv(t *testing.T) {
 func TestManagerConfig_ExpandEnv_UnsetVarBecomesEmpty(t *testing.T) {
 	t.Setenv("GISMGR_TEST_REAL", "real-value")
 
-	c := &ManagerConfig{
+	c := &Manager{
 		Geoserver: GeoserverConfig{
 			ServerURL: "${GISMGR_TEST_REAL}",
 			Password:  "${GISMGR_TEST_DEFINITELY_UNSET_xyzzy}",
@@ -162,15 +164,15 @@ func TestManagerConfig_ExpandEnv_UnsetVarBecomesEmpty(t *testing.T) {
 }
 
 func TestFromConfig_RejectsMissingFields(t *testing.T) {
-	mgr, err := FromConfig("./testdata/test_config_missing.yml")
+	mgr, err := FromConfig("../testdata/test_config_missing.yml")
 	if mgr != nil {
 		t.Errorf("manager = %v; want nil on incomplete config", mgr)
 	}
 	if err == nil {
 		t.Fatal("err = nil; want validation failure")
 	}
-	if !errors.Is(err, ErrConfigInvalid) {
-		t.Errorf("errors.Is(err, ErrConfigInvalid) = false; want true. err=%v", err)
+	if !errors.Is(err, errs.ErrConfigInvalid) {
+		t.Errorf("errors.Is(err, errs.ErrConfigInvalid) = false; want true. err=%v", err)
 	}
 	// The aggregated error should call out every missing field.
 	for _, want := range []string{
@@ -192,9 +194,9 @@ func TestFromConfig_ExpandsEnvVars(t *testing.T) {
 	t.Setenv("GISMGR_TEST_PG_HOST", "demo-postgis")
 	t.Setenv("GISMGR_TEST_PG_USER", "demo-pg-user")
 	t.Setenv("GISMGR_TEST_PG_PASS", "demo-pg-secret")
-	t.Setenv("GISMGR_TEST_SRC_PATH", "./testdata")
+	t.Setenv("GISMGR_TEST_SRC_PATH", "../testdata")
 
-	mgr, err := FromConfig("./testdata/test_config_envvars.yml")
+	mgr, err := FromConfig("../testdata/test_config_envvars.yml")
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -210,7 +212,7 @@ func TestFromConfig_ExpandsEnvVars(t *testing.T) {
 	if got := mgr.Datastore.DBPass; got != "demo-pg-secret" {
 		t.Errorf("Datastore.DBPass = %q", got)
 	}
-	if got := mgr.Source.Path; got != "./testdata" {
+	if got := mgr.Source.Path; got != "../testdata" {
 		t.Errorf("Source.Path = %q", got)
 	}
 }

--- a/publish/vars.go
+++ b/publish/vars.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import "regexp"
 

--- a/publish/vars_test.go
+++ b/publish/vars_test.go
@@ -1,9 +1,9 @@
-package gismanager
+package publish
 
 import "testing"
 
 // TestPgRegex_Matches and TestPgRegex_DoesNotMatch lock in the
-// PostgreSQL connection-string detection used by [(*ManagerConfig).GetDriver]
+// PostgreSQL connection-string detection used by [(*Manager).GetDriver]
 // to choose between the OGR PG driver and a file-extension dispatch.
 // driver_table_test.go's TestGetDriver_Table exercises this regex
 // indirectly via the public GetDriver path; the focused tests here

--- a/publish/walk.go
+++ b/publish/walk.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -7,6 +7,9 @@ import (
 	"sync"
 
 	"github.com/lukeroth/gdal"
+
+	"github.com/hishamkaram/gismanager/internal/errs"
+	"github.com/hishamkaram/gismanager/internal/slogx"
 )
 
 // defaultPublishConcurrency caps how many GeoServer feature-type
@@ -24,7 +27,7 @@ import (
 // functional option in v1.5+ if there's demand to tune.
 const defaultPublishConcurrency = 8
 
-// WalkItem is one yielded element of [(*ManagerConfig).Walk]: a
+// WalkItem is one yielded element of [(*Manager).Walk]: a
 // (path, layer) pair the caller can consume.
 //
 // Convention: when the iterator's second yield value is a non-nil error,
@@ -37,10 +40,10 @@ type WalkItem struct {
 	Path string
 
 	// Layer is the wrapped GDAL layer, with the manager's logger
-	// stamped via [(*ManagerConfig).NewLayer]. Use it directly with
+	// stamped via [(*Manager).NewLayer]. Use it directly with
 	// helpers like [LayerToPostgis] / [PublishGeoserverLayer], or read
 	// its embedded *gdal.Layer for OGR-level operations.
-	Layer *GdalLayer
+	Layer *Layer
 }
 
 // Walk returns an iterator over every layer of every supported GIS file
@@ -53,7 +56,7 @@ type WalkItem struct {
 // is therefore bounded to one file's worth of OGR state at a time, even
 // for very large source directories.
 //
-// Per-file errors do NOT abort the iterator. If [(*ManagerConfig).OpenSource]
+// Per-file errors do NOT abort the iterator. If [(*Manager).OpenSource]
 // fails for a path, Walk yields a zero [WalkItem] paired with the wrapped
 // error and continues to the next file. Callers can:
 //
@@ -67,10 +70,10 @@ type WalkItem struct {
 //
 // `break`-ing out of the for-range loop runs the deferred Destroy on the
 // currently-open source, so early termination doesn't leak.
-func (manager *ManagerConfig) Walk(ctx context.Context) iter.Seq2[WalkItem, error] {
+func (manager *Manager) Walk(ctx context.Context) iter.Seq2[WalkItem, error] {
 	logger := manager.logger
 	if logger == nil {
-		logger = GetLogger()
+		logger = slogx.Default()
 	}
 	return func(yield func(WalkItem, error) bool) {
 		files, err := getGISFiles(manager.Source.Path, logger)
@@ -106,7 +109,7 @@ func (manager *ManagerConfig) Walk(ctx context.Context) iter.Seq2[WalkItem, erro
 // each one via the iterator's yield function. Returns true when the
 // caller signaled stop (yield returned false), letting the outer loop
 // release the source and exit.
-func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSource, path string, yield func(WalkItem, error) bool) bool {
+func walkLayers(manager *Manager, ctx context.Context, source *gdal.DataSource, path string, yield func(WalkItem, error) bool) bool {
 	count := source.LayerCount()
 	for i := 0; i < count; i++ {
 		if err := ctx.Err(); err != nil {
@@ -146,7 +149,7 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 //
 // Error semantics (since v1.4):
 //
-//   - Setup failures abort the operation. If [(*ManagerConfig).OpenSource]
+//   - Setup failures abort the operation. If [(*Manager).OpenSource]
 //     can't open the PostGIS datastore, PublishAll returns the wrapped
 //     error directly without attempting any layer.
 //   - Per-layer failures (walk errors, PostGIS load errors, GeoServer
@@ -157,7 +160,7 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 //     per-layer error, or nil if every layer succeeded.
 //
 // Callers can branch on the aggregated result with
-// `errors.Is(err, ErrGeoServerPublish)` / `errors.Is(err, ErrPostGISConnect)`
+// `errors.Is(err, errs.ErrGeoServerPublish)` / `errors.Is(err, errs.ErrPostGISConnect)`
 // — the joined error walks through every collected failure, so any
 // match in the chain returns true. To enumerate per-layer failures
 // individually, type-assert via `errors.As(err, &gerr)` repeatedly or
@@ -178,10 +181,10 @@ func walkLayers(manager *ManagerConfig, ctx context.Context, source *gdal.DataSo
 // will now see those failures surface; that previous behavior was an
 // acknowledged silent-failure mode (see the v1.3 doc comment) and the
 // aggregated form is the documented path forward.
-func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
+func (manager *Manager) PublishAll(ctx context.Context) error {
 	logger := manager.logger
 	if logger == nil {
-		logger = GetLogger()
+		logger = slogx.Default()
 	}
 	target, err := manager.OpenSource(ctx, manager.Datastore.BuildConnectionString(), 1)
 	if err != nil {
@@ -204,7 +207,7 @@ func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 	// going through PublishAll.)
 	catalog, catErr := manager.GetGeoserverCatalog()
 	if catErr != nil {
-		return newGISError("PublishAll", "", ErrGeoServerPublish, catErr)
+		return errs.NewGISError("PublishAll", "", errs.ErrGeoServerPublish, catErr)
 	}
 	if wsErr := ensureWorkspace(ctx, catalog, manager.Geoserver.WorkspaceName); wsErr != nil {
 		return wsErr
@@ -250,7 +253,7 @@ func (manager *ManagerConfig) PublishAll(ctx context.Context) error {
 		// than spawning unbounded goroutines.
 		sem <- struct{}{}
 		wg.Add(1)
-		go func(item WalkItem, newLayer *GdalLayer) {
+		go func(item WalkItem, newLayer *Layer) {
 			defer wg.Done()
 			defer func() { <-sem }()
 			if pubErr := manager.PublishGeoserverLayer(ctx, newLayer); pubErr != nil {

--- a/publish/walk_test.go
+++ b/publish/walk_test.go
@@ -1,4 +1,4 @@
-package gismanager
+package publish
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 // depends on the fixtures (multiple layers per GeoPackage); we assert
 // it's non-zero so the test stays robust against fixture additions.
 func TestWalk_YieldsLayersFromTestdata(t *testing.T) {
-	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	mgr, err := New(WithSource(SourceConfig{Path: "../testdata"}))
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -37,7 +37,7 @@ func TestWalk_YieldsLayersFromTestdata(t *testing.T) {
 // a successful early break + a subsequent fresh walk is the strongest
 // in-test signal we can produce without instrumenting CGo.
 func TestWalk_EarlyBreak_DoesNotPanic(t *testing.T) {
-	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	mgr, err := New(WithSource(SourceConfig{Path: "../testdata"}))
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -67,7 +67,7 @@ func TestWalk_EarlyBreak_DoesNotPanic(t *testing.T) {
 // asserts the iterator yields the cancellation error without producing
 // any layer items.
 func TestWalk_HonorsContextCancellation(t *testing.T) {
-	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	mgr, err := New(WithSource(SourceConfig{Path: "../testdata"}))
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +92,7 @@ func TestWalk_HonorsContextCancellation(t *testing.T) {
 // the supportedEXT entry was "kml" (no dot) and KML files were silently
 // dropped from directory walks; this test would have failed.
 func TestWalk_PicksUpKMLFixture(t *testing.T) {
-	mgr, err := New(WithSource(SourceConfig{Path: "./testdata"}))
+	mgr, err := New(WithSource(SourceConfig{Path: "../testdata"}))
 	assert.NoError(t, err)
 
 	sawKML := false

--- a/testdata/test_config.yml
+++ b/testdata/test_config.yml
@@ -11,4 +11,4 @@ datastore:
   password: golang
   name: gismanager_data
 source:
-  path: ./testdata
+  path: ../testdata

--- a/testdata/test_config_err.yml
+++ b/testdata/test_config_err.yml
@@ -11,5 +11,5 @@ datastore:
   password: golang
   name: gismanager_data
 source:
-  path: ./testdata
+  path: ../testdata
 </error>


### PR DESCRIPTION
## Summary

**Phase 3** of the v2 restructure plan. The publish pipeline (Manager constructor, Walk + PublishAll orchestration, GdalLayer wrapper, connection helpers, configuration types) splits into \`github.com/hishamkaram/gismanager/publish\`. Public v1.x API preserved via type aliases + function wrappers in \`compat_publish.go\`; new code should import the publish subpackage directly.

## What moved

16 files via \`git mv\` (history preserved):
- \`manager.go\`, \`layer.go\`, \`walk.go\`, \`options.go\`, \`datastore.go\`, \`utils.go\`, \`vars.go\`
- All matching \`_test.go\` files plus \`validate_test.go\`, \`driver_table_test.go\`, \`example_manager_test.go\`, \`publish_integration_test.go\`, \`lifecycle_test.go\`, \`layer_logger_test.go\`

## Key renames in publish package

| v1.x | v2-shape | Why |
|------|---------|-----|
| \`ManagerConfig\` | \`Manager\` | "Config" was a misnomer — the type IS the manager |
| \`GdalLayer\` | \`Layer\` | Drop redundant \`Gdal\` prefix (clear from package context) |

Methods on Manager + Layer are auto-accessible via the v1 type aliases — no separate method wrappers needed.

## Compat layer (root)

\`compat_publish.go\` (~150 lines):
- 8 type aliases (\`ManagerConfig\` = \`publish.Manager\`, \`GdalLayer\` = \`publish.Layer\`, etc.) — preserve full identity for \`errors.As\` / \`errors.Is\` / method sets / slice element types
- 9 top-level function wrappers (\`New\`, \`FromConfig\`, \`WithLogger\`, \`WithGeoserver\`, \`WithDatastore\`, \`WithSource\`, \`GetGISFiles\`, \`DBIsAlive\`, \`DBIsAliveContext\`)

All declarations marked \`Deprecated:\`; v2 module bump (Phase 4) drops the file entirely.

## New documentation

- \`doc.go\` at root — documents the gismanager package as a v1.x compat shim
- \`publish/doc.go\` — package surface + v2 migration story

## Test fixture updates

YAML \`source.path\` rebased from \`./testdata\` to \`../testdata\` (tests now run from \`publish/\` directory):
- \`testdata/test_config.yml\`
- \`testdata/test_config_err.yml\`
- The in-test YAML template in \`publish_integration_test.go\`
- All \`SourceConfig{Path: "..."}\` literals in publish/*_test.go (sed-rewritten)

## Internal callers updated

- \`cmd/gismanager/gismanager.go\` and \`cmd/layerSchema/layerSchema.go\` import \`gismanager/publish\` directly; type signatures use \`*publish.Manager\`.
- \`cmd/layerSchema/main_test.go\` uses \`publish.LayerField\`.
- \`convert/vector_geoparquet_integration_test.go\` uses \`publish.New\` for the cross-package round-trip read-back.

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green; all packages green including the new \`publish/\` (the existing comprehensive test set moved with the source files)
- [x] \`make test-integration\` against GeoServer 2.28.0 — green (9s publish + 3s convert; cross-package geoparquet round-trip works)
- [ ] CI: full matrix runs on push

After this lands, master has the v2 layout AT THE FILE LEVEL but still publishes as v1 with full compat wrappers. Cut **v1.5.0** (Phase 7's job) as the deprecation-introducing release. Phase 4 is the actual module-path bump that breaks v1 callers.