### PR TITLE
refactor(publish)!: drop deprecated GetGeomtryName + GetFeatures

### DIFF
--- a/publish/layer.go
+++ b/publish/layer.go
@@ -221,13 +221,6 @@ func (layer *Layer) GeometryName() string {
 	return name
 }
 
-// GetGeomtryName is the historical (typo'd) name of [GeometryName].
-//
-// Deprecated: typo (missing 'e' in "Geometry"). Use [GeometryName],
-// which is byte-for-byte identical in behaviour. The typo'd form is
-// kept for v1.x back-compat and will be removed at v2.
-func (layer *Layer) GetGeomtryName() string { return layer.GeometryName() }
-
 // GetLayerSchema returns the layer's geometry column followed by every
 // attribute field, each as a LayerField with name + OGR type.
 func (layer *Layer) GetLayerSchema() (fields []*LayerField) {
@@ -247,30 +240,6 @@ func (layer *Layer) GetLayerSchema() (fields []*LayerField) {
 			}
 			fields = append(fields, &layerField)
 
-		}
-	}
-	return
-}
-
-// GetFeatures returns every feature in the layer, materialized into a slice.
-// Features are read in OGR-FID order. Returns nil if FeatureCount fails.
-//
-// Deprecated: leaks gdal.Feature handles — each feature in the returned
-// slice owns a C-level handle that must be released via [gdal.Feature.Destroy],
-// which the slice form makes easy to forget. Use [(*Layer).Features]
-// which destroys each feature as iteration advances and on early break.
-func (layer *Layer) GetFeatures() (features []*gdal.Feature) {
-	logger := layer.loggerOrDefault()
-	if layer.Layer != nil {
-		count, ok := layer.FeatureCount(true)
-		if !ok {
-			logger.Error("could not read features")
-		} else {
-			logger.Info("read features", "count", count)
-			for index := 0; index < count; index++ {
-				f := layer.Feature(int64(index))
-				features = append(features, &f)
-			}
 		}
 	}
 	return

--- a/publish/layer_test.go
+++ b/publish/layer_test.go
@@ -7,18 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFeatures(t *testing.T) {
+// TestFeatures_Iterator tests the v2 Features() iterator that replaced
+// the v1 GetFeatures() handle-leaking slice form. The new API yields
+// each feature once and destroys the C handle as iteration advances,
+// so callers don't need to remember to free.
+func TestFeatures_Iterator(t *testing.T) {
 	manager, _ := FromConfig("../testdata/test_config.yml")
 	files, _ := GetGISFiles(manager.Source.Path)
 	source, _ := manager.OpenSource(context.Background(), files[0], 1)
 	layer := source.LayerByIndex(0)
-	gLayer := Layer{
-		Layer: &layer,
-	}
+	gLayer := Layer{Layer: &layer}
+
 	count, _ := layer.FeatureCount(true)
-	features := gLayer.GetFeatures()
-	assert.NotNil(t, features)
-	assert.Equal(t, count, len(features))
+
+	seen := 0
+	for range gLayer.Features(context.Background()) {
+		// Iterate; the iterator destroys each feature as it advances.
+		// Counting is the contract we lock in here.
+		seen++
+	}
+
+	assert.Equal(t, count, seen, "Features iterator should yield every layer feature once")
 }
 
 func TestGetLayerSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

**Phase 5** of the v2 restructure — the API cleanup pass. Two methods that were already marked Deprecated in v1.x are now removed:

| Method | Why dropped | v2 replacement |
|--------|-------------|----------------|
| \`(*Layer).GetGeomtryName\` | Typo'd duplicate of \`GeometryName()\`; same byte-for-byte behavior; kept in v1.x only for back-compat. | \`(*Layer).GeometryName()\` |
| \`(*Layer).GetFeatures\` | Returned \`[]*gdal.Feature\`; each element owned a C-level handle that callers had to remember to \`Destroy\`. The slice form made leaks too easy. | \`(*Layer).Features(ctx)\` iterator (destroys each feature as iteration advances + on early break) |

## Tests

- \`TestGetFeatures\` replaced by \`TestFeatures_Iterator\`: same fixture, asserts the iterator yields exactly \`FeatureCount\` entries (one per layer feature, no leaks because the iterator handles \`Destroy\`).
- \`TestGetLayerSchema\` unchanged — exercises the kept \`GetLayerSchema\` helper.

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green; new \`TestFeatures_Iterator\` exercises the iterator end-to-end
- [ ] CI: full matrix runs on push

## Breaking change

This is a v2 breaking change (the \`!\` in the commit subject). v1.x users staying on the v1 line via \`release/v1.x\` keep both methods. The v1 → v2 \`MIGRATING.md\` (Phase 7) will spell out the rename + iterator-pattern recipe.