### PR TITLE
docs(v2): CHANGELOG [2.0.0] stanza, MIGRATING.md, README + docs/ updated for v2 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,165 @@ All notable changes to `github.com/hishamkaram/gismanager` are documented here. 
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-05-07
+
+### Context
+
+The v2 line ships gismanager as a subpackage-organized library
+(`github.com/hishamkaram/gismanager/v2`) with the **publish pipeline**,
+**conversion subsystem**, and the typed-error machinery each living in
+its own subpackage. Six focused PRs (#53–#58) sequenced for review
+delivered the layout; the v1.x line (release branch `release/v1.x`)
+stays maintained for users who can't migrate yet. See
+[`MIGRATING.md`](./MIGRATING.md) for the v1 → v2 import-rewrite recipe.
+
+The v2 cycle is intentionally **structural** rather than feature-driven:
+the library API surface is the same shape gismanager has had since v1.4
+plus a few targeted cleanups and one new option. No new external runtime
+dependencies were added; the dep surface stays the small set documented
+in `CLAUDE.md`.
+
+### Module path
+
+- **`github.com/hishamkaram/gismanager` → `github.com/hishamkaram/gismanager/v2`** (PR #56)
+
+  Every external import requires a path bump; type/function names are
+  otherwise either unchanged or renamed per the table in MIGRATING.md.
+  The release/v1.x branch keeps the old import path supported for
+  patch releases (security fixes, etc.).
+
+### Added
+
+- **`github.com/hishamkaram/gismanager/v2/publish`** (PR #55) —
+  the publish pipeline subpackage. Hosts `Manager` (was `ManagerConfig`),
+  `Layer` (was `GdalLayer`), `New`, `FromConfig`, `WithLogger` /
+  `WithGeoserver` / `WithDatastore` / `WithSource`, `(*Manager).Walk`,
+  `(*Manager).PublishAll`, `(*Manager).OpenSource` / `GetDriver` /
+  `Validate`, `(*Layer).LayerToPostgis` / `PublishGeoserverLayer` /
+  `GetLayerSchema` / `Features` / `GeometryName`, plus the configuration
+  struct types (`GeoserverConfig`, `DatastoreConfig`, `SourceConfig`,
+  `LayerField`, `WalkItem`, `Option`).
+- **`github.com/hishamkaram/gismanager/v2/convert`** (PR #54) —
+  the stateless conversion subsystem subpackage. Hosts `ConvertVector`,
+  `ConvertRaster`, `ToCOG`, `ReprojectRaster`, `Rasterize`, `BuildVRT`,
+  `DEMProcessing`, `ToPMTiles`, plus 60-ish `WithVector*` / `WithRaster*`
+  / `WithRasterize*` / `WithVRT*` / `WithDEM*` / `WithPMTiles*` option
+  helpers. Option types renamed: `VectorConvertOption` → `VectorOption`,
+  `RasterConvertOption` → `RasterOption` (the redundant `Convert`
+  prefix made sense at the root but is noise inside `convert/`).
+- **`github.com/hishamkaram/gismanager/v2/errs`** (PR #56) —
+  promoted from `internal/errs` to a public subpackage. Hosts the
+  `*GISError` envelope and the `ErrConfigInvalid` / `ErrUnsupportedFormat`
+  / `ErrInvalidLayer` / `ErrInvalidDatasource` / `ErrPostGISConnect` /
+  `ErrGeoServerPublish` / `ErrNoSourcesFound` / `ErrConvertFailed`
+  sentinels. v2 callers do `errors.Is(err, errs.ErrConvertFailed)`
+  rather than the v1 `errors.Is(err, gismanager.ErrConvertFailed)`.
+- **`publish.WithPublishConcurrency(n int)`** (PR #58) — caps how
+  many GeoServer feature-type creations `(*Manager).PublishAll`
+  dispatches in parallel. Zero/negative → fall back to package
+  default (currently 8); explicit positive → cap; `n=1` forces
+  strictly serial publish (useful for diagnostic runs against
+  finicky GeoServer instances). Walk + LayerToPostgis stay serial
+  regardless — only the HTTP-only publish step parallelizes, since
+  the lukeroth/gdal CGo handles aren't reentrancy-safe across
+  goroutines.
+- **`MIGRATING.md`** — new top-level migration guide covering the
+  module-path bump, every type/function rename, the dropped
+  v1-deprecated methods, the new option, and concrete `sed`-style
+  migration recipes for typical caller patterns.
+
+### Changed
+
+- **`ManagerConfig` → `Manager`** in `publish/` (PR #55). "Config" was
+  a misnomer — the type IS the manager, not its config. Method sets
+  (`Validate`, `OpenSource`, `GetDriver`, `Walk`, `PublishAll`,
+  `GetGeoserverCatalog`, `NewLayer`) flow with the type.
+- **`GdalLayer` → `Layer`** in `publish/` (PR #55). Drop the redundant
+  `Gdal` prefix — clear from package context. Method sets
+  (`LayerToPostgis`, `PublishGeoserverLayer`, `GetLayerSchema`,
+  `Features`, `GeometryName`) flow with the type.
+- **`*ConvertOption` → `*Option`** in `convert/` (PR #54). `VectorOption`
+  / `RasterOption` (`RasterizeOption` / `VRTOption` / `DEMOption` /
+  `PMTilesOption` were already concise, unchanged).
+- **Internal extraction of error machinery + default logger** to
+  `internal/errs` (Phase 1, PR #53) then promotion of `errs` to
+  public (Phase 4, PR #56). `internal/slogx` stays internal in
+  v2; v2 callers construct their own `*slog.Logger` and pass it
+  via `publish.WithLogger`.
+
+### Removed
+
+- **`gismanager.GISError` / `gismanager.Err*` sentinels** (root) —
+  replaced by `errs.GISError` / `errs.Err*`. Pre-v1.4 callers that
+  matched on string error messages keep working (errors.Is preserves
+  identity across the boundary), but type-name compile-time references
+  must update.
+- **`gismanager.ManagerConfig` / `gismanager.GdalLayer` / `gismanager.New`
+  / `gismanager.FromConfig` / `gismanager.WithLogger` / `gismanager.WithGeoserver`
+  / `gismanager.WithDatastore` / `gismanager.WithSource` / `gismanager.GetGISFiles`
+  / `gismanager.DBIsAlive` / `gismanager.DBIsAliveContext`** (root) —
+  replaced by the `publish.X` equivalents.
+- **`gismanager.ConvertVector` / `gismanager.ConvertRaster` / `gismanager.ToCOG`
+  / `gismanager.ReprojectRaster` / `gismanager.Rasterize` / `gismanager.BuildVRT`
+  / `gismanager.DEMProcessing` / `gismanager.ToPMTiles`** + ~60 root-level
+  `WithX*` helpers — replaced by the `convert.X` equivalents.
+- **`gismanager.GetLogger()`** (root) — dropped from public API.
+  v2 callers construct their own `*slog.Logger` (any handler — text,
+  JSON, OTel-bridged) and pass it via `publish.WithLogger`. The
+  internal default at `internal/slogx.Default` is package-private.
+- **`(*Layer).GetGeomtryName()`** (PR #57) — typo'd duplicate of
+  `GeometryName()`; behaviorally identical but with the typo
+  preserved for v1 back-compat. v2 drops it.
+- **`(*Layer).GetFeatures()`** (PR #57) — returned a slice of
+  `*gdal.Feature` whose elements each owned a C-level handle the
+  caller had to remember to `Destroy`; the slice form made leaks
+  too easy. v2 callers use the `(*Layer).Features(ctx)` iterator
+  instead, which destroys each feature as iteration advances and
+  on early break.
+
+### Tests
+
+- `TestFeatures_Iterator` (publish) — replaces `TestGetFeatures`
+  with the iterator-form contract (PR #57).
+- `TestWithPublishConcurrency_*` (publish, 5 cases) — locks in
+  the option's effect on the manager state across explicit-positive,
+  zero-fallback, negative-fallback, n=1-serial, and unset paths
+  (PR #58).
+- The full integration suite (GeoServer 2.27.4 LTS + 2.28.0 stable,
+  PostGIS 16) ran green at every Phase boundary.
+
+### Operations
+
+- **`release/v1.x` maintenance branch** (PR #52) — branched from
+  `v1.4.1`. Patch releases on the v1.x line (security fixes,
+  CVE patches) cut from this branch. CI workflows (`ci.yml`,
+  `integration.yml`, `security.yml`) trigger on `release/v*` in
+  addition to `master`.
+- **Trivy SARIF aggregator race fix** (PR #56 follow-up) — both
+  Trivy job uploads now share a single `category: trivy` to side-
+  step the Code Scanning aggregator's "missing config" race that
+  fired at workflow start (~2s) when an expected SARIF category
+  hadn't yet uploaded.
+
+### Migration
+
+See [`MIGRATING.md`](./MIGRATING.md). The short version:
+
+```bash
+# 1. Bump every import.
+find . -name '*.go' | xargs sed -i \
+  's|"github.com/hishamkaram/gismanager"|"github.com/hishamkaram/gismanager/v2/publish"|g'
+# (then split: convert/ for ConvertVector etc., errs/ for sentinels)
+
+# 2. Rename Manager / Layer types.
+find . -name '*.go' | xargs sed -i \
+  's/\bgismanager\.ManagerConfig\b/publish.Manager/g; s/\bgismanager\.GdalLayer\b/publish.Layer/g'
+
+# 3. Replace dropped methods.
+#    GetGeomtryName → GeometryName
+#    GetFeatures (slice) → Features(ctx) iterator (use range over the result)
+```
+
 ## [1.4.1] — 2026-05-06
 
 ### Context

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,369 @@
+# Migrating from v1.x to v2
+
+This guide covers every breaking change between
+`github.com/hishamkaram/gismanager` (v1.x) and
+`github.com/hishamkaram/gismanager/v2` (v2.0+). The library API
+surface is the same shape it had in v1.4 — the v2 cycle was
+**structural** (subpackage layout, module-path bump, two deprecated
+methods removed, one new option). No behavior changes to
+documented contracts; the conversion entry points and the publish
+pipeline both produce byte-for-byte identical output.
+
+If you can't migrate yet, the v1.x line stays maintained on the
+`release/v1.x` branch (security fixes, CVE patches). v2 is master.
+
+---
+
+## TL;DR — three sed scripts
+
+```bash
+# 1. Bump module path on imports.
+find . -name '*.go' | xargs sed -i \
+  's|"github.com/hishamkaram/gismanager"|"github.com/hishamkaram/gismanager/v2"|g'
+
+# 2. The bumped imports point at the empty root package. Split them
+#    into subpackage imports based on which symbol you used:
+#      gismanager.ConvertVector / ToCOG / ToPMTiles / WithVector*
+#                              → import .../v2/convert
+#      gismanager.New / ManagerConfig / Walk / PublishAll / etc.
+#                              → import .../v2/publish
+#      gismanager.GISError / Err*  → import .../v2/errs
+
+# 3. Apply the type renames.
+find . -name '*.go' | xargs sed -i \
+  -e 's/\bgismanager\.ManagerConfig\b/publish.Manager/g' \
+  -e 's/\bgismanager\.GdalLayer\b/publish.Layer/g' \
+  -e 's/\bgismanager\.VectorConvertOption\b/convert.VectorOption/g' \
+  -e 's/\bgismanager\.RasterConvertOption\b/convert.RasterOption/g' \
+  -e 's/\bgismanager\.\(ConvertVector\|ConvertRaster\|ToCOG\|ReprojectRaster\|Rasterize\|BuildVRT\|DEMProcessing\|ToPMTiles\)\b/convert.\1/g' \
+  -e 's/\bgismanager\.With\(Vector\|Raster\|Rasterize\|VRT\|DEM\|PMTiles\)/convert.With\1/g' \
+  -e 's/\bgismanager\.\(New\|FromConfig\|WithLogger\|WithGeoserver\|WithDatastore\|WithSource\|GetGISFiles\|DBIsAlive\|DBIsAliveContext\)\b/publish.\1/g' \
+  -e 's/\bgismanager\.\(GISError\|Err[A-Z][a-zA-Z]*\)\b/errs.\1/g'
+```
+
+This handles the mechanical part. Edge cases below.
+
+---
+
+## Module path
+
+| v1.x | v2 |
+|------|----|
+| `github.com/hishamkaram/gismanager` | `github.com/hishamkaram/gismanager/v2` |
+
+Tag form: `v1.4.1` (v1 line, on `release/v1.x` branch) vs.
+`v2.0.0+` (v2 line, on `master`).
+
+`go get`:
+
+```bash
+# v1 stayer
+go get github.com/hishamkaram/gismanager@latest  # latest v1.x
+
+# v2 migrator
+go get github.com/hishamkaram/gismanager/v2@v2.0.0
+```
+
+Both lines coexist in `go.mod`. You can have *one* dependency on each
+during a transitional period; just don't mix the two within the same
+caller file (Go will resolve them as distinct types).
+
+---
+
+## Subpackage split
+
+The root `gismanager` package is now empty (only `doc.go`). Public
+API lives in three subpackages:
+
+| Subpackage | Purpose |
+|------------|---------|
+| `github.com/hishamkaram/gismanager/v2/publish` | `Manager`, `Layer`, walk + load + publish pipeline |
+| `github.com/hishamkaram/gismanager/v2/convert` | Stateless GDAL CLI-equivalents + `ToPMTiles` |
+| `github.com/hishamkaram/gismanager/v2/errs` | Typed `*GISError` + `Err*` sentinels |
+
+`internal/slogx` (the default-logger helper) stays internal — v2
+callers construct their own `*slog.Logger`.
+
+---
+
+## Type renames
+
+| v1 | v2 | Reason |
+|----|----|--------|
+| `gismanager.ManagerConfig` | `publish.Manager` | "Config" was a misnomer — the type IS the manager. |
+| `gismanager.GdalLayer` | `publish.Layer` | Drop the redundant `Gdal` prefix (clear from package context). |
+| `gismanager.VectorConvertOption` | `convert.VectorOption` | Drop the redundant `Convert` prefix in subpackage scope. |
+| `gismanager.RasterConvertOption` | `convert.RasterOption` | Same. |
+
+`gismanager.RasterizeOption` / `VRTOption` / `DEMOption` /
+`PMTilesOption` were already concise; v2 just adds the `convert.`
+prefix.
+
+`gismanager.GeoserverConfig` / `SourceConfig` / `DatastoreConfig` /
+`Option` / `WalkItem` / `LayerField` keep their names; only the
+package prefix changes (`publish.X`).
+
+`gismanager.GISError` keeps its name; package prefix becomes
+`errs.GISError`.
+
+---
+
+## Function/method moves
+
+### Conversion subsystem (8 entry points + ~60 helpers)
+
+```
+gismanager.ConvertVector      → convert.ConvertVector
+gismanager.ConvertRaster      → convert.ConvertRaster
+gismanager.ToCOG              → convert.ToCOG
+gismanager.ReprojectRaster    → convert.ReprojectRaster
+gismanager.Rasterize          → convert.Rasterize
+gismanager.BuildVRT           → convert.BuildVRT
+gismanager.DEMProcessing      → convert.DEMProcessing
+gismanager.ToPMTiles          → convert.ToPMTiles
+
+gismanager.WithVector*        → convert.WithVector*
+gismanager.WithRaster*        → convert.WithRaster*
+gismanager.WithRasterize*     → convert.WithRasterize*
+gismanager.WithVRT*           → convert.WithVRT*
+gismanager.WithDEM*           → convert.WithDEM*
+gismanager.WithPMTiles*       → convert.WithPMTiles*
+```
+
+### Publish pipeline
+
+```
+gismanager.New                → publish.New
+gismanager.FromConfig         → publish.FromConfig
+gismanager.WithLogger         → publish.WithLogger
+gismanager.WithGeoserver      → publish.WithGeoserver
+gismanager.WithDatastore      → publish.WithDatastore
+gismanager.WithSource         → publish.WithSource
+gismanager.GetGISFiles        → publish.GetGISFiles
+gismanager.DBIsAlive          → publish.DBIsAlive
+gismanager.DBIsAliveContext   → publish.DBIsAliveContext
+```
+
+Methods on `publish.Manager` and `publish.Layer` are unchanged
+shape-wise — they just live on the renamed types.
+
+### Errors
+
+```
+gismanager.GISError           → errs.GISError
+gismanager.ErrConfigInvalid   → errs.ErrConfigInvalid
+gismanager.ErrUnsupportedFormat → errs.ErrUnsupportedFormat
+gismanager.ErrInvalidLayer    → errs.ErrInvalidLayer
+gismanager.ErrInvalidDatasource → errs.ErrInvalidDatasource
+gismanager.ErrPostGISConnect  → errs.ErrPostGISConnect
+gismanager.ErrGeoServerPublish → errs.ErrGeoServerPublish
+gismanager.ErrNoSourcesFound  → errs.ErrNoSourcesFound
+gismanager.ErrConvertFailed   → errs.ErrConvertFailed
+```
+
+`errors.Is` / `errors.As` semantics are preserved across the
+boundary — the underlying error instances are the same.
+
+---
+
+## Removed methods
+
+### `(*Layer).GetGeomtryName()`
+
+Typo'd duplicate of `GeometryName()`. Same behavior; v1 kept it for
+back-compat. v2 drops it.
+
+```go
+// v1
+name := layer.GetGeomtryName()
+
+// v2
+name := layer.GeometryName()
+```
+
+### `(*Layer).GetFeatures()`
+
+Returned `[]*gdal.Feature`; each element owned a C-level handle that
+the caller had to remember to `Destroy`. Use the iterator instead:
+
+```go
+// v1 — leaks if you forget to Destroy
+features := layer.GetFeatures()
+for _, f := range features {
+    use(f)
+    f.Destroy()  // easy to forget
+}
+
+// v2 — no Destroy needed; iterator handles it
+for f := range layer.Features(ctx) {
+    use(f)
+}
+```
+
+The iterator destroys each feature as the for-range advances **and**
+on early `break`. The `ctx` parameter lets you stop iteration
+mid-way (the iterator yields nothing after `ctx.Done()`).
+
+### Root `gismanager.GetLogger()`
+
+Dropped. v2 callers construct their own `*slog.Logger` (any handler
+— text, JSON, OTel-bridged via the
+[otelslog bridge](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog))
+and pass it via `publish.WithLogger`.
+
+```go
+// v1
+mgr, _ := gismanager.New(gismanager.WithLogger(gismanager.GetLogger()))
+
+// v2
+import "log/slog"
+import "os"
+
+mgr, _ := publish.New(publish.WithLogger(
+    slog.New(slog.NewJSONHandler(os.Stderr, nil)),
+))
+
+// Or pass nil to opt into the package default:
+mgr, _ := publish.New(publish.WithLogger(nil))
+```
+
+`publish.WithLogger(nil)` is equivalent to v1's
+`gismanager.WithLogger(gismanager.GetLogger())` — the package
+internally falls back to `internal/slogx.Default()`.
+
+---
+
+## New in v2
+
+### `publish.WithPublishConcurrency(n int)`
+
+Caps how many GeoServer feature-type creations
+`(*Manager).PublishAll` dispatches in parallel. Walk +
+`LayerToPostgis` stay serial regardless (CGo handle thread-safety).
+
+```go
+mgr, _ := publish.New(
+    publish.WithPublishConcurrency(16),  // default is 8
+    // ... other options ...
+)
+```
+
+| Arg | Effect |
+|-----|--------|
+| `n <= 0` | Fall back to package default (currently 8). |
+| `n > 0` | Cap parallel publish at `n`. |
+| `n == 1` | Strictly serial publish. |
+
+---
+
+## CLI binaries
+
+The three CLI binaries (`gismanager`, `layerSchema`, `gisconvert`)
+are unchanged in their CLI surface — same flags, same outputs.
+Only the package paths inside their source updated to `/v2/...`.
+
+If you build them yourself from source (rather than pulling the
+v2.0.0 GitHub Release tarball or the `ghcr.io/hishamkaram/gismanager:v2.0.0`
+Docker image), the `make build-cli` target now injects v2 ldflags
+automatically.
+
+---
+
+## Common patterns
+
+### Pattern: cross-package use (publish + convert)
+
+In v1, both lived at the root, so there was no cross-package import:
+
+```go
+// v1
+import "github.com/hishamkaram/gismanager"
+
+mgr, _ := gismanager.New(/* ... */)
+_ = gismanager.ConvertVector(ctx, src, dst, gismanager.WithVectorFormat("GPKG"))
+```
+
+In v2, they're separate:
+
+```go
+// v2
+import (
+    "github.com/hishamkaram/gismanager/v2/convert"
+    "github.com/hishamkaram/gismanager/v2/publish"
+)
+
+mgr, _ := publish.New(/* ... */)
+_ = convert.ConvertVector(ctx, src, dst, convert.WithVectorFormat("GPKG"))
+```
+
+### Pattern: error matching
+
+`errors.Is` semantics are preserved — the v2 sentinels are the same
+underlying error instances the v1 sentinels aliased to.
+
+```go
+// v1
+if errors.Is(err, gismanager.ErrGeoServerPublish) { ... }
+
+// v2
+if errors.Is(err, errs.ErrGeoServerPublish) { ... }
+```
+
+`errors.As` to the typed envelope:
+
+```go
+// v1
+var ge *gismanager.GISError
+if errors.As(err, &ge) { fmt.Println(ge.Op, ge.Source) }
+
+// v2
+var ge *errs.GISError
+if errors.As(err, &ge) { fmt.Println(ge.Op, ge.Source) }
+```
+
+The `Op`, `Source`, `Sentinel`, `Cause` fields are unchanged.
+
+### Pattern: PublishAll error aggregation
+
+The error contract from v1.4 (`errors.Join` of per-layer failures)
+is preserved in v2:
+
+```go
+err := mgr.PublishAll(ctx)
+if err != nil {
+    if errors.Is(err, errs.ErrGeoServerPublish) {
+        // at least one layer failed at the publish step
+    }
+    // Enumerate every per-layer failure:
+    var u interface{ Unwrap() []error }
+    if errors.As(err, &u) {
+        for _, e := range u.Unwrap() {
+            log.Printf("per-layer failure: %v", e)
+        }
+    }
+}
+```
+
+---
+
+## What didn't change
+
+- The CLI flags, environment variables, config YAML schema.
+- The Docker image entry points (`ghcr.io/hishamkaram/gismanager:v2.0.0`
+  has the same `gismanager` / `layerSchema` / `gisconvert` binaries at
+  the same `/usr/local/bin/` paths).
+- The minimum supported Go version (1.25.0).
+- The pinned GDAL base (`ghcr.io/osgeo/gdal:ubuntu-full-3.12.4`,
+  digest-pinned).
+- The supported GeoServer versions (2.27.4 LTS + 2.28.0 stable).
+- The dependency surface: `lukeroth/gdal`, `lib/pq`,
+  `hishamkaram/geoserver/v2`, `gopkg.in/yaml.v3`, `protomaps/go-pmtiles`,
+  stdlib. No new runtime deps.
+
+---
+
+## Where to ask
+
+- v2 issues: open against `master`.
+- v1.x patch requests: open against `release/v1.x` (the maintenance
+  branch documented in `RELEASING.md`).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/hishamkaram/gismanager.svg)](https://pkg.go.dev/github.com/hishamkaram/gismanager)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hishamkaram/gismanager)](https://goreportcard.com/report/github.com/hishamkaram/gismanager)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hishamkaram/gismanager/v2.svg)](https://pkg.go.dev/github.com/hishamkaram/gismanager/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hishamkaram/gismanager/v2)](https://goreportcard.com/report/github.com/hishamkaram/gismanager/v2)
 [![GitHub license](https://img.shields.io/github/license/hishamkaram/gismanager.svg)](https://github.com/hishamkaram/gismanager/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/hishamkaram/gismanager.svg)](https://github.com/hishamkaram/gismanager/issues)
 
@@ -31,8 +31,8 @@ Three CLI binaries plus a Go library covering two GIS workflows:
 - **`layerSchema`** — read-only schema inspector. Walks `source.path`, opens each GIS file via GDAL, and prints the geometry column + attribute fields for every layer it finds. No PostGIS, no GeoServer.
 - **`gisconvert`** *(v1.2+)* — data-conversion CLI: vector format conversion (`ogr2ogr` equivalent), raster format conversion (`gdal_translate` equivalent), Cloud-Optimized GeoTIFF generation, and raster reprojection (`gdalwarp` equivalent). See [Conversion](#conversion).
 - **`package gismanager`** — both flows as a Go library:
-  - **Publish**: construct a `*ManagerConfig` via `gismanager.New(opts ...Option)` (functional-options) or the YAML-driven `gismanager.FromConfig(yamlPath)`, then call `Walk` / `PublishAll` or the lower-level `OpenSource` / `LayerToPostgis` / `PublishGeoserverLayer` primitives.
-  - **Convert** *(v1.2+)*: stateless `ConvertVector` / `ConvertRaster` / `ToCOG` / `ReprojectRaster` package functions. No `*ManagerConfig` required.
+  - **Publish**: construct a `*publish.Manager` via `publish.New(opts ...Option)` (functional-options) or the YAML-driven `publish.FromConfig(yamlPath)`, then call `Walk` / `PublishAll` or the lower-level `OpenSource` / `LayerToPostgis` / `PublishGeoserverLayer` primitives.
+  - **Convert** *(v1.2+)*: stateless `ConvertVector` / `ConvertRaster` / `ToCOG` / `ReprojectRaster` package functions. No `*publish.Manager` required.
 
 ### Supported source formats
 
@@ -40,7 +40,7 @@ The two surfaces have different reach.
 
 #### Publish pipeline (`cmd/gismanager`, `Walk`, `PublishAll`)
 
-Driven by an explicit extension allowlist in [`vars.go::supportedEXT`](vars.go) — only these extensions are picked up by directory walks:
+Driven by an explicit extension allowlist in [`publish/vars.go::supportedEXT`](publish/vars.go) — only these extensions are picked up by directory walks:
 
 | Extension | OGR driver |
 |---|---|
@@ -49,7 +49,7 @@ Driven by an explicit extension allowlist in [`vars.go::supportedEXT`](vars.go) 
 | `.gpkg` | GeoPackage |
 | `.kml` | KML |
 
-Zipped shapefile bundles are auto-extracted into a temp directory before the OGR open — see [`internal/zipx`](internal/zipx) for the stdlib `archive/zip`-based extractor (zip-slip rejection, 2 GiB per-entry cap). Adding a new extension to the publish pipeline means adding a row to `supportedEXT` and a switch case in [`manager.go::GetDriver`](manager.go).
+Zipped shapefile bundles are auto-extracted into a temp directory before the OGR open — see [`internal/zipx`](internal/zipx) for the stdlib `archive/zip`-based extractor (zip-slip rejection, 2 GiB per-entry cap). Adding a new extension to the publish pipeline means adding a row to `supportedEXT` and a switch case in [`publish/manager.go::GetDriver`](publish/manager.go).
 
 #### Conversion entry points *(v1.2+, `cmd/gisconvert`, `ConvertVector` / `ConvertRaster` / `ToCOG` / `ReprojectRaster`)*
 
@@ -131,7 +131,7 @@ curl -fsS -u admin:geoserver \
 make compose-test-down
 ```
 
-Same idea programmatically (the integration suite is a worked example — see [`publish_integration_test.go`](publish_integration_test.go) `TestPublishGeoJSON_EndToEnd_Integration`).
+Same idea programmatically (the integration suite is a worked example — see [`publish/publish_integration_test.go`](publish/publish_integration_test.go) `TestPublishGeoJSON_EndToEnd_Integration`).
 
 ## Conversion
 
@@ -147,26 +147,26 @@ Beyond the publish pipeline, gismanager ships a stateless conversion subsystem t
 | `BuildVRT` | `gdalbuildvrt` | mosaic many GeoTIFFs into a Virtual Raster (tile pyramid prep, RGBA stacking) | v1.3 |
 | `DEMProcessing` | `gdaldem` | DEM analysis: hillshade, slope, aspect, color-relief, TRI, TPI, roughness | v1.3 |
 
-All seven are top-level package functions — no `*ManagerConfig` required — and accept `/vsi*/`-prefixed paths transparently (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`). Driver names supplied via the `With*Format` helpers are pre-validated against the running GDAL build (since v1.3) — an unknown driver surfaces as a clean `ErrConvertFailed` instead of GDAL's silent fail-with-stderr-warning behavior.
+All seven are top-level package functions — no `*publish.Manager` required — and accept `/vsi*/`-prefixed paths transparently (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`). Driver names supplied via the `With*Format` helpers are pre-validated against the running GDAL build (since v1.3) — an unknown driver surfaces as a clean `ErrConvertFailed` instead of GDAL's silent fail-with-stderr-warning behavior.
 
 ```go
 // Vector: 4326 GeoJSON → 3857 GeoPackage, clipped to Africa, simplified.
-err := gismanager.ConvertVector(ctx, "world.geojson", "africa.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
-    gismanager.WithVectorOverwrite(),
-    gismanager.WithVectorTargetSRS("EPSG:3857"),
-    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
-    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
-    gismanager.WithVectorSimplify(100),
+err := convert.ConvertVector(ctx, "world.geojson", "africa.gpkg",
+    convert.WithVectorFormat("GPKG"),
+    convert.WithVectorOverwrite(),
+    convert.WithVectorTargetSRS("EPSG:3857"),
+    convert.WithVectorBoundingBox(-25, -40, 60, 40),
+    convert.WithVectorWhere("CONTINENT = 'Africa'"),
+    convert.WithVectorSimplify(100),
 )
 
 // Raster: GeoTIFF → COG with the canonical defaults.
-err = gismanager.ToCOG(ctx, "scene.tif", "scene.cog.tif")
+err = convert.ToCOG(ctx, "scene.tif", "scene.cog.tif")
 
 // Raster reprojection: UTM → Web Mercator.
-err = gismanager.ReprojectRaster(ctx, "utm.tif", "wm.tif",
+err = convert.ReprojectRaster(ctx, "utm.tif", "wm.tif",
     "EPSG:32618", "EPSG:3857",
-    gismanager.WithRasterResamplingAlg("bilinear"),
+    convert.WithRasterResamplingAlg("bilinear"),
 )
 ```
 
@@ -174,23 +174,23 @@ Full reference, more examples, and the cloud-I/O matrix: [`docs/conversions.md`]
 
 ## Errors
 
-Every error gismanager returns is a `*GISError` wrapping a sentinel from [`errors.go`](errors.go). Match by sentinel:
+Every error gismanager returns is a `*GISError` wrapping a sentinel from [`errs/errs.go`](errs/errs.go). Match by sentinel:
 
 ```go
-import "github.com/hishamkaram/gismanager"
+import "github.com/hishamkaram/gismanager/v2/publish"
 
 err := mgr.PublishGeoserverLayer(ctx, layer)
 switch {
-case errors.Is(err, gismanager.ErrPostGISConnect):
+case errors.Is(err, errs.ErrPostGISConnect):
     // PostGIS unreachable; bring it up and retry.
-case errors.Is(err, gismanager.ErrGeoServerPublish):
+case errors.Is(err, errs.ErrGeoServerPublish):
     // Workspace/datastore/feature-type creation failed; the wrapped
     // *geoserver.APIError carries the HTTP status (404, 409, 500…).
     var apiErr *geoserver.APIError
     if errors.As(err, &apiErr) {
         log.Printf("status=%d body=%s", apiErr.StatusCode, apiErr.Body)
     }
-case errors.Is(err, gismanager.ErrUnsupportedFormat):
+case errors.Is(err, errs.ErrUnsupportedFormat):
     // The path's extension isn't one of the dispatched OGR drivers.
 }
 ```
@@ -214,7 +214,7 @@ pattern and a Kubernetes deployment recipe.
 
 ## Configuration
 
-YAML schema (the same struct gets used by `gismanager.FromConfig`):
+YAML schema (the same struct gets used by `publish.FromConfig`):
 
 ```yaml
 geoserver:
@@ -244,11 +244,11 @@ A working config used by the integration suite lives at [`testdata/test_config.y
 ```go
 import (
     "context"
-    "github.com/hishamkaram/gismanager"
+    "github.com/hishamkaram/gismanager/v2/publish"
 )
 
 func main() {
-    mgr, err := gismanager.FromConfig("my-config.yaml")
+    mgr, err := publish.FromConfig("my-config.yaml")
     if err != nil { /* ... */ }
 
     ctx := context.Background()
@@ -287,46 +287,46 @@ func main() {
 
 ### Conversion *(v1.2+)*
 
-The conversion entry points are top-level package functions — no `*ManagerConfig` required, no GeoServer/PostGIS state held.
+The conversion entry points are top-level package functions — no `*publish.Manager` required, no GeoServer/PostGIS state held.
 
 ```go
 // Reproject + clip + filter + simplify in one call.
-err := gismanager.ConvertVector(ctx, "world.geojson", "africa.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
-    gismanager.WithVectorOverwrite(),
-    gismanager.WithVectorTargetSRS("EPSG:3857"),
-    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
-    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
-    gismanager.WithVectorSimplify(100),
+err := convert.ConvertVector(ctx, "world.geojson", "africa.gpkg",
+    convert.WithVectorFormat("GPKG"),
+    convert.WithVectorOverwrite(),
+    convert.WithVectorTargetSRS("EPSG:3857"),
+    convert.WithVectorBoundingBox(-25, -40, 60, 40),
+    convert.WithVectorWhere("CONTINENT = 'Africa'"),
+    convert.WithVectorSimplify(100),
 )
 
 // Cloud-Optimized GeoTIFF with sane defaults.
-err = gismanager.ToCOG(ctx, "scene.tif", "scene.cog.tif")
+err = convert.ToCOG(ctx, "scene.tif", "scene.cog.tif")
 
 // UTM → Web Mercator with bilinear resampling.
-err = gismanager.ReprojectRaster(ctx, "utm.tif", "wm.tif",
+err = convert.ReprojectRaster(ctx, "utm.tif", "wm.tif",
     "EPSG:32618", "EPSG:3857",
-    gismanager.WithRasterResamplingAlg("bilinear"),
+    convert.WithRasterResamplingAlg("bilinear"),
 )
 
 // v1.3+: vector → raster (burn an attribute into a continuous Float32 field).
-err = gismanager.Rasterize(ctx, "countries.geojson", "pop.tif",
-    gismanager.WithRasterizeFormat("GTiff"),
-    gismanager.WithRasterizeOutputType("Float32"),
-    gismanager.WithRasterizeAttribute("POP_EST"),
-    gismanager.WithRasterizeOutputSize(360, 180),
+err = convert.Rasterize(ctx, "countries.geojson", "pop.tif",
+    convert.WithRasterizeFormat("GTiff"),
+    convert.WithRasterizeOutputType("Float32"),
+    convert.WithRasterizeAttribute("POP_EST"),
+    convert.WithRasterizeOutputSize(360, 180),
 )
 
 // v1.3+: stack many GeoTIFFs into a single VRT for downstream Warp/Translate.
-err = gismanager.BuildVRT(ctx, "mosaic.vrt",
+err = convert.BuildVRT(ctx, "mosaic.vrt",
     []string{"tile1.tif", "tile2.tif", "tile3.tif"},
-    gismanager.WithVRTResolution("highest"),
+    convert.WithVRTResolution("highest"),
 )
 
 // v1.3+: hillshade from a DEM.
-err = gismanager.DEMProcessing(ctx, "dem.tif", "dem.hs.tif", "hillshade",
-    gismanager.WithDEMAzimuth(315),
-    gismanager.WithDEMAltitude(45),
+err = convert.DEMProcessing(ctx, "dem.tif", "dem.hs.tif", "hillshade",
+    convert.WithDEMAzimuth(315),
+    convert.WithDEMAltitude(45),
 )
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,13 +27,13 @@ gismanager is a small composition of three things:
                  └─────────────────────────┘
 ```
 
-The package wires the three together with a `*ManagerConfig` that holds the GeoServer endpoint, the PostGIS connection params, and the source-directory path. Everything else is a thin orchestration layer over GDAL + the upstream Go client.
+The package wires the three together with a `*publish.Manager` that holds the GeoServer endpoint, the PostGIS connection params, and the source-directory path. Everything else is a thin orchestration layer over GDAL + the upstream Go client.
 
 ## Package shape
 
 | Path | Purpose |
 |---|---|
-| `github.com/hishamkaram/gismanager` | Public API — `*ManagerConfig`, `*GdalLayer`, `*GISError`, sentinels, public method receivers |
+| `github.com/hishamkaram/gismanager` | Public API — `*publish.Manager`, `*publish.Layer`, `*GISError`, sentinels, public method receivers |
 | `github.com/hishamkaram/gismanager/internal/zipx` | stdlib `archive/zip` extractor with zip-slip rejection + per-entry size cap. Used to auto-extract zipped shapefile bundles before the OGR open. Internal — not importable |
 | `github.com/hishamkaram/gismanager/cmd/gismanager` | Full publish-pipeline CLI |
 | `github.com/hishamkaram/gismanager/cmd/layerSchema` | Read-only schema-printing CLI |
@@ -44,38 +44,38 @@ A single Go module at the repo root. No `/v2` semantic-import-versioning suffix 
 
 ## Public API
 
-The lead type is `*ManagerConfig`, constructed via `gismanager.New(opts ...Option)` (functional options — `WithLogger`, `WithGeoserver`, `WithDatastore`, `WithSource`) or the YAML-driven `gismanager.FromConfig(path)`. Methods:
+The lead type is `*publish.Manager`, constructed via `publish.New(opts ...Option)` (functional options — `WithLogger`, `WithGeoserver`, `WithDatastore`, `WithSource`) or the YAML-driven `publish.FromConfig(path)`. Methods:
 
 ```go
 // Build a v2 GeoServer client from the configured endpoint + credentials.
-func (m *ManagerConfig) GetGeoserverCatalog() (*geoserver.Client, error)
+func (m *publish.Manager) GetGeoserverCatalog() (*geoserver.Client, error)
 
 // Open a GIS data source via GDAL. ctx is reserved for cancellation.
-func (m *ManagerConfig) OpenSource(ctx context.Context, path string, access int) (*gdal.DataSource, error)
+func (m *publish.Manager) OpenSource(ctx context.Context, path string, access int) (*gdal.DataSource, error)
 
 // Map a path or connection string to its OGR driver.
-func (m *ManagerConfig) GetDriver(path string) (gdal.OGRDriver, error)
+func (m *publish.Manager) GetDriver(path string) (gdal.OGRDriver, error)
 
 // Copy this GDAL layer into a PostGIS-backed OGR data source.
-func (l *GdalLayer) LayerToPostgis(targetSource *gdal.DataSource, m *ManagerConfig, overwrite bool) (*GdalLayer, error)
+func (l *publish.Layer) LayerToPostgis(targetSource *gdal.DataSource, m *publish.Manager, overwrite bool) (*publish.Layer, error)
 
 // Publish a PostGIS-backed layer as a GeoServer feature type. Idempotent
 // end-to-end (Get + ErrNotFound for workspace, datastore, and feature type).
-func (m *ManagerConfig) PublishGeoserverLayer(ctx context.Context, layer *GdalLayer) error
+func (m *publish.Manager) PublishGeoserverLayer(ctx context.Context, layer *publish.Layer) error
 
 // High-level pipeline: walk → load → publish, with per-file source.Destroy().
 // Iteration is files-outer / layers-inner.
-func (m *ManagerConfig) Walk(ctx context.Context) iter.Seq2[WalkItem, error]
-func (m *ManagerConfig) PublishAll(ctx context.Context) error
+func (m *publish.Manager) Walk(ctx context.Context) iter.Seq2[WalkItem, error]
+func (m *publish.Manager) PublishAll(ctx context.Context) error
 
 // Streaming feature iterator that Destroys each gdal.Feature as iteration
 // advances; replaces the deprecated GetFeatures() []*gdal.Feature shape.
-func (l *GdalLayer) Features(ctx context.Context) iter.Seq[gdal.Feature]
+func (l *publish.Layer) Features(ctx context.Context) iter.Seq[gdal.Feature]
 ```
 
 ### Conversion subsystem (v1.2+ / v1.3+)
 
-A second, **stateless** surface alongside the publish pipeline. No `*ManagerConfig` required — these are top-level package functions that wrap GDAL's command-line workhorses:
+A second, **stateless** surface alongside the publish pipeline. No `*publish.Manager` required — these are top-level package functions that wrap GDAL's command-line workhorses:
 
 ```go
 // v1.2 — format conversion family
@@ -96,11 +96,11 @@ Driver names supplied via the `With<Op>Format` helpers are pre-validated against
 
 All conversion entry points pass paths transparently to GDAL, so any `/vsi*/` prefix (`/vsis3/`, `/vsicurl/`, `/vsimem/`, `/vsizip/`, `/vsigs/`, `/vsiaz/`) works without special handling. Full reference: [`conversions.md`](conversions.md).
 
-All methods that can fail return errors wrapping a sentinel from [`../errors.go`](../errors.go) — see the README's [Errors](../README.md#errors) section for the matching idiom.
+All methods that can fail return errors wrapping a sentinel from [`../errs/errs.go`](../errs/errs.go) — see the README's [Errors](../README.md#errors) section for the matching idiom.
 
 ### Resource lifecycle
 
-`*gdal.DataSource` (returned by [`OpenSource`](../manager.go)) and `gdal.Feature` (yielded by [`Features`](../layer.go)) own CGo-side handles that must be released via `.Destroy()`. The binding does not have a `Close()` method — `Destroy()` is the canonical release primitive in `lukeroth/gdal`.
+`*gdal.DataSource` (returned by [`OpenSource`](../publish/manager.go)) and `gdal.Feature` (yielded by [`Features`](../publish/layer.go)) own CGo-side handles that must be released via `.Destroy()`. The binding does not have a `Close()` method — `Destroy()` is the canonical release primitive in `lukeroth/gdal`.
 
 The library's high-level helpers handle this automatically:
 
@@ -119,7 +119,7 @@ Today the OGR / GDAL bindings don't accept context (no upstream cancellation sur
 
 ## Errors
 
-`errors.go` defines 7 sentinels (`ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`) and a typed `*GISError` with `Op`, `Source`, `Sentinel`, `Cause` fields. `Unwrap` returns Cause; `Is` matches Sentinel.
+`errs` package defines 7 sentinels (`ErrConfigInvalid`, `ErrUnsupportedFormat`, `ErrInvalidLayer`, `ErrInvalidDatasource`, `ErrPostGISConnect`, `ErrGeoServerPublish`, `ErrNoSourcesFound`) and a typed `*GISError` with `Op`, `Source`, `Sentinel`, `Cause` fields. `Unwrap` returns Cause; `Is` matches Sentinel.
 
 Why both layers: callers can branch by category (`errors.Is(err, ErrPostGISConnect)`) for control flow, *and* extract the underlying `*geoserver.APIError` (or driver-level error) via `errors.As` for diagnostic logging. The same error satisfies both at once.
 
@@ -131,13 +131,13 @@ gismanager: PublishGeoserverLayer "myws/mystore": gismanager: geoserver publish:
 
 ## Logging
 
-`*slog.Logger` directly. No wrapper. The default `gismanager.GetLogger()` returns `slog.New(slog.NewTextHandler(os.Stderr, nil))`; production callers should construct their own `*slog.Logger` (any handler — JSON, lumberjack rotation, otel) and pass it on `ManagerConfig.logger`.
+`*slog.Logger` directly. No wrapper. The default `slogx.Default()` returns `slog.New(slog.NewTextHandler(os.Stderr, nil))`; production callers should construct their own `*slog.Logger` (any handler — JSON, lumberjack rotation, otel) and pass it on `publish.Manager.logger`.
 
 Internal call sites use structured logging — `logger.Error("publish feature type", "workspace", ws, "datastore", ds, "layer", name, "err", err)`. The library emits Debug/Warn/Error only; `cmd/*` may emit Info on successful publish events.
 
 ## Concurrency
 
-`*ManagerConfig` is intended to be read-only after construction. The `logger` field is `*slog.Logger` (concurrency-safe by stdlib contract). The other fields are configuration values that never change.
+`*publish.Manager` is intended to be read-only after construction. The `logger` field is `*slog.Logger` (concurrency-safe by stdlib contract). The other fields are configuration values that never change.
 
 The geoserver/v2 client constructed by `GetGeoserverCatalog` is itself concurrency-safe (the upstream contract — verified in that project's CI under `-race`). gismanager itself doesn't introduce shared mutable state.
 
@@ -178,7 +178,7 @@ gismanager publishes via [`github.com/hishamkaram/geoserver/v2`](https://github.
 | Feature type exists? | `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Get(ctx, name)` + ErrNotFound |
 | Publish feature type | `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Create(ctx, &featuretypes.FeatureType{...})` |
 
-The Get + ErrNotFound idiom is what makes the publish flow idempotent end-to-end — see [`../publish_integration_test.go`](../publish_integration_test.go) `TestPublishGeoJSON_Idempotent_Integration`.
+The Get + ErrNotFound idiom is what makes the publish flow idempotent end-to-end — see [`../publish/publish_integration_test.go`](../publish/publish_integration_test.go) `TestPublishGeoJSON_Idempotent_Integration`.
 
 ## Cross-references
 
@@ -186,4 +186,4 @@ The Get + ErrNotFound idiom is what makes the publish flow idempotent end-to-end
 - [`../CHANGELOG.md`](../CHANGELOG.md) — release notes
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — Docker-only dev workflow, PR conventions
 - [`version-compat.md`](version-compat.md) — Go × GeoServer × GDAL × PostGIS matrix
-- [`../publish_integration_test.go`](../publish_integration_test.go) — worked end-to-end example as a test
+- [`../publish/publish_integration_test.go`](../publish/publish_integration_test.go) — worked end-to-end example as a test

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -8,7 +8,7 @@ the four most common GDAL/OGR operations:
 - **`ToCOG`** — Cloud-Optimized GeoTIFF generation (a thin wrapper over `ConvertRaster`)
 - **`ReprojectRaster`** — raster reprojection (the `gdalwarp` equivalent)
 
-Each is a top-level package function; none requires a `*ManagerConfig`.
+Each is a top-level package function; none requires a `*publish.Manager`.
 Configuration goes through functional options (`WithVector*` or
 `WithRaster*` modality prefix to avoid name collisions).
 
@@ -17,36 +17,36 @@ Configuration goes through functional options (`WithVector*` or
 ### Shapefile → GeoPackage
 
 ```go
-err := gismanager.ConvertVector(ctx,
+err := convert.ConvertVector(ctx,
     "/vsizip//data/countries.zip", // /vsizip/ for zipped Shapefile bundles
     "/data/countries.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
-    gismanager.WithVectorOverwrite(),
+    convert.WithVectorFormat("GPKG"),
+    convert.WithVectorOverwrite(),
 )
 ```
 
 ### GeoJSON → GeoPackage with reprojection, bbox clip, and attribute filter
 
 ```go
-err := gismanager.ConvertVector(ctx,
+err := convert.ConvertVector(ctx,
     "/data/world.geojson",
     "/data/africa_3857.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
-    gismanager.WithVectorOverwrite(),
-    gismanager.WithVectorTargetSRS("EPSG:3857"),
-    gismanager.WithVectorBoundingBox(-25, -40, 60, 40),
-    gismanager.WithVectorWhere("CONTINENT = 'Africa'"),
-    gismanager.WithVectorSimplify(100),
-    gismanager.WithVectorLayerName("africa"),
+    convert.WithVectorFormat("GPKG"),
+    convert.WithVectorOverwrite(),
+    convert.WithVectorTargetSRS("EPSG:3857"),
+    convert.WithVectorBoundingBox(-25, -40, 60, 40),
+    convert.WithVectorWhere("CONTINENT = 'Africa'"),
+    convert.WithVectorSimplify(100),
+    convert.WithVectorLayerName("africa"),
 )
 ```
 
 ### Vector field selection
 
 ```go
-err := gismanager.ConvertVector(ctx, src, dst,
-    gismanager.WithVectorFormat("FlatGeobuf"),
-    gismanager.WithVectorSelectFields("NAME", "POP_EST", "CONTINENT"),
+err := convert.ConvertVector(ctx, src, dst,
+    convert.WithVectorFormat("FlatGeobuf"),
+    convert.WithVectorSelectFields("NAME", "POP_EST", "CONTINENT"),
 )
 ```
 
@@ -54,20 +54,20 @@ err := gismanager.ConvertVector(ctx, src, dst,
 
 `gismanager` v1.4 added GeoParquet support to the conversion subsystem
 and the publish-pipeline OGR dispatch. The `.parquet` extension routes
-to the GDAL `Parquet` driver in [`OpenSource`](../manager.go) and
+to the GDAL `Parquet` driver in [`OpenSource`](../publish/manager.go) and
 `GetDriver`, and `ConvertVector` accepts `Parquet` as a target format.
 
 ```go
 // Convert a Shapefile bundle into GeoParquet (cloud-native interchange).
-err := gismanager.ConvertVector(ctx,
+err := convert.ConvertVector(ctx,
     "/vsizip//data/countries.zip",
     "/data/countries.parquet",
-    gismanager.WithVectorFormat("Parquet"),
-    gismanager.WithVectorOverwrite(),
+    convert.WithVectorFormat("Parquet"),
+    convert.WithVectorOverwrite(),
 )
 
 // Read a GeoParquet file via the publish pipeline (manager-driven).
-mgr, _ := gismanager.New(/* ... */)
+mgr, _ := publish.New(/* ... */)
 ds, _ := mgr.OpenSource(ctx, "/data/cities.parquet", 0)
 defer ds.Destroy()
 ```
@@ -96,7 +96,7 @@ the same way it publishes from a Shapefile or GeoPackage today.
 ### GeoTIFF → Cloud-Optimized GeoTIFF
 
 ```go
-err := gismanager.ToCOG(ctx, "/data/scene.tif", "/data/scene.cog.tif")
+err := convert.ToCOG(ctx, "/data/scene.tif", "/data/scene.cog.tif")
 ```
 
 `ToCOG` defaults to `COMPRESS=DEFLATE`, `BLOCKSIZE=512`,
@@ -104,39 +104,39 @@ err := gismanager.ToCOG(ctx, "/data/scene.tif", "/data/scene.cog.tif")
 `WithRasterCreationOption`:
 
 ```go
-err := gismanager.ToCOG(ctx, src, dst,
-    gismanager.WithRasterCreationOption("COMPRESS", "ZSTD"),
-    gismanager.WithRasterCreationOption("PREDICTOR", "2"),
+err := convert.ToCOG(ctx, src, dst,
+    convert.WithRasterCreationOption("COMPRESS", "ZSTD"),
+    convert.WithRasterCreationOption("PREDICTOR", "2"),
 )
 ```
 
 ### GeoTIFF → PNG thumbnail
 
 ```go
-err := gismanager.ConvertRaster(ctx, "/data/scene.tif", "/data/preview.png",
-    gismanager.WithRasterFormat("PNG"),
-    gismanager.WithRasterBands(1, 2, 3),
+err := convert.ConvertRaster(ctx, "/data/scene.tif", "/data/preview.png",
+    convert.WithRasterFormat("PNG"),
+    convert.WithRasterBands(1, 2, 3),
 )
 ```
 
 ### Raster reprojection (UTM → Web Mercator)
 
 ```go
-err := gismanager.ReprojectRaster(ctx,
+err := convert.ReprojectRaster(ctx,
     "/data/scene_utm.tif",
     "/data/scene_3857.tif",
     "EPSG:32618", "EPSG:3857",
-    gismanager.WithRasterFormat("GTiff"),
-    gismanager.WithRasterResamplingAlg("bilinear"),
+    convert.WithRasterFormat("GTiff"),
+    convert.WithRasterResamplingAlg("bilinear"),
 )
 ```
 
 ### Raster reprojection with cookie-cutter clipping
 
 ```go
-err := gismanager.ReprojectRaster(ctx, src, dst,
+err := convert.ReprojectRaster(ctx, src, dst,
     "EPSG:4326", "EPSG:3857",
-    gismanager.WithRasterCutline("/data/aoi.geojson", "outline"),
+    convert.WithRasterCutline("/data/aoi.geojson", "outline"),
 )
 ```
 
@@ -149,24 +149,24 @@ extent shrinks to the polygon's envelope.
 ### Burn polygons into a Byte mask
 
 ```go
-err := gismanager.Rasterize(ctx, "countries.geojson", "africa_mask.tif",
-    gismanager.WithRasterizeFormat("GTiff"),
-    gismanager.WithRasterizeOutputType("Byte"),
-    gismanager.WithRasterizeBurnValues(1.0),
-    gismanager.WithRasterizeWhere("CONTINENT = 'Africa'"),
-    gismanager.WithRasterizeOutputBounds(-25, -40, 60, 40),
-    gismanager.WithRasterizeOutputSize(256, 256),
+err := convert.Rasterize(ctx, "countries.geojson", "africa_mask.tif",
+    convert.WithRasterizeFormat("GTiff"),
+    convert.WithRasterizeOutputType("Byte"),
+    convert.WithRasterizeBurnValues(1.0),
+    convert.WithRasterizeWhere("CONTINENT = 'Africa'"),
+    convert.WithRasterizeOutputBounds(-25, -40, 60, 40),
+    convert.WithRasterizeOutputSize(256, 256),
 )
 ```
 
 ### Burn an attribute into a continuous Float32 field
 
 ```go
-err := gismanager.Rasterize(ctx, "countries.geojson", "pop.tif",
-    gismanager.WithRasterizeFormat("GTiff"),
-    gismanager.WithRasterizeOutputType("Float32"),
-    gismanager.WithRasterizeAttribute("POP_EST"),
-    gismanager.WithRasterizeOutputSize(360, 180),
+err := convert.Rasterize(ctx, "countries.geojson", "pop.tif",
+    convert.WithRasterizeFormat("GTiff"),
+    convert.WithRasterizeOutputType("Float32"),
+    convert.WithRasterizeAttribute("POP_EST"),
+    convert.WithRasterizeOutputSize(360, 180),
 )
 ```
 
@@ -178,19 +178,19 @@ exclusive — use one or the other.
 ### Combine many GeoTIFFs into a Virtual Raster
 
 ```go
-err := gismanager.BuildVRT(ctx, "mosaic.vrt",
+err := convert.BuildVRT(ctx, "mosaic.vrt",
     []string{"tile1.tif", "tile2.tif", "tile3.tif"},
-    gismanager.WithVRTResolution("highest"),
-    gismanager.WithVRTAddAlpha(),
+    convert.WithVRTResolution("highest"),
+    convert.WithVRTAddAlpha(),
 )
 ```
 
 ### Stack single-band inputs into RGBA
 
 ```go
-err := gismanager.BuildVRT(ctx, "rgba.vrt",
+err := convert.BuildVRT(ctx, "rgba.vrt",
     []string{"red.tif", "green.tif", "blue.tif", "alpha.tif"},
-    gismanager.WithVRTSeparate(),
+    convert.WithVRTSeparate(),
 )
 ```
 
@@ -203,26 +203,26 @@ shared band count.
 ### Hillshade
 
 ```go
-err := gismanager.DEMProcessing(ctx, "dem.tif", "dem.hs.tif", "hillshade",
-    gismanager.WithDEMAzimuth(315),
-    gismanager.WithDEMAltitude(45),
-    gismanager.WithDEMMultidirectional(),
+err := convert.DEMProcessing(ctx, "dem.tif", "dem.hs.tif", "hillshade",
+    convert.WithDEMAzimuth(315),
+    convert.WithDEMAltitude(45),
+    convert.WithDEMMultidirectional(),
 )
 ```
 
 ### Slope
 
 ```go
-err := gismanager.DEMProcessing(ctx, "dem.tif", "dem.slope.tif", "slope",
-    gismanager.WithDEMAlgorithm("ZevenbergenThorne"),
+err := convert.DEMProcessing(ctx, "dem.tif", "dem.slope.tif", "slope",
+    convert.WithDEMAlgorithm("ZevenbergenThorne"),
 )
 ```
 
 ### Color-relief (requires a color file)
 
 ```go
-err := gismanager.DEMProcessing(ctx, "dem.tif", "dem.color.tif", "color-relief",
-    gismanager.WithDEMColorFile("./elevation_palette.txt"),
+err := convert.DEMProcessing(ctx, "dem.tif", "dem.color.tif", "color-relief",
+    convert.WithDEMColorFile("./elevation_palette.txt"),
 )
 ```
 
@@ -235,7 +235,7 @@ documented at https://gdal.org/programs/gdaldem.html#color-relief.
 [PMTiles](https://docs.protomaps.com/pmtiles/) is a single-file
 range-readable tile archive — ideal for serverless tile distribution
 from S3, HTTP, or any blob storage that supports HTTP range requests.
-v1.4 added [`ToPMTiles`](../convert_pmtiles.go), a thin wrapper over
+v1.4 added [`ToPMTiles`](../convert/pmtiles.go), a thin wrapper over
 [`protomaps/go-pmtiles`](https://github.com/protomaps/go-pmtiles)
 that converts an existing **MBTiles** archive to PMTiles v3.
 
@@ -243,14 +243,14 @@ Two-stage pipeline starting from a raster source:
 
 ```go
 // 1. raster -> MBTiles (via the GDAL MBTiles driver)
-err := gismanager.ConvertRaster(ctx,
+err := convert.ConvertRaster(ctx,
     "/data/scene.tif",
     "/tmp/scene.mbtiles",
-    gismanager.WithRasterFormat("MBTILES"),
+    convert.WithRasterFormat("MBTILES"),
 )
 
 // 2. MBTiles -> PMTiles
-err = gismanager.ToPMTiles(ctx,
+err = convert.ToPMTiles(ctx,
     "/tmp/scene.mbtiles",
     "/data/scene.pmtiles",
 )
@@ -279,7 +279,7 @@ so any of GDAL's virtual file system prefixes work transparently:
 ### Example: read a remote COG from S3 and reproject locally
 
 ```go
-err := gismanager.ReprojectRaster(ctx,
+err := convert.ReprojectRaster(ctx,
     "/vsis3/satellite-archive/2024/scene.tif",
     "/data/scene.local.tif",
     "EPSG:32618", "EPSG:3857",
@@ -289,21 +289,21 @@ err := gismanager.ReprojectRaster(ctx,
 ### Example: convert a remote GeoJSON over HTTP
 
 ```go
-err := gismanager.ConvertVector(ctx,
+err := convert.ConvertVector(ctx,
     "/vsicurl/https://example.com/data/admin.geojson",
     "/data/admin.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
-    gismanager.WithVectorOverwrite(),
+    convert.WithVectorFormat("GPKG"),
+    convert.WithVectorOverwrite(),
 )
 ```
 
 ### Example: in-memory pipeline with `/vsimem/`
 
 ```go
-gismanager.ConvertVector(ctx,
+convert.ConvertVector(ctx,
     "/vsimem/in.geojson",   // populated upstream via gdal.VSIFileFromMemBuffer
     "/vsimem/out.gpkg",
-    gismanager.WithVectorFormat("GPKG"),
+    convert.WithVectorFormat("GPKG"),
 )
 ```
 
@@ -313,9 +313,9 @@ Every conversion entry point wraps GDAL's error in a `*GISError`. Branch
 on the sentinel to detect category:
 
 ```go
-err := gismanager.ConvertVector(ctx, src, dst, opts...)
-if errors.Is(err, gismanager.ErrConvertFailed) {
-    var gerr *gismanager.GISError
+err := convert.ConvertVector(ctx, src, dst, opts...)
+if errors.Is(err, errs.ErrConvertFailed) {
+    var gerr *errs.GISError
     if errors.As(err, &gerr) {
         log.Printf("conversion %s failed: %v", gerr.Op, gerr.Cause)
     }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,7 +14,7 @@ This doc covers two integration patterns:
 
 ## 1. Plain slog
 
-The library default (`gismanager.GetLogger()`) writes text-handler
+The library default (`slogx.Default()`) writes text-handler
 records to stderr with default level filtering. To customize, build
 your own `*slog.Logger` and pass it on construction:
 
@@ -28,7 +28,7 @@ logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
     Level: slog.LevelDebug,
 }))
 
-mgr, _ := gismanager.New(gismanager.WithLogger(logger), /* ... */)
+mgr, _ := publish.New(publish.WithLogger(logger), /* ... */)
 ```
 
 Library log calls follow standard Go conventions — `key`-`value`
@@ -72,7 +72,7 @@ correlate in the backend without any further library changes.
 
 See [`examples/otel_pipeline/`](../examples/otel_pipeline/) — a
 ~120-line `main.go` that wires `otelslog.NewLogger`, the
-`otlploghttp` exporter, and a `*ManagerConfig.PublishAll` call. It
+`otlploghttp` exporter, and a `*publish.Manager.PublishAll` call. It
 lives in its own Go submodule so the OTel SDK + exporter
 dependencies don't leak into gismanager's top-level `go.mod`.
 


### PR DESCRIPTION
## Summary

**Phase 7** of the v2 restructure — the documentation pass. Three deliverables:

1. **\`CHANGELOG.md\` \`[2.0.0] — 2026-05-07\`** — consolidated entry covering PRs #53–#58 (Context / Module path / Added / Changed / Removed / Tests / Operations / Migration sections). Canonical record of the v1 → v2 transition.
2. **\`MIGRATING.md\`** — top-level v1 → v2 migration guide. Includes TL;DR sed scripts (module-path bump + subpackage split + type renames), full inventory of the 8 conversion entry points + ~60 With* helpers + 9 publish top-level functions + 8 sentinels, removed-method recipes, the new \`WithPublishConcurrency\` option, and common-pattern walkthroughs for cross-package use / error matching / PublishAll aggregation.
3. **README + docs/ updates** — every code sample bumped to \`convert.X\` / \`publish.X\` / \`errs.X\`; stale file-path links updated (\`vars.go\` → \`publish/vars.go\`, \`errors.go\` → \`errs/errs.go\`, etc.); \`GetLogger\` references replaced with the v2 "construct your own \`*slog.Logger\`" story.

This is item #7 of the v2 restructure plan ([\`~/.claude/plans/how-can-we-improve-steady-emerson.md\`](#)). Phase 8 cuts \`v2.0.0\` proper.

## Test plan

- [x] \`make lint\` — 0 issues (no Go code changed; sanity gate)
- [x] \`make test-unit\` — green (no production-code changes; documentation only)
- [ ] CI: full matrix runs on push