### PR TITLE
feat(publish): expose WithPublishConcurrency option for tunable PublishAll worker pool

### DIFF
--- a/publish/manager.go
+++ b/publish/manager.go
@@ -36,6 +36,14 @@ type Manager struct {
 	Datastore DatastoreConfig `yaml:"datastore"`
 	Source    SourceConfig    `yaml:"source"`
 	logger    *slog.Logger
+
+	// publishConcurrency caps how many GeoServer feature-type
+	// creations [PublishAll] dispatches in parallel. Zero (the
+	// zero-value) means "use [defaultPublishConcurrency]"; an explicit
+	// positive value (set via [WithPublishConcurrency]) overrides.
+	// One means strictly serial publish — useful for diagnostic
+	// runs against finicky GeoServer instances.
+	publishConcurrency int
 }
 
 // Validate checks that every required field on a Manager is set

--- a/publish/options.go
+++ b/publish/options.go
@@ -48,6 +48,27 @@ func WithSource(cfg SourceConfig) Option {
 	return func(m *Manager) { m.Source = cfg }
 }
 
+// WithPublishConcurrency caps how many GeoServer feature-type
+// creations [(*Manager).PublishAll] dispatches in parallel. Zero or
+// negative values fall back to the package default
+// ([defaultPublishConcurrency], currently 8). An explicit value of 1
+// forces strictly serial publish — useful for diagnostic runs against
+// finicky GeoServer instances or when GeoServer's own thread pool is
+// the bottleneck.
+//
+// Walk and [(*Layer).LayerToPostgis] always run serially regardless
+// of this option — the lukeroth/gdal CGo handles aren't reentrancy-safe
+// across goroutines. This option only affects the HTTP-only publish step.
+func WithPublishConcurrency(n int) Option {
+	return func(m *Manager) {
+		if n <= 0 {
+			m.publishConcurrency = 0 // signal "use default"
+			return
+		}
+		m.publishConcurrency = n
+	}
+}
+
 // New constructs a [Manager] from the given options. With no options,
 // the returned manager has zero-value GeoServer / Datastore / Source
 // configs and the default logger from [slogx.Default]. The error return is

--- a/publish/options_publish_concurrency_test.go
+++ b/publish/options_publish_concurrency_test.go
@@ -1,0 +1,48 @@
+package publish
+
+import "testing"
+
+// Tests for the v2 [WithPublishConcurrency] option.
+//
+// We can't drive PublishAll's actual concurrency in a unit test (would
+// need a live GeoServer + PostGIS); the integration suite covers the
+// runtime flow. These cases lock in the option's effect on the manager
+// state, which the runtime path then reads.
+
+func TestWithPublishConcurrency_ExplicitValue(t *testing.T) {
+	mgr, err := New(WithPublishConcurrency(16))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := mgr.publishConcurrency; got != 16 {
+		t.Errorf("publishConcurrency = %d; want 16", got)
+	}
+}
+
+func TestWithPublishConcurrency_ZeroFallsBackToDefault(t *testing.T) {
+	mgr, _ := New(WithPublishConcurrency(0))
+	if got := mgr.publishConcurrency; got != 0 {
+		t.Errorf("publishConcurrency for zero arg = %d; want 0 (PublishAll then uses defaultPublishConcurrency)", got)
+	}
+}
+
+func TestWithPublishConcurrency_NegativeFallsBackToDefault(t *testing.T) {
+	mgr, _ := New(WithPublishConcurrency(-3))
+	if got := mgr.publishConcurrency; got != 0 {
+		t.Errorf("publishConcurrency for negative arg = %d; want 0 (treated as default)", got)
+	}
+}
+
+func TestWithPublishConcurrency_OneEnablesSerial(t *testing.T) {
+	mgr, _ := New(WithPublishConcurrency(1))
+	if got := mgr.publishConcurrency; got != 1 {
+		t.Errorf("publishConcurrency = %d; want 1 (serial publish)", got)
+	}
+}
+
+func TestNewWithoutOption_LeavesZeroForDefault(t *testing.T) {
+	mgr, _ := New()
+	if got := mgr.publishConcurrency; got != 0 {
+		t.Errorf("publishConcurrency without WithPublishConcurrency = %d; want 0", got)
+	}
+}

--- a/publish/walk.go
+++ b/publish/walk.go
@@ -220,7 +220,14 @@ func (manager *Manager) PublishAll(ctx context.Context) error {
 	// the concurrency gate; wg ensures we wait for every dispatched
 	// publish before returning. errsMu protects perLayerErrs from
 	// concurrent writes by the publish goroutines.
-	sem := make(chan struct{}, defaultPublishConcurrency)
+	//
+	// Concurrency comes from [WithPublishConcurrency] when set (>0);
+	// otherwise falls back to [defaultPublishConcurrency].
+	concurrency := manager.publishConcurrency
+	if concurrency <= 0 {
+		concurrency = defaultPublishConcurrency
+	}
+	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 	var errsMu sync.Mutex
 	perLayerErrs := []error{}


### PR DESCRIPTION
## Summary

**Phase 6** of the v2 restructure. v1.4 hardcoded the worker-pool size to 8 with a TODO to expose it as a functional option in v1.5+; v2 lands the option.

## API

\`\`\`go
publish.New(
    publish.WithPublishConcurrency(16), // override default of 8
    // ... other options ...
)
\`\`\`

## Semantics

| Arg | Effect |
|-----|--------|
| `n <= 0` | Fall back to `defaultPublishConcurrency` (8) — same as not setting the option |
| `n > 0` | Cap parallel GeoServer `FeatureType.Create` calls at `n` |
| `n == 1` | Strictly serial publish — useful for diagnostic runs against finicky GeoServer instances or when GeoServer's own thread pool is the bottleneck |

Walk + `LayerToPostgis` stay serial regardless of this option — the `lukeroth/gdal` CGo handles aren't reentrancy-safe across goroutines. This option **only** affects the HTTP-only publish step.

## Implementation

- New private `publishConcurrency int` field on `*Manager` (zero-value means "use default")
- `PublishAll` reads it at the top of the bounded worker pool dispatch and falls back when zero
- New `WithPublishConcurrency(n int) Option` in `publish/options.go`

## Tests

5 new unit cases in `publish/options_publish_concurrency_test.go`:
- `TestWithPublishConcurrency_ExplicitValue` (n=16 → field=16)
- `TestWithPublishConcurrency_ZeroFallsBackToDefault` (n=0 → field=0, runtime defaults)
- `TestWithPublishConcurrency_NegativeFallsBackToDefault` (n=-3 → field=0)
- `TestWithPublishConcurrency_OneEnablesSerial` (n=1 → field=1)
- `TestNewWithoutOption_LeavesZeroForDefault` (option not set → field=0)

The runtime concurrency flow is exercised by the existing integration suite (still hits `defaultPublishConcurrency` since no test uses the option).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`make test-unit\` — green; 5 new cases pass
- [ ] CI: full matrix runs on push